### PR TITLE
feat: add GoReleaser and quick install script for Linux distributions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lobster
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,64 @@
+version: 2
+
+project_name: lobster
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X lobster/cmd.Version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+nfpms:
+  - file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    homepage: https://github.com/billmal071/lobster
+    description: "Search in your terminal. Stream instantly in your media player."
+    maintainer: "billmal071 <billmal071@github.com>"
+    license: "MIT"
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - fzf
+    recommends:
+      - mpv
+      - ffmpeg
+    bindir: /usr/local/bin
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -44,12 +44,23 @@ See [GUIDE.md](GUIDE.md) for detailed usage instructions.
 
 ## Installation
 
+### Quick Install (Linux & macOS)
+
+You can easily install Lobster system-wide by running our automatic installation script. It automatically detects your OS and architecture, and downloads the appropriate system package (`.deb`, `.rpm`, or `.tar.gz`) to install dependencies like `fzf`.
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/billmal071/lobster/main/install.sh | sh
+```
+
+### From Source (macOS / Linux)
+
 ```bash
 brew install go fzf mpv
 
 git clone https://github.com/billmal071/lobster && cd lobster
 
 go build -o lobster .
+sudo make install # installs to /usr/local/bin
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/spf13/cobra v1.8.1
+	golang.org/x/term v0.41.0
 )
 
 require (
@@ -14,5 +15,4 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 )

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -e
+
+REPO="billmal071/lobster"
+
+echo "🦞 Installing Lobster from $REPO..."
+
+# Get latest release version
+LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/')
+
+if [ -z "$LATEST_RELEASE" ]; then
+    echo "Error: Could not determine latest release."
+    exit 1
+fi
+
+VERSION_NO_V=$(echo "$LATEST_RELEASE" | sed 's/^v//')
+echo "Latest release: $LATEST_RELEASE"
+
+# Determine architecture
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64) PKG_ARCH="amd64"; TAR_ARCH="x86_64" ;;
+    aarch64) PKG_ARCH="arm64"; TAR_ARCH="arm64" ;;
+    armv7l) PKG_ARCH="armv7"; TAR_ARCH="armv7" ;;
+    *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+OS_LOWER=$(uname -s | tr '[:upper:]' '[:lower:]')
+OS_TITLE=$(uname -s | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}')
+
+# Downloading function
+download() {
+    URL="https://github.com/billmal071/lobster/releases/download/$LATEST_RELEASE/$1"
+    echo "Downloading $URL..."
+    if ! curl -sLf "$URL" -o "/tmp/$1"; then
+        echo "Error: Failed to download $URL"
+        exit 1
+    fi
+}
+
+echo "Detected OS: $OS_TITLE, Architecture: $ARCH"
+
+if [ "$OS_LOWER" = "linux" ]; then
+    if command -v dpkg >/dev/null 2>&1; then
+        # Debian/Ubuntu
+        FILE="lobster_${VERSION_NO_V}_linux_${PKG_ARCH}.deb"
+        download "$FILE"
+        echo "Installing $FILE via dpkg..."
+        sudo dpkg -i "/tmp/$FILE" || true
+        # Install missing dependencies (e.g., fzf) automatically
+        sudo apt-get install -f -y
+    elif command -v rpm >/dev/null 2>&1; then
+        # RHEL/Fedora/CentOS
+        FILE="lobster_${VERSION_NO_V}_linux_${PKG_ARCH}.rpm"
+        download "$FILE"
+        echo "Installing $FILE via rpm..."
+        if command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y "/tmp/$FILE"
+        elif command -v yum >/dev/null 2>&1; then
+            sudo yum install -y "/tmp/$FILE"
+        else
+            sudo rpm -i "/tmp/$FILE"
+        fi
+    else
+        # Fallback to tarball
+        FILE="lobster_${OS_TITLE}_${TAR_ARCH}.tar.gz"
+        download "$FILE"
+        echo "Extracting binary..."
+        tar -xzf "/tmp/$FILE" -C /tmp lobster
+        sudo install -m 755 /tmp/lobster /usr/local/bin/lobster
+    fi
+elif [ "$OS_LOWER" = "darwin" ]; then
+    FILE="lobster_${OS_TITLE}_${TAR_ARCH}.tar.gz"
+    download "$FILE"
+    echo "Extracting binary..."
+    tar -xzf "/tmp/$FILE" -C /tmp lobster
+    sudo install -m 755 /tmp/lobster /usr/local/bin/lobster
+else
+    echo "Unsupported OS: $OS_LOWER"
+    exit 1
+fi
+
+echo "✅ Lobster installed successfully!"
+echo "Run 'lobster' in your terminal to get started."


### PR DESCRIPTION
### Description
This PR introduces a proper release pipeline and a streamlined software installation experience for Linux users. By utilizing GoReleaser and a custom bash script, users can now easily install the `lobster` CLI without needing to manually compile it or install the Go toolchain.

### Key Changes
*   **GoReleaser Configuration** (`.goreleaser.yaml`): Defined automated build targets for different OS/architectures and binary packaging.
*   **CI/CD Pipeline** (`.github/workflows/release.yml`): Added a GitHub Action workflow to automatically trigger GoReleaser to build, package, and publish binaries to GitHub Releases whenever a new semantic version tag is pushed.
*   **Quick Install Script** (`install.sh`): Created an intelligent bash script that identifies the user's OS and architecture, fetches the latest release, and installs the binary to their system path (e.g., `/usr/local/bin`).
*   **Documentation Update** (`README.md`): Added the new one-line installation command so users can immediately get started using curl.
*   **Misc Setup**: Included directory ignores for local builds (`.gitignore` update) and formatted `go.mod`.

### Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🚀 Deployment / Packaging automation
- [x] 📝 Documentation update

### Testing / Verification 
- [x] Verified that `.goreleaser.yaml` is valid.
- [x] Verified that `install.sh` successfully curls the binary artifact and places it in the correct system directory.
- [x] Confirmed the GitHub action syntax is correct.
