### PR TITLE
feat: add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: 'stable'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![IINA](https://img.shields.io/badge/IINA-supported-lightgrey?style=flat)
 ![ffmpeg](https://img.shields.io/badge/ffmpeg-download-red?style=flat)
 ![Security](https://img.shields.io/badge/security-hardened-green?style=flat)
-![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey?style=flat)
+![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat)
 
 > **Search in your terminal. Stream instantly in your media player.**
 
@@ -62,6 +62,18 @@ git clone https://github.com/billmal071/lobster && cd lobster
 go build -o lobster .
 sudo make install # installs to /usr/local/bin
 ```
+
+### Windows
+
+Install [Go](https://go.dev/dl/), [fzf](https://github.com/junegunn/fzf#windows), [mpv](https://mpv.io/installation/) (or [VLC](https://www.videolan.org/)), and optionally [ffmpeg](https://ffmpeg.org/download.html). Ensure they are in your PATH.
+
+```powershell
+git clone https://github.com/billmal071/lobster && cd lobster
+
+go build -o lobster.exe .
+```
+
+Config is stored in `%APPDATA%\lobster\config.toml` and history in `%LOCALAPPDATA%\lobster\history.tsv`.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,17 +40,7 @@ func Default() *Config {
 	}
 }
 
-// configDir returns the XDG-compliant config directory.
-func configDir() (string, error) {
-	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, "lobster"), nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("getting home directory: %w", err)
-	}
-	return filepath.Join(home, ".config", "lobster"), nil
-}
+// configDir is defined in paths_unix.go / paths_windows.go.
 
 // ConfigPath returns the path to the config file.
 func ConfigPath() (string, error) {
@@ -123,7 +113,7 @@ func (c *Config) Validate() error {
 // ExpandDownloadDir resolves ~ in the download directory path.
 func (c *Config) ExpandDownloadDir() (string, error) {
 	dir := c.DownloadDir
-	if strings.HasPrefix(dir, "~/") {
+	if strings.HasPrefix(dir, "~/") || strings.HasPrefix(dir, `~\`) {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("expanding home dir: %w", err)
@@ -135,13 +125,9 @@ func (c *Config) ExpandDownloadDir() (string, error) {
 
 // HistoryPath returns the path to the history file.
 func HistoryPath() (string, error) {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("getting home directory: %w", err)
-		}
-		dataDir = filepath.Join(home, ".local", "share")
+	dir, err := dataDir()
+	if err != nil {
+		return "", err
 	}
-	return filepath.Join(dataDir, "lobster", "history.tsv"), nil
+	return filepath.Join(dir, "history.tsv"), nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -65,8 +66,12 @@ history = false
 		t.Fatal(err)
 	}
 
-	// Override config dir for testing
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	// Override config dir for testing (platform-specific)
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", tmpDir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	}
 
 	// Create the lobster subdir and move the config
 	lobsterDir := filepath.Join(tmpDir, "lobster")
@@ -96,7 +101,12 @@ history = false
 }
 
 func TestLoadMissingFile(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	tmp := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", tmp)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", tmp)
+	}
 
 	cfg, err := Load()
 	if err != nil {
@@ -108,14 +118,16 @@ func TestLoadMissingFile(t *testing.T) {
 }
 
 func TestExpandDownloadDir(t *testing.T) {
+	tmpDir := t.TempDir()
 	cfg := Default()
-	cfg.DownloadDir = "/tmp/test-downloads"
+	cfg.DownloadDir = tmpDir
 
 	dir, err := cfg.ExpandDownloadDir()
 	if err != nil {
 		t.Fatalf("ExpandDownloadDir() error: %v", err)
 	}
-	if dir != "/tmp/test-downloads" {
-		t.Errorf("got %q, want /tmp/test-downloads", dir)
+	want, _ := filepath.Abs(tmpDir)
+	if dir != want {
+		t.Errorf("got %q, want %q", dir, want)
 	}
 }

--- a/internal/config/paths_unix.go
+++ b/internal/config/paths_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// configDir returns the XDG-compliant config directory.
+func configDir() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "lobster"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "lobster"), nil
+}
+
+// dataDir returns the XDG-compliant data directory.
+func dataDir() (string, error) {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "lobster"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "share", "lobster"), nil
+}

--- a/internal/config/paths_windows.go
+++ b/internal/config/paths_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// configDir returns the Windows config directory (%APPDATA%\lobster).
+func configDir() (string, error) {
+	appData := os.Getenv("APPDATA")
+	if appData != "" {
+		return filepath.Join(appData, "lobster"), nil
+	}
+	// Fallback to os.UserConfigDir which returns %APPDATA% on Windows
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("getting config directory: %w", err)
+	}
+	return filepath.Join(dir, "lobster"), nil
+}
+
+// dataDir returns the Windows data directory (%LOCALAPPDATA%\lobster).
+func dataDir() (string, error) {
+	localAppData := os.Getenv("LOCALAPPDATA")
+	if localAppData != "" {
+		return filepath.Join(localAppData, "lobster"), nil
+	}
+	// Fallback
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, "AppData", "Local", "lobster"), nil
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -3,14 +3,25 @@ package history
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"lobster/internal/media"
 )
 
+// setDataHome sets the platform-specific env var so dataDir() resolves to tmpDir.
+func setDataHome(t *testing.T, tmpDir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", tmpDir)
+	} else {
+		t.Setenv("XDG_DATA_HOME", tmpDir)
+	}
+}
+
 func TestSaveAndLoad(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("XDG_DATA_HOME", tmpDir)
+	setDataHome(t, tmpDir)
 
 	// Create the lobster data dir
 	dataDir := filepath.Join(tmpDir, "lobster")
@@ -53,7 +64,7 @@ func TestSaveAndLoad(t *testing.T) {
 
 func TestSaveUpdatesExisting(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("XDG_DATA_HOME", tmpDir)
+	setDataHome(t, tmpDir)
 	os.MkdirAll(filepath.Join(tmpDir, "lobster"), 0700)
 
 	entry := media.HistoryEntry{
@@ -79,7 +90,7 @@ func TestSaveUpdatesExisting(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	tmpDir := t.TempDir()
-	t.Setenv("XDG_DATA_HOME", tmpDir)
+	setDataHome(t, tmpDir)
 	os.MkdirAll(filepath.Join(tmpDir, "lobster"), 0700)
 
 	Save(media.HistoryEntry{ID: "a", Title: "A", Type: media.Movie})

--- a/internal/httputil/sanitize_test.go
+++ b/internal/httputil/sanitize_test.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -87,6 +88,16 @@ func TestValidateNumericID(t *testing.T) {
 	}
 }
 
+// backslashTraversalExpected returns the expected result for backslash traversal test.
+// On Windows, filepath.Base treats \ as separator, so "..\\..\\windows\\system32" → "system32".
+// On Unix, \ is not a separator, so the entire string is the base name and gets sanitized.
+func backslashTraversalExpected() string {
+	if runtime.GOOS == "windows" {
+		return "system32"
+	}
+	return "____windows_system32"
+}
+
 func TestSanitizeFilename(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -103,7 +114,7 @@ func TestSanitizeFilename(t *testing.T) {
 		{"empty string", "", "untitled"},
 		{"just dots", "..", "_"},                                                      // filepath.Base("..") = "..", replacer makes "_"
 		{"just dot", ".", "untitled"},
-		{"backslash traversal", "..\\..\\windows\\system32", "____windows_system32"}, // on linux, backslash isn't path sep
+		{"backslash traversal", "..\\..\\windows\\system32", backslashTraversalExpected()},
 		{"XSS payload", "<script>alert(1)</script>.mkv", "script_.mkv"},              // filepath.Base handles angle brackets
 	}
 

--- a/internal/player/ipc_unix.go
+++ b/internal/player/ipc_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package player
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// ipcSocket holds the IPC socket path and cleanup function.
+type ipcSocket struct {
+	path    string
+	cleanup func()
+}
+
+// newIPCSocket creates a randomized Unix socket path for mpv IPC.
+func newIPCSocket() (*ipcSocket, error) {
+	socketDir, err := os.MkdirTemp("", "lobster-mpv-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir for mpv socket: %w", err)
+	}
+	return &ipcSocket{
+		path:    filepath.Join(socketDir, "socket"),
+		cleanup: func() { os.RemoveAll(socketDir) },
+	}, nil
+}
+
+// dial connects to the mpv IPC socket.
+func (s *ipcSocket) dial() (io.ReadWriteCloser, error) {
+	return net.Dial("unix", s.path)
+}

--- a/internal/player/ipc_windows.go
+++ b/internal/player/ipc_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package player
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// ipcSocket holds the IPC named pipe path and cleanup function.
+type ipcSocket struct {
+	path    string
+	cleanup func()
+}
+
+// newIPCSocket creates a randomized named pipe path for mpv IPC on Windows.
+func newIPCSocket() (*ipcSocket, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("generating random pipe name: %w", err)
+	}
+	name := fmt.Sprintf(`\\.\pipe\lobster-mpv-%x`, buf)
+	return &ipcSocket{
+		path:    name,
+		cleanup: func() {}, // Named pipes are cleaned up automatically
+	}, nil
+}
+
+// dial connects to the mpv IPC named pipe.
+// Windows named pipes can be opened as regular files.
+func (s *ipcSocket) dial() (io.ReadWriteCloser, error) {
+	var f *os.File
+	var err error
+	// Retry briefly as mpv may not have created the pipe yet
+	for i := 0; i < 10; i++ {
+		f, err = os.OpenFile(s.path, os.O_RDWR, 0)
+		if err == nil {
+			return f, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("opening named pipe %s: %w", s.path, err)
+}

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -4,10 +4,8 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -29,20 +27,18 @@ func (m *MPV) Available() bool {
 
 // Play launches mpv with the given stream and returns the final playback position.
 func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile string) (float64, error) {
-	// Create randomized IPC socket path (prevents symlink attacks)
-	socketDir, err := os.MkdirTemp("", "lobster-mpv-*")
+	// Create randomized IPC path (Unix socket on Unix, named pipe on Windows)
+	ipc, err := newIPCSocket()
 	if err != nil {
-		return 0, fmt.Errorf("creating temp dir for mpv socket: %w", err)
+		return 0, err
 	}
-	defer os.RemoveAll(socketDir)
-
-	socketPath := filepath.Join(socketDir, "socket")
+	defer ipc.cleanup()
 
 	// Build args as explicit slice — each arg is separate, no shell interpretation
 	args := []string{
 		stream.URL,
 		"--force-media-title=" + title,
-		"--input-ipc-server=" + socketPath,
+		"--input-ipc-server=" + ipc.path,
 		"--really-quiet",
 	}
 
@@ -74,7 +70,7 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 	// Wait briefly for IPC socket to become available
 	var lastPos float64
 	go func() {
-		lastPos = m.trackPosition(socketPath)
+		lastPos = m.trackPosition(ipc)
 	}()
 
 	if err := cmd.Wait(); err != nil {
@@ -87,19 +83,14 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 	return lastPos, nil
 }
 
-// trackPosition polls mpv's IPC socket for the current playback position.
-func (m *MPV) trackPosition(socketPath string) float64 {
+// trackPosition polls mpv's IPC for the current playback position.
+func (m *MPV) trackPosition(ipc *ipcSocket) float64 {
 	var lastPos float64
 
-	// Wait for socket to appear
-	for i := 0; i < 50; i++ {
-		if _, err := os.Stat(socketPath); err == nil {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	// Wait for IPC to become available
+	time.Sleep(500 * time.Millisecond)
 
-	conn, err := net.Dial("unix", socketPath)
+	conn, err := ipc.dial()
 	if err != nil {
 		return 0
 	}

--- a/internal/player/vlc.go
+++ b/internal/player/vlc.go
@@ -14,7 +14,12 @@ type VLC struct{}
 func (v *VLC) Name() string { return "vlc" }
 
 func (v *VLC) Available() bool {
-	_, err := exec.LookPath("vlc")
+	bin := vlcBinaryName()
+	_, err := exec.LookPath(bin)
+	if err != nil {
+		// vlcBinaryName may return a full path on Windows
+		_, err = os.Stat(bin)
+	}
 	return err == nil
 }
 
@@ -35,7 +40,7 @@ func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFile
 		args = append(args, "--sub-file", subFile)
 	}
 
-	cmd := exec.Command("vlc", args...)
+	cmd := exec.Command(vlcBinaryName(), args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/player/vlc_path_unix.go
+++ b/internal/player/vlc_path_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package player
+
+// vlcBinaryName returns the VLC binary name for the current platform.
+func vlcBinaryName() string {
+	return "vlc"
+}

--- a/internal/player/vlc_path_windows.go
+++ b/internal/player/vlc_path_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package player
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// vlcBinaryName returns the VLC binary name for the current platform.
+// On Windows, VLC is often not in PATH, so check common install locations.
+func vlcBinaryName() string {
+	// If vlc is in PATH, use it directly
+	if _, err := exec.LookPath("vlc"); err == nil {
+		return "vlc"
+	}
+
+	// Check common Windows install paths
+	programFiles := os.Getenv("ProgramFiles")
+	if programFiles != "" {
+		vlcPath := filepath.Join(programFiles, "VideoLAN", "VLC", "vlc.exe")
+		if _, err := os.Stat(vlcPath); err == nil {
+			return vlcPath
+		}
+	}
+
+	programFilesX86 := os.Getenv("ProgramFiles(x86)")
+	if programFilesX86 != "" {
+		vlcPath := filepath.Join(programFilesX86, "VideoLAN", "VLC", "vlc.exe")
+		if _, err := os.Stat(vlcPath); err == nil {
+			return vlcPath
+		}
+	}
+
+	return "vlc"
+}


### PR DESCRIPTION
## Summary
- Platform-specific config/data paths using build tags (XDG on Unix, `%APPDATA%`/`%LOCALAPPDATA%` on Windows)
- mpv IPC via named pipes on Windows (Unix sockets on Unix)
- VLC auto-discovery from Program Files on Windows
- `~\` path expansion for Windows download dirs
- CI workflow running build, vet, and tests on Ubuntu, Windows, and macOS

## Test plan
- [ ] CI passes on all three platforms (Ubuntu, Windows, macOS)
- [ ] Manual test on Windows with mpv + fzf installed
- [ ] Verify config loads from `%APPDATA%\lobster\config.toml`
- [ ] Verify history writes to `%LOCALAPPDATA%\lobster\history.tsv`