### PR TITLE
fix: find fzf on Windows when not in PATH

### DIFF
--- a/internal/ui/fzf_path_unix.go
+++ b/internal/ui/fzf_path_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package ui
+
+import "os/exec"
+
+// fzfBinary returns the path to the fzf binary.
+func fzfBinary() (string, error) {
+	return exec.LookPath("fzf")
+}

--- a/internal/ui/fzf_path_windows.go
+++ b/internal/ui/fzf_path_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// fzfBinary returns the path to the fzf binary, checking common Windows
+// install locations when fzf is not found in PATH.
+func fzfBinary() (string, error) {
+	// Try PATH first
+	if p, err := exec.LookPath("fzf"); err == nil {
+		return p, nil
+	}
+
+	// Common install locations on Windows
+	candidates := []string{}
+
+	if local := os.Getenv("LOCALAPPDATA"); local != "" {
+		// winget shim
+		candidates = append(candidates, filepath.Join(local, "Microsoft", "WinGet", "Links", "fzf.exe"))
+	}
+
+	if home := os.Getenv("USERPROFILE"); home != "" {
+		// scoop
+		candidates = append(candidates, filepath.Join(home, "scoop", "shims", "fzf.exe"))
+	}
+
+	if choco := os.Getenv("ChocolateyInstall"); choco != "" {
+		candidates = append(candidates, filepath.Join(choco, "bin", "fzf.exe"))
+	}
+
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("fzf not found — install with: winget install junegunn.fzf")
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -22,9 +22,9 @@ func Select(prompt string, items []string) (int, error) {
 	}
 
 	// Check if fzf is available
-	fzfPath, err := exec.LookPath("fzf")
+	fzfPath, err := fzfBinary()
 	if err != nil {
-		return -1, fmt.Errorf("fzf not found in PATH: %w", err)
+		return -1, fmt.Errorf("fzf not found: %w", err)
 	}
 
 	// Prepare numbered items for reliable index extraction
@@ -91,9 +91,9 @@ func Confirm(prompt string) (bool, error) {
 
 // Input prompts the user for free-text input via fzf's --print-query.
 func Input(prompt string) (string, error) {
-	fzfPath, err := exec.LookPath("fzf")
+	fzfPath, err := fzfBinary()
 	if err != nil {
-		return "", fmt.Errorf("fzf not found in PATH: %w", err)
+		return "", fmt.Errorf("fzf not found: %w", err)
 	}
 
 	cmd := exec.Command(fzfPath,


### PR DESCRIPTION
## Summary
- On Windows, winget/scoop/chocolatey install fzf but the current terminal session often doesn't have the updated PATH
- Added platform-specific fzf binary lookup: checks common Windows install locations (winget shim, scoop shims, chocolatey bin) as fallback
- Unix behavior unchanged — still uses simple `exec.LookPath`

## Test plan
- [ ] Verify lobster finds fzf on Windows after fresh winget install without restarting terminal
- [ ] Verify existing Linux/macOS behavior is unaffected
- [ ] CI passes on all three platforms