### PR TITLE
feat: add provider backends (flixhq.ws + consumet API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ Config is stored in `%APPDATA%\lobster\config.toml` and history in `%LOCALAPPDAT
 
 ---
 
+## Configuration
+
+Config file location:
+- **Linux/macOS:** `~/.config/lobster/config.toml`
+- **Windows:** `%APPDATA%\lobster\config.toml`
+
+```toml
+base = "flixhq.to"
+player = "mpv"
+provider = "Vidcloud"
+subs_language = "english"
+quality = "1080"
+history = true
+auto_next = true
+download_dir = "~/Videos/lobster"
+
+# Optional: use a consumet API backend instead of the built-in scraper.
+# Self-host from: https://github.com/consumet/api.consumet.org
+# When set, lobster uses this API for search, streaming, etc.
+# api_url = "https://your-consumet-instance.example.com"
+```
+
+---
+
 ## Project Structure
 
 ```
@@ -125,7 +149,7 @@ lobster/
 │   ├── media/              # Shared types (Stream, SearchResult, etc.)
 │   ├── player/             # Player backends (mpv, vlc, iina, celluloid)
 │   ├── playlist/           # Episode navigation and session state
-│   ├── provider/           # FlixHQ scraper and HTML parser
+│   ├── provider/           # Content providers (FlixHQ scraper, Consumet API)
 │   ├── subtitle/           # Subtitle download and language matching
 │   └── ui/                 # fzf-based terminal UI
 ├── Makefile

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -170,7 +170,7 @@ func downloadSingleEpisode(p provider.Provider, selected media.SearchResult, ep 
 	for _, srv := range ordered {
 		debugf("trying server: %s (ID: %s)", srv.Name, srv.ID)
 
-		err := tryDownloadFromServer(p, srv, title, outputDir)
+		err := tryDownloadFromServer(p, srv, selected.ID, ep.ID, title, outputDir)
 		if err == nil {
 			return nil
 		}
@@ -185,18 +185,29 @@ func downloadSingleEpisode(p provider.Provider, selected media.SearchResult, ep 
 }
 
 // tryDownloadFromServer attempts to resolve and download from a single server.
-func tryDownloadFromServer(p provider.Provider, srv media.Server, title, outputDir string) error {
-	// Get embed URL
-	embedURL, err := p.GetEmbedURL(srv.ID)
-	if err != nil {
-		return fmt.Errorf("getting embed URL: %w", err)
-	}
+func tryDownloadFromServer(p provider.Provider, srv media.Server, mediaID, episodeID, title, outputDir string) error {
+	var stream *media.Stream
+	var err error
 
-	// Extract stream
-	ext := extract.New()
-	stream, err := ext.Extract(embedURL, cfg.Quality)
-	if err != nil {
-		return fmt.Errorf("extracting stream: %w", err)
+	// StreamProvider (consumet) can resolve streams directly
+	if sp, ok := p.(provider.StreamProvider); ok {
+		stream, err = sp.Watch(mediaID, episodeID, srv.Name, cfg.Quality)
+		if err != nil {
+			return fmt.Errorf("watch failed: %w", err)
+		}
+	} else {
+		// Get embed URL
+		embedURL, err := p.GetEmbedURL(srv.ID)
+		if err != nil {
+			return fmt.Errorf("getting embed URL: %w", err)
+		}
+
+		// Extract stream
+		ext := extract.New()
+		stream, err = ext.Extract(embedURL, cfg.Quality)
+		if err != nil {
+			return fmt.Errorf("extracting stream: %w", err)
+		}
 	}
 
 	// Handle subtitles (explicit cleanup, no defer in loop)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"lobster/internal/history"
-	"lobster/internal/provider"
 	"lobster/internal/ui"
 )
 
@@ -38,7 +37,7 @@ func historyRun(cmd *cobra.Command, args []string) error {
 	debugf("resuming: %s (ID: %s)", selected.Title, selected.ID)
 
 	// Re-resolve and play from the saved position
-	p := provider.NewFlixHQ(cfg.Base)
+	p := newProvider()
 
 	// Search for the title to get fresh results
 	results, err := p.Search(selected.Title)

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -1,0 +1,14 @@
+package cmd
+
+import "lobster/internal/provider"
+
+// newProvider returns the configured content provider.
+// When cfg.APIURL is set, it returns a Consumet provider (which supports
+// direct stream resolution via the StreamProvider interface).
+// Otherwise, it falls back to the default FlixHQ scraper.
+func newProvider() provider.Provider {
+	if cfg.APIURL != "" {
+		return provider.NewConsumet(cfg.APIURL)
+	}
+	return provider.NewFlixHQ(cfg.Base)
+}

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -1,14 +1,22 @@
 package cmd
 
-import "lobster/internal/provider"
+import (
+	"strings"
+
+	"lobster/internal/provider"
+)
 
 // newProvider returns the configured content provider.
 // When cfg.APIURL is set, it returns a Consumet provider (which supports
 // direct stream resolution via the StreamProvider interface).
-// Otherwise, it falls back to the default FlixHQ scraper.
+// When base is "flixhq.ws", uses the FlixHQWS scraper.
+// Otherwise, uses the default FlixHQ scraper.
 func newProvider() provider.Provider {
 	if cfg.APIURL != "" {
 		return provider.NewConsumet(cfg.APIURL)
+	}
+	if strings.Contains(cfg.Base, "flixhq.ws") {
+		return provider.NewFlixHQWS(cfg.Base)
 	}
 	return provider.NewFlixHQ(cfg.Base)
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -24,7 +24,7 @@ import (
 func searchRun(cmd *cobra.Command, args []string) error {
 	query := strings.Join(args, " ")
 
-	p := provider.NewFlixHQ(cfg.Base)
+	p := newProvider()
 
 	if query == "" {
 		// Launch the rich TUI Dashboard
@@ -239,6 +239,40 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 	}
 
 
+	// If provider supports direct streaming (consumet API), skip embed+extract step.
+	if sp, ok := p.(provider.StreamProvider); ok {
+		stopStream := ui.StartSpinner("Negotiating stream servers...")
+		servers, err := p.GetServers(selected.ID, episodeID)
+		stopStream()
+		if err != nil {
+			return fmt.Errorf("getting servers: %w", err)
+		}
+		if len(servers) == 0 {
+			return fmt.Errorf("no servers found")
+		}
+
+		stopWatch := ui.StartSpinner(fmt.Sprintf("Fetching %s media stream...", title))
+		defer stopWatch()
+
+		ordered := orderServers(servers, cfg.Provider)
+		var stream *media.Stream
+		for _, srv := range ordered {
+			debugf("trying server (watch): %s (ID: %s)", srv.Name, srv.ID)
+			stream, err = sp.Watch(selected.ID, episodeID, srv.Name, cfg.Quality)
+			if err != nil {
+				debugf("server %s watch failed: %v", srv.Name, err)
+				fmt.Fprintf(os.Stderr, "Server %s failed, trying next...\n", srv.Name)
+				continue
+			}
+			debugf("stream URL: %s (server: %s)", stream.URL, srv.Name)
+			break
+		}
+		if stream == nil {
+			return fmt.Errorf("all servers failed for %s", title)
+		}
+		stopWatch()
+		return playStream(stream, title, selected, season, episode)
+	}
 
 	// Get servers
 	stopServer := ui.StartSpinner("Negotiating stream servers...")
@@ -281,10 +315,16 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 	if stream == nil {
 		return fmt.Errorf("all servers failed for %s", title)
 	}
-	
+
 	// Stop extraction spinner before printing/playing
 	stopExt()
 
+	return playStream(stream, title, selected, season, episode)
+}
+
+// playStream handles all post-stream-resolution logic: JSON output, subtitle
+// download, download mode, playback, and history saving.
+func playStream(stream *media.Stream, title string, selected media.SearchResult, season, episode int) error {
 	// JSON output mode
 	if flagJSON {
 		out := map[string]interface{}{

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -12,6 +12,7 @@ import (
 	"lobster/internal/media"
 	"lobster/internal/player"
 	"lobster/internal/playlist"
+	"lobster/internal/provider"
 	"lobster/internal/subtitle"
 	"lobster/internal/ui"
 )
@@ -206,6 +207,16 @@ func resolveStream(sess *playlist.Session, excludeNames map[string]bool) (*media
 
 // tryServer attempts to extract a stream from a single server.
 func tryServer(sess *playlist.Session, srv *media.Server) (*media.Stream, error) {
+	// StreamProvider (consumet) can resolve streams directly
+	if sp, ok := sess.Provider.(provider.StreamProvider); ok {
+		stream, err := sp.Watch(sess.Content.ID, sess.Current().ID, srv.Name, cfg.Quality)
+		if err != nil {
+			return nil, fmt.Errorf("watch failed: %w", err)
+		}
+		debugf("stream URL: %s (server: %s)", stream.URL, srv.Name)
+		return stream, nil
+	}
+
 	embedURL, err := sess.Provider.GetEmbedURL(srv.ID)
 	if err != nil {
 		return nil, fmt.Errorf("embed failed: %w", err)

--- a/cmd/trending.go
+++ b/cmd/trending.go
@@ -21,7 +21,7 @@ var trendingCmd = &cobra.Command{
 func trendingRun(cmd *cobra.Command, args []string) error {
 	mediaType := parseMediaTypeArg(args)
 
-	p := provider.NewFlixHQ(cfg.Base)
+	p := newProvider()
 	results, err := p.Trending(mediaType)
 	if err != nil {
 		return fmt.Errorf("getting trending: %w", err)
@@ -55,7 +55,7 @@ var recentCmd = &cobra.Command{
 func recentRun(cmd *cobra.Command, args []string) error {
 	mediaType := parseMediaTypeArg(args)
 
-	p := provider.NewFlixHQ(cfg.Base)
+	p := newProvider()
 	results, err := p.Recent(mediaType)
 	if err != nil {
 		return fmt.Errorf("getting recent: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 // Config holds all application configuration.
 type Config struct {
 	Base         string `toml:"base"`
+	APIURL       string `toml:"api_url"`
 	Player       string `toml:"player"`
 	Provider     string `toml:"provider"`
 	SubsLanguage string `toml:"subs_language"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type Config struct {
 // Default returns the default configuration.
 func Default() *Config {
 	return &Config{
-		Base:         "flixhq.to",
+		Base:         "flixhq.ws",
 		Player:       "mpv",
 		Provider:     "Vidcloud",
 		SubsLanguage: "english",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,6 +117,40 @@ func TestLoadMissingFile(t *testing.T) {
 	}
 }
 
+func TestLoadAPIURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	lobsterDir := filepath.Join(tmpDir, "lobster")
+	if err := os.MkdirAll(lobsterDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `
+base = "flixhq.to"
+player = "mpv"
+provider = "Vidcloud"
+quality = "1080"
+api_url = "https://my-consumet.example.com"
+`
+	if err := os.WriteFile(filepath.Join(lobsterDir, "config.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Setenv("APPDATA", tmpDir)
+	} else {
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.APIURL != "https://my-consumet.example.com" {
+		t.Errorf("APIURL = %q, want %q", cfg.APIURL, "https://my-consumet.example.com")
+	}
+}
+
 func TestExpandDownloadDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := Default()

--- a/internal/provider/consumet.go
+++ b/internal/provider/consumet.go
@@ -184,19 +184,116 @@ func (c *Consumet) GetEpisodes(id string, seasonID string) ([]media.Episode, err
 	return episodes, nil
 }
 
-// GetServers is not yet implemented.
+// consumetServerResponse is an item in the servers list.
+type consumetServerResponse struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	ID   string `json:"id"`
+}
+
+// GetServers returns available streaming servers for content.
 func (c *Consumet) GetServers(id string, episodeID string) ([]media.Server, error) {
-	return nil, fmt.Errorf("not implemented")
+	endpoint := fmt.Sprintf("%s/movies/flixhq/servers?episodeId=%s&mediaId=%s",
+		c.baseURL, url.QueryEscape(episodeID), url.QueryEscape(id))
+
+	body, err := c.fetchJSON(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("consumet servers: %w", err)
+	}
+
+	var raw []consumetServerResponse
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("consumet servers: parsing response: %w", err)
+	}
+
+	servers := make([]media.Server, 0, len(raw))
+	for _, s := range raw {
+		servers = append(servers, media.Server{
+			Name: s.Name,
+			ID:   s.ID,
+		})
+	}
+
+	return servers, nil
 }
 
-// GetEmbedURL is not yet implemented.
+// GetEmbedURL is not used with the Consumet provider — streaming goes through Watch.
 func (c *Consumet) GetEmbedURL(serverID string) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return "", fmt.Errorf("GetEmbedURL not supported by consumet provider; use Watch instead")
 }
 
-// Watch is not yet implemented.
+// consumetWatchResponse is the JSON structure returned by the watch endpoint.
+type consumetWatchResponse struct {
+	Sources   []consumetSource   `json:"sources"`
+	Subtitles []consumetSubtitle `json:"subtitles"`
+}
+
+type consumetSource struct {
+	URL     string `json:"url"`
+	Quality string `json:"quality"`
+	IsM3U8  bool   `json:"isM3U8"`
+}
+
+type consumetSubtitle struct {
+	URL  string `json:"url"`
+	Lang string `json:"lang"`
+}
+
+// Watch resolves a stream for the given media/episode/server/quality combination.
 func (c *Consumet) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
-	return nil, fmt.Errorf("not implemented")
+	endpoint := fmt.Sprintf("%s/movies/flixhq/watch?episodeId=%s&mediaId=%s&server=%s",
+		c.baseURL, url.QueryEscape(episodeID), url.QueryEscape(mediaID), url.QueryEscape(server))
+
+	body, err := c.fetchJSON(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("consumet watch: %w", err)
+	}
+
+	var resp consumetWatchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("consumet watch: parsing response: %w", err)
+	}
+
+	if len(resp.Sources) == 0 {
+		return nil, fmt.Errorf("consumet watch: no sources returned")
+	}
+
+	// Pick source matching the requested quality; fall back to first.
+	chosen := resp.Sources[0]
+	for _, s := range resp.Sources {
+		if containsStr(s.Quality, quality) {
+			chosen = s
+			break
+		}
+	}
+
+	subtitles := make([]media.Subtitle, 0, len(resp.Subtitles))
+	for _, sub := range resp.Subtitles {
+		subtitles = append(subtitles, media.Subtitle{
+			Language: sub.Lang,
+			Label:    sub.Lang,
+			URL:      sub.URL,
+		})
+	}
+
+	return &media.Stream{
+		URL:       chosen.URL,
+		Quality:   chosen.Quality,
+		Subtitles: subtitles,
+	}, nil
+}
+
+// containsStr reports whether s contains substr.
+func containsStr(s, substr string) bool {
+	if substr == "" {
+		return false
+	}
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }
 
 // Trending is not yet implemented.

--- a/internal/provider/consumet.go
+++ b/internal/provider/consumet.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"lobster/internal/httputil"
 	"lobster/internal/media"
@@ -78,19 +79,109 @@ func (c *Consumet) Search(query string) ([]media.SearchResult, error) {
 	return results, nil
 }
 
-// GetDetails is not yet implemented.
+// consumetInfoResponse is the JSON structure returned by the info endpoint.
+type consumetInfoResponse struct {
+	ID          string            `json:"id"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	Type        string            `json:"type"`
+	ReleaseDate string            `json:"releaseDate"`
+	Genres      []string          `json:"genres"`
+	Casts       []string          `json:"casts"`
+	Country     string            `json:"country"`
+	Duration    string            `json:"duration"`
+	Rating      json.Number       `json:"rating"`
+	Episodes    []consumetEpisode `json:"episodes"`
+}
+
+type consumetEpisode struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Number int    `json:"number"`
+	Season int    `json:"season"`
+}
+
+// fetchInfo fetches content info from the Consumet info endpoint.
+func (c *Consumet) fetchInfo(id string) (*consumetInfoResponse, error) {
+	endpoint := fmt.Sprintf("%s/movies/flixhq/info?id=%s", c.baseURL, url.QueryEscape(id))
+
+	body, err := c.fetchJSON(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("consumet info: %w", err)
+	}
+
+	var info consumetInfoResponse
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("consumet info: parsing response: %w", err)
+	}
+
+	return &info, nil
+}
+
+// GetDetails returns detailed metadata for a content item.
 func (c *Consumet) GetDetails(id string) (*media.ContentDetail, error) {
-	return nil, fmt.Errorf("not implemented")
+	info, err := c.fetchInfo(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &media.ContentDetail{
+		Description: info.Description,
+		Rating:      info.Rating.String(),
+		Duration:    info.Duration,
+		Genre:       info.Genres,
+		Released:    info.ReleaseDate,
+		Country:     info.Country,
+		Casts:       info.Casts,
+	}, nil
 }
 
-// GetSeasons is not yet implemented.
+// GetSeasons returns available seasons derived from the episodes list.
 func (c *Consumet) GetSeasons(id string) ([]media.Season, error) {
-	return nil, fmt.Errorf("not implemented")
+	info, err := c.fetchInfo(id)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[int]bool)
+	var seasons []media.Season
+	for _, ep := range info.Episodes {
+		if !seen[ep.Season] {
+			seen[ep.Season] = true
+			seasons = append(seasons, media.Season{
+				Number: ep.Season,
+				ID:     fmt.Sprintf("%d", ep.Season),
+			})
+		}
+	}
+
+	return seasons, nil
 }
 
-// GetEpisodes is not yet implemented.
+// GetEpisodes returns episodes for a given season (seasonID is a string number like "1").
 func (c *Consumet) GetEpisodes(id string, seasonID string) ([]media.Episode, error) {
-	return nil, fmt.Errorf("not implemented")
+	info, err := c.fetchInfo(id)
+	if err != nil {
+		return nil, err
+	}
+
+	var seasonNum int
+	if _, err := fmt.Sscanf(seasonID, "%d", &seasonNum); err != nil {
+		return nil, fmt.Errorf("invalid season ID %q: %w", seasonID, err)
+	}
+
+	var episodes []media.Episode
+	for _, ep := range info.Episodes {
+		if ep.Season == seasonNum {
+			episodes = append(episodes, media.Episode{
+				Number: ep.Number,
+				Title:  ep.Title,
+				ID:     ep.ID,
+			})
+		}
+	}
+
+	return episodes, nil
 }
 
 // GetServers is not yet implemented.

--- a/internal/provider/consumet.go
+++ b/internal/provider/consumet.go
@@ -296,12 +296,12 @@ func containsStr(s, substr string) bool {
 	return false
 }
 
-// Trending is not yet implemented.
+// Trending is not supported by the Consumet API provider.
 func (c *Consumet) Trending(mediaType media.MediaType) ([]media.SearchResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("trending not supported by consumet API provider")
 }
 
-// Recent is not yet implemented.
+// Recent is not supported by the Consumet API provider.
 func (c *Consumet) Recent(mediaType media.MediaType) ([]media.SearchResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("recent not supported by consumet API provider")
 }

--- a/internal/provider/consumet.go
+++ b/internal/provider/consumet.go
@@ -1,0 +1,119 @@
+// Package provider defines the interface for media content providers
+// and their implementations.
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+// Consumet implements the Provider interface using the Consumet REST API.
+type Consumet struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewConsumet creates a new Consumet provider targeting the given base URL.
+func NewConsumet(baseURL string) *Consumet {
+	return &Consumet{
+		baseURL: baseURL,
+		client:  httputil.NewClient(),
+	}
+}
+
+// fetchJSON fetches a URL and returns the raw JSON bytes.
+func (c *Consumet) fetchJSON(rawURL string) ([]byte, error) {
+	return httputil.GetJSON(c.client, rawURL)
+}
+
+// consumetSearchResponse is the JSON structure returned by the search endpoint.
+type consumetSearchResponse struct {
+	CurrentPage int                    `json:"currentPage"`
+	HasNextPage bool                   `json:"hasNextPage"`
+	Results     []consumetSearchResult `json:"results"`
+}
+
+type consumetSearchResult struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Type        string `json:"type"`
+	ReleaseDate string `json:"releaseDate"`
+	Seasons     int    `json:"seasons"`
+}
+
+// Search returns matching results for the given query.
+func (c *Consumet) Search(query string) ([]media.SearchResult, error) {
+	encoded := httputil.EncodeQuery(query)
+	endpoint := fmt.Sprintf("%s/movies/flixhq/%s", c.baseURL, encoded)
+
+	body, err := c.fetchJSON(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("consumet search: %w", err)
+	}
+
+	var resp consumetSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("consumet search: parsing response: %w", err)
+	}
+
+	results := make([]media.SearchResult, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		mt := media.Movie
+		if r.Type == "TV Series" {
+			mt = media.TV
+		}
+		results = append(results, media.SearchResult{
+			ID:      r.ID,
+			Title:   r.Title,
+			Type:    mt,
+			Year:    r.ReleaseDate,
+			Seasons: r.Seasons,
+		})
+	}
+
+	return results, nil
+}
+
+// GetDetails is not yet implemented.
+func (c *Consumet) GetDetails(id string) (*media.ContentDetail, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetSeasons is not yet implemented.
+func (c *Consumet) GetSeasons(id string) ([]media.Season, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetEpisodes is not yet implemented.
+func (c *Consumet) GetEpisodes(id string, seasonID string) ([]media.Episode, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetServers is not yet implemented.
+func (c *Consumet) GetServers(id string, episodeID string) ([]media.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetEmbedURL is not yet implemented.
+func (c *Consumet) GetEmbedURL(serverID string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// Watch is not yet implemented.
+func (c *Consumet) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Trending is not yet implemented.
+func (c *Consumet) Trending(mediaType media.MediaType) ([]media.SearchResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Recent is not yet implemented.
+func (c *Consumet) Recent(mediaType media.MediaType) ([]media.SearchResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/internal/provider/consumet_test.go
+++ b/internal/provider/consumet_test.go
@@ -9,12 +9,39 @@ import (
 	"lobster/internal/media"
 )
 
-// newSearchTestServer creates an httptest.Server serving search results.
-func newSearchTestServer(t *testing.T) *httptest.Server {
+// infoJSON is the shared info response used across tests.
+const infoJSON = `{
+  "id": "tv/watch-breaking-bad-39506",
+  "title": "Breaking Bad",
+  "description": "A chemistry teacher turns to crime.",
+  "type": "TV Series",
+  "releaseDate": "2008-01-20",
+  "genres": ["Crime", "Drama"],
+  "casts": ["Bryan Cranston"],
+  "country": "United States",
+  "duration": "45 min",
+  "rating": 9.5,
+  "episodes": [
+    {"id": "1001", "title": "Pilot", "number": 1, "season": 1},
+    {"id": "1002", "title": "Cat's in the Bag", "number": 2, "season": 1},
+    {"id": "2001", "title": "Seven Thirty-Seven", "number": 1, "season": 2}
+  ]
+}`
+
+// newTestServer creates an httptest.Server that routes based on path/query.
+func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 
+	// Search and info share the /movies/flixhq/ prefix.
 	mux.HandleFunc("/movies/flixhq/", func(w http.ResponseWriter, r *http.Request) {
+		// Distinguish info (has ?id=...) vs search.
+		if r.URL.Query().Get("id") != "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(infoJSON))
+			return
+		}
+		// Search response.
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"currentPage": 1,
@@ -31,10 +58,19 @@ func newSearchTestServer(t *testing.T) *httptest.Server {
 	return srv
 }
 
-func TestConsumetSearch(t *testing.T) {
-	srv := newSearchTestServer(t)
+func newConsumetForTest(srv *httptest.Server) *Consumet {
 	c := NewConsumet(srv.URL)
 	c.client = srv.Client()
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// Task 2: Search
+// ---------------------------------------------------------------------------
+
+func TestConsumetSearch(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
 
 	results, err := c.Search("batman")
 	if err != nil {
@@ -62,5 +98,87 @@ func TestConsumetSearch(t *testing.T) {
 	}
 	if results[1].Seasons != 4 {
 		t.Errorf("expected 4 seasons, got %d", results[1].Seasons)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 3: GetDetails, GetSeasons, GetEpisodes
+// ---------------------------------------------------------------------------
+
+func TestConsumetGetDetails(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
+
+	detail, err := c.GetDetails("tv/watch-breaking-bad-39506")
+	if err != nil {
+		t.Fatalf("GetDetails returned error: %v", err)
+	}
+
+	if detail.Description != "A chemistry teacher turns to crime." {
+		t.Errorf("unexpected description: %q", detail.Description)
+	}
+	if detail.Rating != "9.5" {
+		t.Errorf("expected rating 9.5, got %q", detail.Rating)
+	}
+	if detail.Duration != "45 min" {
+		t.Errorf("expected duration '45 min', got %q", detail.Duration)
+	}
+	if detail.Country != "United States" {
+		t.Errorf("unexpected country: %q", detail.Country)
+	}
+	if len(detail.Genre) != 2 || detail.Genre[0] != "Crime" {
+		t.Errorf("unexpected genres: %v", detail.Genre)
+	}
+	if len(detail.Casts) != 1 || detail.Casts[0] != "Bryan Cranston" {
+		t.Errorf("unexpected casts: %v", detail.Casts)
+	}
+}
+
+func TestConsumetGetSeasons(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
+
+	seasons, err := c.GetSeasons("tv/watch-breaking-bad-39506")
+	if err != nil {
+		t.Fatalf("GetSeasons returned error: %v", err)
+	}
+
+	if len(seasons) != 2 {
+		t.Fatalf("expected 2 seasons, got %d", len(seasons))
+	}
+	if seasons[0].Number != 1 || seasons[0].ID != "1" {
+		t.Errorf("unexpected season 0: %+v", seasons[0])
+	}
+	if seasons[1].Number != 2 || seasons[1].ID != "2" {
+		t.Errorf("unexpected season 1: %+v", seasons[1])
+	}
+}
+
+func TestConsumetGetEpisodes(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
+
+	episodes, err := c.GetEpisodes("tv/watch-breaking-bad-39506", "1")
+	if err != nil {
+		t.Fatalf("GetEpisodes returned error: %v", err)
+	}
+
+	if len(episodes) != 2 {
+		t.Fatalf("expected 2 episodes in season 1, got %d", len(episodes))
+	}
+	if episodes[0].Title != "Pilot" || episodes[0].ID != "1001" {
+		t.Errorf("unexpected episode 0: %+v", episodes[0])
+	}
+	if episodes[1].Title != "Cat's in the Bag" || episodes[1].ID != "1002" {
+		t.Errorf("unexpected episode 1: %+v", episodes[1])
+	}
+
+	// Season 2 filter
+	epS2, err := c.GetEpisodes("tv/watch-breaking-bad-39506", "2")
+	if err != nil {
+		t.Fatalf("GetEpisodes season 2 error: %v", err)
+	}
+	if len(epS2) != 1 || epS2[0].ID != "2001" {
+		t.Errorf("unexpected season 2 episodes: %+v", epS2)
 	}
 }

--- a/internal/provider/consumet_test.go
+++ b/internal/provider/consumet_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// newSearchTestServer creates an httptest.Server serving search results.
+func newSearchTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/movies/flixhq/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"currentPage": 1,
+			"hasNextPage": false,
+			"results": []map[string]interface{}{
+				{"id": "movie/watch-batman-19913", "title": "Batman Begins", "type": "Movie", "releaseDate": "2005"},
+				{"id": "tv/watch-batman-67955", "title": "Batman: TAS", "type": "TV Series", "releaseDate": "1992", "seasons": 4},
+			},
+		})
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestConsumetSearch(t *testing.T) {
+	srv := newSearchTestServer(t)
+	c := NewConsumet(srv.URL)
+	c.client = srv.Client()
+
+	results, err := c.Search("batman")
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// First result: movie
+	if results[0].Type != media.Movie {
+		t.Errorf("expected Movie for %q, got %v", results[0].Title, results[0].Type)
+	}
+	if results[0].Year != "2005" {
+		t.Errorf("expected year 2005, got %q", results[0].Year)
+	}
+	if results[0].ID != "movie/watch-batman-19913" {
+		t.Errorf("unexpected ID: %q", results[0].ID)
+	}
+
+	// Second result: TV
+	if results[1].Type != media.TV {
+		t.Errorf("expected TV for %q, got %v", results[1].Title, results[1].Type)
+	}
+	if results[1].Seasons != 4 {
+		t.Errorf("expected 4 seasons, got %d", results[1].Seasons)
+	}
+}

--- a/internal/provider/consumet_test.go
+++ b/internal/provider/consumet_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"lobster/internal/media"
@@ -268,4 +269,30 @@ func TestConsumetGetEmbedURL_NotSupported(t *testing.T) {
 
 func TestConsumetImplementsStreamProvider(t *testing.T) {
 	var _ StreamProvider = (*Consumet)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// Task 5: Trending / Recent not supported
+// ---------------------------------------------------------------------------
+
+func TestConsumetTrending_NotSupported(t *testing.T) {
+	c := NewConsumet("https://example.com")
+	_, err := c.Trending(media.Movie)
+	if err == nil {
+		t.Fatal("expected error from Trending")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error should mention 'not supported', got: %v", err)
+	}
+}
+
+func TestConsumetRecent_NotSupported(t *testing.T) {
+	c := NewConsumet("https://example.com")
+	_, err := c.Recent(media.TV)
+	if err == nil {
+		t.Fatal("expected error from Recent")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error should mention 'not supported', got: %v", err)
+	}
 }

--- a/internal/provider/consumet_test.go
+++ b/internal/provider/consumet_test.go
@@ -28,20 +28,43 @@ const infoJSON = `{
   ]
 }`
 
-// newTestServer creates an httptest.Server that routes based on path/query.
+// newTestServer creates an httptest.Server routing all consumet endpoints.
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 
-	// Search and info share the /movies/flixhq/ prefix.
+	// Servers endpoint (must be registered before the catch-all below)
+	mux.HandleFunc("/movies/flixhq/servers", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]string{
+			{"name": "vidcloud", "url": "https://example.com/vidcloud", "id": "vc1"},
+			{"name": "upcloud", "url": "https://example.com/upcloud", "id": "uc1"},
+		})
+	})
+
+	// Watch endpoint
+	mux.HandleFunc("/movies/flixhq/watch", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"sources": []map[string]interface{}{
+				{"url": "https://example.com/1080.m3u8", "quality": "1080p", "isM3U8": true},
+				{"url": "https://example.com/720.m3u8", "quality": "720p", "isM3U8": true},
+			},
+			"subtitles": []map[string]string{
+				{"url": "https://example.com/en.vtt", "lang": "English"},
+			},
+		})
+	})
+
+	// Search and info share the /movies/flixhq/ catch-all prefix.
 	mux.HandleFunc("/movies/flixhq/", func(w http.ResponseWriter, r *http.Request) {
-		// Distinguish info (has ?id=...) vs search.
 		if r.URL.Query().Get("id") != "" {
+			// Info endpoint
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(infoJSON))
 			return
 		}
-		// Search response.
+		// Search response
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"currentPage": 1,
@@ -81,7 +104,6 @@ func TestConsumetSearch(t *testing.T) {
 		t.Fatalf("expected 2 results, got %d", len(results))
 	}
 
-	// First result: movie
 	if results[0].Type != media.Movie {
 		t.Errorf("expected Movie for %q, got %v", results[0].Title, results[0].Type)
 	}
@@ -91,8 +113,6 @@ func TestConsumetSearch(t *testing.T) {
 	if results[0].ID != "movie/watch-batman-19913" {
 		t.Errorf("unexpected ID: %q", results[0].ID)
 	}
-
-	// Second result: TV
 	if results[1].Type != media.TV {
 		t.Errorf("expected TV for %q, got %v", results[1].Title, results[1].Type)
 	}
@@ -173,7 +193,6 @@ func TestConsumetGetEpisodes(t *testing.T) {
 		t.Errorf("unexpected episode 1: %+v", episodes[1])
 	}
 
-	// Season 2 filter
 	epS2, err := c.GetEpisodes("tv/watch-breaking-bad-39506", "2")
 	if err != nil {
 		t.Fatalf("GetEpisodes season 2 error: %v", err)
@@ -181,4 +200,72 @@ func TestConsumetGetEpisodes(t *testing.T) {
 	if len(epS2) != 1 || epS2[0].ID != "2001" {
 		t.Errorf("unexpected season 2 episodes: %+v", epS2)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Task 4: GetServers, Watch, StreamProvider interface
+// ---------------------------------------------------------------------------
+
+func TestConsumetGetServers(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
+
+	servers, err := c.GetServers("tv/watch-breaking-bad-39506", "1001")
+	if err != nil {
+		t.Fatalf("GetServers returned error: %v", err)
+	}
+
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(servers))
+	}
+	if servers[0].Name != "vidcloud" || servers[0].ID != "vc1" {
+		t.Errorf("unexpected server 0: %+v", servers[0])
+	}
+}
+
+func TestConsumetWatch_QualityMatch(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
+
+	stream, err := c.Watch("tv/watch-breaking-bad-39506", "1001", "vidcloud", "1080")
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	if stream.URL != "https://example.com/1080.m3u8" {
+		t.Errorf("expected 1080 stream URL, got %q", stream.URL)
+	}
+	if stream.Quality != "1080p" {
+		t.Errorf("expected quality '1080p', got %q", stream.Quality)
+	}
+	if len(stream.Subtitles) != 1 || stream.Subtitles[0].Language != "English" {
+		t.Errorf("unexpected subtitles: %+v", stream.Subtitles)
+	}
+}
+
+func TestConsumetWatch_FallbackToFirst(t *testing.T) {
+	srv := newTestServer(t)
+	c := newConsumetForTest(srv)
+
+	stream, err := c.Watch("tv/watch-breaking-bad-39506", "1001", "vidcloud", "4k")
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	// No 4k source → falls back to first (1080p)
+	if stream.URL != "https://example.com/1080.m3u8" {
+		t.Errorf("expected fallback to first source, got %q", stream.URL)
+	}
+}
+
+func TestConsumetGetEmbedURL_NotSupported(t *testing.T) {
+	c := NewConsumet("https://example.com")
+	_, err := c.GetEmbedURL("someID")
+	if err == nil {
+		t.Fatal("expected error from GetEmbedURL")
+	}
+}
+
+func TestConsumetImplementsStreamProvider(t *testing.T) {
+	var _ StreamProvider = (*Consumet)(nil)
 }

--- a/internal/provider/flixhqws.go
+++ b/internal/provider/flixhqws.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -37,7 +38,8 @@ func (f *FlixHQWS) baseURL() string {
 
 // Search returns matching results for a query, fetching multiple pages.
 func (f *FlixHQWS) Search(query string) ([]media.SearchResult, error) {
-	encoded := httputil.EncodeQuery(query)
+	// flixhq.ws uses space-encoded queries (%20), not dash-separated like flixhq.to
+	encoded := url.PathEscape(query)
 	baseSearchURL := fmt.Sprintf("%s/search/%s/", f.baseURL(), encoded)
 
 	doc, err := f.fetchDocument(baseSearchURL)

--- a/internal/provider/flixhqws.go
+++ b/internal/provider/flixhqws.go
@@ -1,0 +1,346 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+// plURLPattern matches the inline script variable that holds the AJAX URL for server listings.
+// Movies use "vdkz" and TV episodes use "vds" as the query parameter.
+var plURLPattern = regexp.MustCompile(`const\s+pl_url\s*=\s*'([^']+)'`)
+
+// FlixHQWS implements the Provider interface for the flixhq.ws content source.
+type FlixHQWS struct {
+	base   string // e.g., "flixhq.ws"
+	client *http.Client
+}
+
+// NewFlixHQWS creates a new FlixHQWS provider.
+func NewFlixHQWS(base string) *FlixHQWS {
+	return &FlixHQWS{
+		base:   base,
+		client: httputil.NewClient(),
+	}
+}
+
+func (f *FlixHQWS) baseURL() string {
+	return "https://" + f.base
+}
+
+// Search returns matching results for a query, fetching multiple pages.
+func (f *FlixHQWS) Search(query string) ([]media.SearchResult, error) {
+	encoded := httputil.EncodeQuery(query)
+	baseSearchURL := fmt.Sprintf("%s/search/%s/", f.baseURL(), encoded)
+
+	doc, err := f.fetchDocument(baseSearchURL)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q: %w", query, err)
+	}
+
+	results := parseSearchResults(doc)
+	lastPage := parseLastPage(doc)
+
+	pages := lastPage
+	if pages > maxSearchPages {
+		pages = maxSearchPages
+	}
+	for page := 2; page <= pages; page++ {
+		pageURL := fmt.Sprintf("%s?page=%d", baseSearchURL, page)
+		pageDoc, err := f.fetchDocument(pageURL)
+		if err != nil {
+			break
+		}
+		results = append(results, parseSearchResults(pageDoc)...)
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found for %q", query)
+	}
+
+	sortByRelevance(results, query)
+
+	for i := range results {
+		if !strings.HasPrefix(results[i].URL, "http") {
+			results[i].URL = f.baseURL() + results[i].URL
+		}
+	}
+
+	return results, nil
+}
+
+// GetDetails returns detailed metadata for a content item.
+func (f *FlixHQWS) GetDetails(id string) (*media.ContentDetail, error) {
+	if err := httputil.ValidateID(id); err != nil {
+		return nil, fmt.Errorf("invalid content ID: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/%s/", f.baseURL(), id)
+	doc, err := f.fetchDocument(url)
+	if err != nil {
+		return nil, fmt.Errorf("getting details: %w", err)
+	}
+
+	return parseDetailPage(doc), nil
+}
+
+// GetSeasons returns available seasons for a TV show.
+// On flixhq.ws, seasons are embedded in the detail page as .ss-item elements
+// inside a .dropdown-menu, each with data-ss (season number) and data-id (hash).
+func (f *FlixHQWS) GetSeasons(id string) ([]media.Season, error) {
+	if err := httputil.ValidateID(id); err != nil {
+		return nil, fmt.Errorf("invalid content ID: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/%s/", f.baseURL(), id)
+	doc, err := f.fetchDocument(url)
+	if err != nil {
+		return nil, fmt.Errorf("getting seasons: %w", err)
+	}
+
+	return parseWSSeason(doc), nil
+}
+
+// parseWSSeason extracts seasons from flixhq.ws detail page HTML.
+func parseWSSeason(doc *goquery.Document) []media.Season {
+	var seasons []media.Season
+
+	doc.Find(".dropdown-menu .ss-item").Each(func(_ int, s *goquery.Selection) {
+		dataSS, _ := s.Attr("data-ss")
+		dataID, _ := s.Attr("data-id")
+
+		num, _ := strconv.Atoi(dataSS)
+
+		if dataID != "" {
+			seasons = append(seasons, media.Season{
+				Number: num,
+				ID:     dataID,
+			})
+		}
+	})
+
+	return seasons
+}
+
+// GetEpisodes returns episodes for a given season.
+// seasonID is the data-id hash from GetSeasons. We fetch the AJAX endpoint
+// to get episode HTML fragments.
+func (f *FlixHQWS) GetEpisodes(id string, seasonID string) ([]media.Episode, error) {
+	if seasonID == "" {
+		return nil, fmt.Errorf("season ID cannot be empty")
+	}
+
+	url := fmt.Sprintf("%s/ajax/ajax.php?episode=%s", f.baseURL(), seasonID)
+	doc, err := f.fetchDocument(url)
+	if err != nil {
+		return nil, fmt.Errorf("getting episodes: %w", err)
+	}
+
+	return parseWSEpisodes(doc), nil
+}
+
+// parseWSEpisodes extracts episodes from flixhq.ws AJAX episode response.
+func parseWSEpisodes(doc *goquery.Document) []media.Episode {
+	var episodes []media.Episode
+
+	doc.Find("li.nav-item a.eps-item").Each(func(_ int, s *goquery.Selection) {
+		dataID, exists := s.Attr("data-id")
+		if !exists {
+			return
+		}
+
+		title := strings.TrimSpace(s.AttrOr("title", ""))
+		if title == "" {
+			title = strings.TrimSpace(s.Text())
+		}
+
+		// Extract the href for use as the episode identifier in GetServers.
+		// The href has the form /series/{slug}-{id}/{season}-{episode}/
+		href, _ := s.Attr("href")
+
+		num := 0
+		text := strings.TrimSpace(s.Text())
+		if parts := strings.Fields(text); len(parts) >= 2 {
+			candidate := strings.TrimRight(parts[1], ":")
+			if n, err := strconv.Atoi(candidate); err == nil {
+				num = n
+			} else if n, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
+				num = n
+			}
+		}
+
+		// Use href as the episode ID if available so GetServers can fetch
+		// the episode page to extract the pl_url. Fall back to data-id.
+		epID := href
+		if epID == "" {
+			epID = dataID
+		}
+
+		episodes = append(episodes, media.Episode{
+			Number: num,
+			Title:  title,
+			ID:     epID,
+		})
+	})
+
+	return episodes
+}
+
+// GetServers returns available streaming servers for content.
+// For movies (episodeID is empty), fetches the movie page and extracts pl_url.
+// For TV (episodeID is the episode page path), fetches the episode page.
+func (f *FlixHQWS) GetServers(id string, episodeID string) ([]media.Server, error) {
+	var pageURL string
+
+	if episodeID != "" {
+		// TV episode: episodeID is the episode page path (e.g., /series/batman-19660/1-3/)
+		if strings.HasPrefix(episodeID, "/") {
+			pageURL = f.baseURL() + episodeID
+		} else {
+			pageURL = fmt.Sprintf("%s/%s", f.baseURL(), episodeID)
+		}
+	} else {
+		// Movie
+		if err := httputil.ValidateID(id); err != nil {
+			return nil, fmt.Errorf("invalid content ID: %w", err)
+		}
+		pageURL = fmt.Sprintf("%s/%s/", f.baseURL(), id)
+	}
+
+	// Ensure trailing slash
+	if !strings.HasSuffix(pageURL, "/") {
+		pageURL += "/"
+	}
+
+	doc, err := f.fetchDocument(pageURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching content page: %w", err)
+	}
+
+	// Extract pl_url from inline <script> tags.
+	plURL := ""
+	doc.Find("script").Each(func(_ int, s *goquery.Selection) {
+		text := s.Text()
+		if matches := plURLPattern.FindStringSubmatch(text); len(matches) > 1 {
+			plURL = matches[1]
+		}
+	})
+
+	if plURL == "" {
+		return nil, fmt.Errorf("no server listing URL found on page")
+	}
+
+	serverDoc, err := f.fetchDocument(plURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching server list: %w", err)
+	}
+
+	return parseWSServers(serverDoc), nil
+}
+
+// parseWSServers extracts servers from flixhq.ws AJAX server response.
+func parseWSServers(doc *goquery.Document) []media.Server {
+	var servers []media.Server
+
+	doc.Find(".sv-item").Each(func(_ int, s *goquery.Selection) {
+		dataID, exists := s.Attr("data-id")
+		if !exists {
+			return
+		}
+
+		name := strings.TrimSpace(s.AttrOr("data-srv", ""))
+		if name == "" {
+			name = strings.TrimSpace(s.Text())
+		}
+		if name == "" {
+			name = "Unknown"
+		}
+
+		servers = append(servers, media.Server{
+			Name: name,
+			ID:   dataID,
+		})
+	})
+
+	return servers
+}
+
+// GetEmbedURL returns the embed URL for a given server.
+// On flixhq.ws, the server ID from GetServers is already the embed URL.
+func (f *FlixHQWS) GetEmbedURL(serverID string) (string, error) {
+	if serverID == "" {
+		return "", fmt.Errorf("server ID cannot be empty")
+	}
+	return serverID, nil
+}
+
+// Trending returns trending content from the /home page.
+func (f *FlixHQWS) Trending(mediaType media.MediaType) ([]media.SearchResult, error) {
+	url := fmt.Sprintf("%s/home/", f.baseURL())
+
+	doc, err := f.fetchDocument(url)
+	if err != nil {
+		return nil, fmt.Errorf("getting trending: %w", err)
+	}
+
+	results := parseTrendingResults(doc, mediaType)
+	for i := range results {
+		if !strings.HasPrefix(results[i].URL, "http") {
+			results[i].URL = f.baseURL() + results[i].URL
+		}
+	}
+	return results, nil
+}
+
+// Recent returns recently added content from /movie or /series pages.
+func (f *FlixHQWS) Recent(mediaType media.MediaType) ([]media.SearchResult, error) {
+	var url string
+	switch mediaType {
+	case media.Movie:
+		url = fmt.Sprintf("%s/movie/", f.baseURL())
+	case media.TV:
+		url = fmt.Sprintf("%s/series/", f.baseURL())
+	default:
+		url = fmt.Sprintf("%s/movie/", f.baseURL())
+	}
+
+	doc, err := f.fetchDocument(url)
+	if err != nil {
+		return nil, fmt.Errorf("getting recent: %w", err)
+	}
+
+	results := parseSearchResults(doc)
+	for i := range results {
+		if !strings.HasPrefix(results[i].URL, "http") {
+			results[i].URL = f.baseURL() + results[i].URL
+		}
+	}
+	return results, nil
+}
+
+// fetchDocument fetches a URL and parses it into a goquery Document.
+func (f *FlixHQWS) fetchDocument(url string) (*goquery.Document, error) {
+	resp, err := httputil.Get(f.client, url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	return doc, nil
+}

--- a/internal/provider/flixhqws_test.go
+++ b/internal/provider/flixhqws_test.go
@@ -1,0 +1,254 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"lobster/internal/media"
+)
+
+func TestParseSearchResultsWithSeries(t *testing.T) {
+	// Verify that parseSearchResults detects /series/ URLs as TV type
+	doc := loadTestDoc(t, "ws_search_series.html")
+	results := parseSearchResults(doc)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	if results[0].Type != media.Movie {
+		t.Errorf("result[0].Type = %v, want Movie", results[0].Type)
+	}
+	if results[0].ID != "movie/free-the-exorcist-hd-75043" {
+		t.Errorf("result[0].ID = %q, want 'movie/free-the-exorcist-hd-75043'", results[0].ID)
+	}
+
+	if results[1].Title != "Breaking Bad" {
+		t.Errorf("result[1].Title = %q, want 'Breaking Bad'", results[1].Title)
+	}
+	if results[1].Type != media.TV {
+		t.Errorf("result[1].Type = %v, want TV (via /series/ URL)", results[1].Type)
+	}
+	if results[1].ID != "series/watch-breaking-bad-39516" {
+		t.Errorf("result[1].ID = %q, want 'series/watch-breaking-bad-39516'", results[1].ID)
+	}
+	if results[1].Seasons != 5 {
+		t.Errorf("result[1].Seasons = %d, want 5", results[1].Seasons)
+	}
+	if results[1].Episodes != 62 {
+		t.Errorf("result[1].Episodes = %d, want 62", results[1].Episodes)
+	}
+}
+
+func TestParseWSSeasons(t *testing.T) {
+	doc := loadTestDoc(t, "ws_seasons.html")
+	seasons := parseWSSeason(doc)
+
+	if len(seasons) != 3 {
+		t.Fatalf("expected 3 seasons, got %d", len(seasons))
+	}
+
+	tests := []struct {
+		idx    int
+		number int
+		id     string
+	}{
+		{0, 1, "abc123hash"},
+		{1, 2, "def456hash"},
+		{2, 3, "ghi789hash"},
+	}
+
+	for _, tt := range tests {
+		if seasons[tt.idx].Number != tt.number {
+			t.Errorf("seasons[%d].Number = %d, want %d", tt.idx, seasons[tt.idx].Number, tt.number)
+		}
+		if seasons[tt.idx].ID != tt.id {
+			t.Errorf("seasons[%d].ID = %q, want %q", tt.idx, seasons[tt.idx].ID, tt.id)
+		}
+	}
+}
+
+func TestParseWSEpisodes(t *testing.T) {
+	doc := loadTestDoc(t, "ws_episodes.html")
+	episodes := parseWSEpisodes(doc)
+
+	if len(episodes) != 3 {
+		t.Fatalf("expected 3 episodes, got %d", len(episodes))
+	}
+
+	if episodes[0].Number != 1 {
+		t.Errorf("episodes[0].Number = %d, want 1", episodes[0].Number)
+	}
+	if episodes[0].Title != "Pilot" {
+		t.Errorf("episodes[0].Title = %q, want 'Pilot'", episodes[0].Title)
+	}
+	if episodes[0].ID != "/series/batman-19660/1-1/" {
+		t.Errorf("episodes[0].ID = %q, want '/series/batman-19660/1-1/'", episodes[0].ID)
+	}
+
+	if episodes[2].Number != 3 {
+		t.Errorf("episodes[2].Number = %d, want 3", episodes[2].Number)
+	}
+	if episodes[2].Title != "Fine Feathered Finks" {
+		t.Errorf("episodes[2].Title = %q, want 'Fine Feathered Finks'", episodes[2].Title)
+	}
+}
+
+func TestParseWSServers(t *testing.T) {
+	doc := loadTestDoc(t, "ws_servers.html")
+	servers := parseWSServers(doc)
+
+	if len(servers) != 3 {
+		t.Fatalf("expected 3 servers, got %d", len(servers))
+	}
+
+	if servers[0].Name != "Vidcdn" {
+		t.Errorf("servers[0].Name = %q, want 'Vidcdn'", servers[0].Name)
+	}
+	if servers[0].ID != "https://vidcdn.co/iframe/abc123" {
+		t.Errorf("servers[0].ID = %q, want 'https://vidcdn.co/iframe/abc123'", servers[0].ID)
+	}
+
+	if servers[1].Name != "UpCloud" {
+		t.Errorf("servers[1].Name = %q, want 'UpCloud'", servers[1].Name)
+	}
+	if servers[1].ID != "https://upcloud.to/embed/def456" {
+		t.Errorf("servers[1].ID = %q, want 'https://upcloud.to/embed/def456'", servers[1].ID)
+	}
+}
+
+func TestFlixHQWSGetEmbedURL(t *testing.T) {
+	p := NewFlixHQWS("flixhq.ws")
+
+	// GetEmbedURL should return the serverID as-is
+	url, err := p.GetEmbedURL("https://vidcdn.co/iframe/abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != "https://vidcdn.co/iframe/abc123" {
+		t.Errorf("GetEmbedURL = %q, want 'https://vidcdn.co/iframe/abc123'", url)
+	}
+
+	// Empty serverID should error
+	_, err = p.GetEmbedURL("")
+	if err == nil {
+		t.Error("expected error for empty serverID")
+	}
+}
+
+func TestFlixHQWSPlURLExtractionMovie(t *testing.T) {
+	doc := loadTestDoc(t, "ws_movie_page.html")
+	plURL := ""
+	doc.Find("script").Each(func(_ int, s *goquery.Selection) {
+		text := s.Text()
+		if matches := plURLPattern.FindStringSubmatch(text); len(matches) > 1 {
+			plURL = matches[1]
+		}
+	})
+
+	if plURL != "https://flixhq.ws/ajax/ajax.php?vdkz=moviehash123" {
+		t.Errorf("pl_url = %q, want 'https://flixhq.ws/ajax/ajax.php?vdkz=moviehash123'", plURL)
+	}
+}
+
+func TestFlixHQWSPlURLExtractionTV(t *testing.T) {
+	doc := loadTestDoc(t, "ws_episode_page.html")
+	plURL := ""
+	doc.Find("script").Each(func(_ int, s *goquery.Selection) {
+		text := s.Text()
+		if matches := plURLPattern.FindStringSubmatch(text); len(matches) > 1 {
+			plURL = matches[1]
+		}
+	})
+
+	if plURL != "https://flixhq.ws/ajax/ajax.php?vds=episodehash456" {
+		t.Errorf("pl_url = %q, want 'https://flixhq.ws/ajax/ajax.php?vds=episodehash456'", plURL)
+	}
+}
+
+func TestFlixHQWSGetServersIntegration(t *testing.T) {
+	// Integration test using httptest server.
+	// The movie page pl_url must point back to our test server.
+	mux := http.NewServeMux()
+
+	var tsURL string
+
+	mux.HandleFunc("/movie/free-the-exorcist-hd-75043/", func(w http.ResponseWriter, r *http.Request) {
+		// Serve a movie page whose pl_url points back to our test server
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body><script>
+const pl_url = '` + tsURL + `/ajax/ajax.php?vdkz=moviehash123';
+</script></body></html>`))
+	})
+
+	mux.HandleFunc("/ajax/ajax.php", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "testdata/ws_servers.html")
+	})
+
+	ts := httptest.NewTLSServer(mux)
+	defer ts.Close()
+	tsURL = ts.URL
+
+	base := strings.TrimPrefix(ts.URL, "https://")
+	p := &FlixHQWS{
+		base:   base,
+		client: ts.Client(),
+	}
+
+	servers, err := p.GetServers("movie/free-the-exorcist-hd-75043", "")
+	if err != nil {
+		t.Fatalf("GetServers error: %v", err)
+	}
+
+	if len(servers) != 3 {
+		t.Fatalf("expected 3 servers, got %d", len(servers))
+	}
+	if servers[0].Name != "Vidcdn" {
+		t.Errorf("servers[0].Name = %q, want 'Vidcdn'", servers[0].Name)
+	}
+}
+
+func TestFlixHQWSGetServersTVIntegration(t *testing.T) {
+	mux := http.NewServeMux()
+	var tsURL string
+
+	mux.HandleFunc("/series/batman-19660/1-3/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body><script>
+const pl_url = '` + tsURL + `/ajax/ajax.php?vds=episodehash456';
+</script></body></html>`))
+	})
+
+	mux.HandleFunc("/ajax/ajax.php", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "testdata/ws_servers.html")
+	})
+
+	ts := httptest.NewTLSServer(mux)
+	defer ts.Close()
+	tsURL = ts.URL
+
+	base := strings.TrimPrefix(ts.URL, "https://")
+	p := &FlixHQWS{
+		base:   base,
+		client: ts.Client(),
+	}
+
+	servers, err := p.GetServers("series/batman-19660", "/series/batman-19660/1-3/")
+	if err != nil {
+		t.Fatalf("GetServers error: %v", err)
+	}
+
+	if len(servers) != 3 {
+		t.Fatalf("expected 3 servers, got %d", len(servers))
+	}
+}
+
+// Ensure FlixHQWS implements the Provider interface at compile time.
+var _ Provider = (*FlixHQWS)(nil)
+
+// Suppress unused import warning for goquery used in test helpers
+var _ = (*goquery.Selection)(nil)

--- a/internal/provider/parser.go
+++ b/internal/provider/parser.go
@@ -28,7 +28,7 @@ func parseSearchResults(doc *goquery.Document) []media.SearchResult {
 		}
 
 		// Determine type from URL path or class
-		if strings.Contains(href, "/tv/") {
+		if strings.Contains(href, "/tv/") || strings.Contains(href, "/series/") {
 			result.Type = media.TV
 		} else {
 			result.Type = media.Movie
@@ -288,7 +288,7 @@ func parseTrendingResults(doc *goquery.Document, mediaType media.MediaType) []me
 			result.ID = extractID(href)
 		}
 
-		if strings.Contains(href, "/tv/") {
+		if strings.Contains(href, "/tv/") || strings.Contains(href, "/series/") {
 			result.Type = media.TV
 		} else {
 			result.Type = media.Movie

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,3 +33,11 @@ type Provider interface {
 	// Recent returns recently added content.
 	Recent(mediaType media.MediaType) ([]media.SearchResult, error)
 }
+
+// StreamProvider extends Provider with a direct stream-resolution method.
+// Providers that talk to a streaming API (like Consumet) implement this
+// instead of relying on GetEmbedURL.
+type StreamProvider interface {
+	Provider
+	Watch(mediaID, episodeID, server, quality string) (*media.Stream, error)
+}

--- a/internal/provider/testdata/ws_episode_page.html
+++ b/internal/provider/testdata/ws_episode_page.html
@@ -1,0 +1,8 @@
+<html>
+<head><title>Batman - S1E3</title></head>
+<body>
+<script>
+  const pl_url = 'https://flixhq.ws/ajax/ajax.php?vds=episodehash456';
+</script>
+</body>
+</html>

--- a/internal/provider/testdata/ws_episodes.html
+++ b/internal/provider/testdata/ws_episodes.html
@@ -1,0 +1,11 @@
+<ul>
+  <li class="nav-item">
+    <a class="eps-item" data-id="1001" href="/series/batman-19660/1-1/" title="Pilot">Eps 1: Pilot</a>
+  </li>
+  <li class="nav-item">
+    <a class="eps-item" data-id="1002" href="/series/batman-19660/1-2/" title="The Cat and the Fiddle">Eps 2: The Cat and the Fiddle</a>
+  </li>
+  <li class="nav-item">
+    <a class="eps-item" data-id="1003" href="/series/batman-19660/1-3/" title="Fine Feathered Finks">Eps 3: Fine Feathered Finks</a>
+  </li>
+</ul>

--- a/internal/provider/testdata/ws_movie_page.html
+++ b/internal/provider/testdata/ws_movie_page.html
@@ -1,0 +1,17 @@
+<html>
+<head><title>The Exorcist</title></head>
+<body>
+<div class="description">A visiting actress in Washington, D.C. notices dramatic changes in the behavior of her daughter.</div>
+<div class="elements">
+  <div class="row-line"><span class="type">Genre:</span> <a>Horror</a>, <a>Thriller</a></div>
+  <div class="row-line"><span class="type">Released:</span> 1973-12-26</div>
+  <div class="row-line"><span class="type">Country:</span> <a>United States</a></div>
+  <div class="row-line"><span class="type">Casts:</span> <a>Ellen Burstyn</a>, <a>Max von Sydow</a></div>
+</div>
+<script>
+  var something = 'unrelated';
+  const pl_url = 'https://flixhq.ws/ajax/ajax.php?vdkz=moviehash123';
+  var another = 'value';
+</script>
+</body>
+</html>

--- a/internal/provider/testdata/ws_search_series.html
+++ b/internal/provider/testdata/ws_search_series.html
@@ -1,0 +1,24 @@
+<div class="film_list-wrap">
+  <div class="flw-item">
+    <div class="film-name">
+      <a href="/movie/free-the-exorcist-hd-75043" title="The Exorcist">The Exorcist</a>
+    </div>
+    <div class="fd-infor">
+      <span class="fdi-item">1973</span>
+      <span class="dot"></span>
+      <span class="fdi-item fdi-duration">122m</span>
+      <span class="float-right fdi-type">Movie</span>
+    </div>
+  </div>
+  <div class="flw-item">
+    <div class="film-name">
+      <a href="/series/watch-breaking-bad-39516" title="Breaking Bad">Breaking Bad</a>
+    </div>
+    <div class="fd-infor">
+      <span class="fdi-item">SS 5</span>
+      <span class="dot"></span>
+      <span class="fdi-item">EPS 62</span>
+      <span class="float-right fdi-type">TV</span>
+    </div>
+  </div>
+</div>

--- a/internal/provider/testdata/ws_seasons.html
+++ b/internal/provider/testdata/ws_seasons.html
@@ -1,0 +1,5 @@
+<div class="dropdown-menu">
+  <a class="ss-item" data-ss="1" data-id="abc123hash">Season 1</a>
+  <a class="ss-item" data-ss="2" data-id="def456hash">Season 2</a>
+  <a class="ss-item" data-ss="3" data-id="ghi789hash">Season 3</a>
+</div>

--- a/internal/provider/testdata/ws_servers.html
+++ b/internal/provider/testdata/ws_servers.html
@@ -1,0 +1,5 @@
+<div class="server-list">
+  <div class="sv-item" data-srv="Vidcdn" data-id="https://vidcdn.co/iframe/abc123">Vidcdn</div>
+  <div class="sv-item" data-srv="UpCloud" data-id="https://upcloud.to/embed/def456">UpCloud</div>
+  <div class="sv-item" data-srv="VidStreaming" data-id="https://vidstreaming.io/embed/ghi789">VidStreaming</div>
+</div>


### PR DESCRIPTION
## Summary
- **Switches default from flixhq.to (down) to flixhq.ws** — lobster works again out of the box
- Adds `FlixHQWS` scraper provider targeting flixhq.ws with its different AJAX API structure
- Adds `Consumet` API provider as optional backend (set `api_url` in config)
- Adds `StreamProvider` interface for providers that resolve streams directly
- Wires up provider selection: `base = "flixhq.ws"` uses new scraper, `api_url` uses consumet API

## How to use
**Default (no config change needed):** Works with flixhq.ws automatically.

**To use consumet API:** Add to `~/.config/lobster/config.toml`:
```toml
api_url = "https://your-consumet-instance.example.com"
```

**To switch back to flixhq.to** (when it recovers):
```toml
base = "flixhq.to"
```

## Test plan
- [x] All unit tests pass (30+ provider tests)
- [x] Cross-compiles for linux/darwin/windows
- [x] Live search against flixhq.ws returns results ("south park", "batman")
- [ ] Full flow test: search → select → play on Windows
- [ ] Verify TV show season/episode selection works