### PR TITLE
feat: multi-provider fallback with KimCartoon + Soap2Day

### DIFF
--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// fallbackProviders returns a list of fallback providers to try when
+// the primary provider's servers all fail. The primary provider is excluded.
+func fallbackProviders(primary provider.Provider) []provider.StreamProvider {
+	var fallbacks []provider.StreamProvider
+
+	// Soap2Day is the main fallback for movies/TV
+	if _, ok := primary.(*provider.Soap2Day); !ok {
+		fallbacks = append(fallbacks, provider.NewSoap2Day())
+	}
+
+	return fallbacks
+}
+
+// tryFallbackStream attempts to resolve a stream using fallback providers.
+// It searches for the title on each fallback provider, finds the matching
+// season/episode, and tries to get a stream via Watch().
+func tryFallbackStream(primary provider.Provider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
+	fallbacks := fallbackProviders(primary)
+	if len(fallbacks) == 0 {
+		return nil, fmt.Errorf("no fallback providers available")
+	}
+
+	for _, fb := range fallbacks {
+		debugf("trying fallback provider: %T", fb)
+		stream, err := tryFallbackProvider(fb, title, mediaType, season, episode)
+		if err != nil {
+			debugf("fallback %T failed: %v", fb, err)
+			continue
+		}
+		return stream, nil
+	}
+
+	return nil, fmt.Errorf("all fallback providers failed")
+}
+
+// tryFallbackProvider tries a single fallback StreamProvider.
+func tryFallbackProvider(fb provider.StreamProvider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
+	// Search for the title
+	results, err := fb.Search(title)
+	if err != nil {
+		return nil, fmt.Errorf("search failed: %w", err)
+	}
+
+	// Find best match: same type
+	var match *media.SearchResult
+	for i, r := range results {
+		if r.Type == mediaType {
+			match = &results[i]
+			break
+		}
+	}
+	if match == nil && len(results) > 0 {
+		match = &results[0]
+	}
+	if match == nil {
+		return nil, fmt.Errorf("no matching result for %q", title)
+	}
+
+	debugf("fallback matched: %s (ID: %s)", match.Title, match.ID)
+
+	if mediaType == media.Movie || (season == 0 && episode == 0) {
+		// Movie
+		quality := "1080"
+		if cfg != nil && cfg.Quality != "" {
+			quality = cfg.Quality
+		}
+		return fb.Watch(match.ID, "", "Default", quality)
+	}
+
+	// TV: need to construct the episode ID that Watch() expects
+	// For Soap2Day, Watch expects episodeID in format "tmdbID:season:episode"
+	// The match.ID is "tv/{tmdbID}", so extract tmdbID
+	tmdbID := match.ID
+	if idx := len("tv/"); len(tmdbID) > idx && tmdbID[:idx] == "tv/" {
+		tmdbID = tmdbID[idx:]
+	} else if idx := len("movie/"); len(tmdbID) > idx && tmdbID[:idx] == "movie/" {
+		tmdbID = tmdbID[idx:]
+	}
+
+	episodeID := fmt.Sprintf("%s:%d:%d", tmdbID, season, episode)
+	debugf("fallback episode ID: %s", episodeID)
+
+	quality := "1080"
+	if cfg != nil && cfg.Quality != "" {
+		quality = cfg.Quality
+	}
+	return fb.Watch(match.ID, episodeID, "Default", quality)
+}

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -15,6 +15,12 @@ func newProvider() provider.Provider {
 	if cfg.APIURL != "" {
 		return provider.NewConsumet(cfg.APIURL)
 	}
+	if strings.Contains(cfg.Base, "soap2day") {
+		return provider.NewSoap2Day()
+	}
+	if strings.Contains(cfg.Base, "kimcartoon") {
+		return provider.NewKimCartoon(cfg.Base)
+	}
 	if strings.Contains(cfg.Base, "flixhq.ws") {
 		return provider.NewFlixHQWS(cfg.Base)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagPlayer, "player", "", "Media player: mpv | vlc | iina | celluloid")
 	rootCmd.PersistentFlags().BoolVarP(&flagContinue, "continue", "c", false, "Auto-resume from history")
 	rootCmd.PersistentFlags().BoolVarP(&flagJSON, "json", "j", false, "Output stream metadata as JSON")
-	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws")
+	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
 
 	rootCmd.AddCommand(historyCmd)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -268,9 +268,17 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 			break
 		}
 		if stream == nil {
-			return fmt.Errorf("all servers failed for %s", title)
+			stopWatch()
+			// Try fallback providers
+			fmt.Fprintf(os.Stderr, "Primary provider failed, trying fallback...\n")
+			fbStream, err := tryFallbackStream(p, selected.Title, selected.Type, season, episode)
+			if err != nil {
+				return fmt.Errorf("all servers failed for %s", title)
+			}
+			stream = fbStream
+		} else {
+			stopWatch()
 		}
-		stopWatch()
 		return playStream(stream, title, selected, season, episode)
 	}
 
@@ -313,11 +321,20 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 		break
 	}
 	if stream == nil {
-		return fmt.Errorf("all servers failed for %s", title)
+		stopExt()
+		// Try fallback providers
+		fmt.Fprintf(os.Stderr, "Primary provider failed, trying fallback...\n")
+		debugf("attempting fallback for %s", title)
+		fbStream, err := tryFallbackStream(p, selected.Title, selected.Type, season, episode)
+		if err != nil {
+			debugf("fallback failed: %v", err)
+			return fmt.Errorf("all servers failed for %s", title)
+		}
+		stream = fbStream
+		debugf("fallback stream: %s", stream.URL)
+	} else {
+		stopExt()
 	}
-
-	// Stop extraction spinner before printing/playing
-	stopExt()
 
 	return playStream(stream, title, selected, season, episode)
 }

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -202,7 +202,22 @@ func resolveStream(sess *playlist.Session, excludeNames map[string]bool) (*media
 		return stream, srv.Name, nil
 	}
 
-	return nil, "", fmt.Errorf("all servers failed for %s", sess.Title())
+	// Try fallback providers before giving up
+	fmt.Fprintf(os.Stderr, "Primary provider failed, trying fallback...\n")
+	debugf("attempting fallback for %s", sess.Title())
+	stream, err := tryFallbackStream(
+		sess.Provider,
+		sess.Content.Title,
+		sess.Content.Type,
+		sess.CurrentSeason().Number,
+		sess.Current().Number,
+	)
+	if err != nil {
+		debugf("fallback failed: %v", err)
+		return nil, "", fmt.Errorf("all servers failed for %s", sess.Title())
+	}
+	debugf("fallback stream: %s", stream.URL)
+	return stream, "Fallback", nil
 }
 
 // tryServer attempts to extract a stream from a single server.
@@ -294,6 +309,11 @@ func playCurrentEpisode(sess *playlist.Session) error {
 		if lastPos > 0 {
 			startPos = lastPos
 			debugf("playback stopped at %.0fs, will resume from there", lastPos)
+		}
+
+		// If the fallback stream also failed, don't retry endlessly
+		if serverName == "Fallback" {
+			return fmt.Errorf("playback failed: %w", playErr)
 		}
 
 		// Exclude this server and try the next one

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -35,6 +35,8 @@ func ResolveForURL(embedURL string) (Extractor, string) {
 		return NewByse(), target
 	case strings.Contains(target, "strcdn.org") || strings.Contains(target, "netu"):
 		return NewNetu(), target
+	case strings.Contains(target, "vidwish.live"):
+		return NewVidWish(), target
 	default:
 		return NewMegaCloud(), target
 	}

--- a/internal/extract/netu.go
+++ b/internal/extract/netu.go
@@ -41,9 +41,10 @@ func (n *NetuExtractor) Extract(embedURL string, preferredQuality string) (*medi
 		pageURL = resolved
 	}
 
-	// Step 2: If the page redirects to /e/ path, follow that too
-	if strings.Contains(pageURL, "strcdn.org") && !strings.Contains(pageURL, "/e/") {
-		// Direct URL, use as-is
+	// Step 2: The /f/ path is a full page that JS-redirects to /e/ in iframes.
+	// Convert /f/ to /e/ directly to get the embed page with m3u8 URLs.
+	if strings.Contains(pageURL, "/f/") {
+		pageURL = strings.Replace(pageURL, "/f/", "/e/", 1)
 	}
 
 	// Fetch the embed page (follow redirects)

--- a/internal/extract/vidwish.go
+++ b/internal/extract/vidwish.go
@@ -1,0 +1,62 @@
+package extract
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+// VidWishExtractor extracts streams from player.vidwish.live pages.
+// These pages contain JWPlayer setup with m3u8 URLs in the sources array.
+type VidWishExtractor struct {
+	client *http.Client
+}
+
+// NewVidWish creates a new VidWishExtractor.
+func NewVidWish() *VidWishExtractor {
+	return &VidWishExtractor{
+		client: httputil.NewClient(),
+	}
+}
+
+var vidwishSourceRe = regexp.MustCompile(`"file"\s*:\s*"(https?://[^"]+\.m3u8[^"]*)"`)
+
+// Extract resolves a vidwish.live player URL into a stream.
+func (v *VidWishExtractor) Extract(embedURL string, preferredQuality string) (*media.Stream, error) {
+	req, err := http.NewRequest(http.MethodGet, embedURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
+	req.Header.Set("Referer", "https://vid.kimcartoon.com.co/")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching player page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("player page returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading page: %w", err)
+	}
+	html := string(body)
+
+	match := vidwishSourceRe.FindStringSubmatch(html)
+	if len(match) < 2 {
+		return nil, fmt.Errorf("no m3u8 URL found in player page")
+	}
+
+	return &media.Stream{
+		URL:     match[1],
+		Quality: preferredQuality,
+	}, nil
+}

--- a/internal/media/types.go
+++ b/internal/media/types.go
@@ -67,6 +67,7 @@ type Stream struct {
 	URL       string     // m3u8 or direct video URL
 	Subtitles []Subtitle // Available subtitle tracks
 	Quality   string     // Resolved quality
+	Referer   string     // Referer header required by the CDN (if any)
 }
 
 // Subtitle represents a subtitle track.

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -40,6 +40,14 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 		"--force-media-title=" + title,
 		"--input-ipc-server=" + ipc.path,
 		"--really-quiet",
+		"--network-timeout=15",
+	}
+
+	if stream.Referer != "" {
+		args = append(args, "--http-header-fields=Referer: "+stream.Referer)
+		// Propagate referer to ffmpeg's HLS demuxer for segment requests
+		args = append(args, "--demuxer-lavf-o=headers=Referer: "+stream.Referer+"\r\n")
+		args = append(args, "--tls-verify=no")
 	}
 
 	if startPos > 0 {
@@ -69,15 +77,26 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 
 	// Wait briefly for IPC socket to become available
 	var lastPos float64
+	startTime := time.Now()
 	go func() {
 		lastPos = m.trackPosition(ipc)
 	}()
 
-	if err := cmd.Wait(); err != nil {
-		// mpv returns non-zero on user quit, which is normal
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 4 {
+	waitErr := cmd.Wait()
+	elapsed := time.Since(startTime)
+
+	if waitErr != nil {
+		// mpv returns non-zero on user quit (code 4), which is normal
+		if exitErr, ok := waitErr.(*exec.ExitError); ok && exitErr.ExitCode() == 4 {
 			return lastPos, nil
 		}
+		return lastPos, fmt.Errorf("mpv exited: %w", waitErr)
+	}
+
+	// If mpv exited almost instantly with no playback progress,
+	// the stream likely failed to load (e.g., CDN unreachable).
+	if lastPos == 0 && elapsed < 5*time.Second {
+		return 0, fmt.Errorf("stream failed to load (mpv exited in %s with no playback)", elapsed.Round(time.Millisecond))
 	}
 
 	return lastPos, nil

--- a/internal/player/vlc.go
+++ b/internal/player/vlc.go
@@ -32,6 +32,10 @@ func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFile
 		"--play-and-exit",
 	}
 
+	if stream.Referer != "" {
+		args = append(args, "--http-referrer", stream.Referer)
+	}
+
 	if startPos > 0 {
 		args = append(args, fmt.Sprintf("--start-time=%.0f", startPos))
 	}

--- a/internal/provider/kimcartoon.go
+++ b/internal/provider/kimcartoon.go
@@ -1,0 +1,329 @@
+package provider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+// KimCartoon implements the Provider interface for kimcartoon.com.co.
+// This provider serves cartoons and anime content.
+type KimCartoon struct {
+	base   string // e.g., "kimcartoon.com.co"
+	client *http.Client
+}
+
+// NewKimCartoon creates a new KimCartoon provider.
+func NewKimCartoon(base string) *KimCartoon {
+	return &KimCartoon{
+		base:   base,
+		client: httputil.NewClient(),
+	}
+}
+
+func (k *KimCartoon) baseURL() string {
+	return "https://" + k.base
+}
+
+// Search returns matching results for a query.
+func (k *KimCartoon) Search(query string) ([]media.SearchResult, error) {
+	searchURL := fmt.Sprintf("%s/?s=%s", k.baseURL(), url.QueryEscape(query))
+
+	doc, err := k.fetchDocument(searchURL)
+	if err != nil {
+		return nil, fmt.Errorf("searching for %q: %w", query, err)
+	}
+
+	results := parseKCSearchResults(doc)
+
+	// Fetch page 2 if available
+	if doc.Find("a.next.page-numbers").Length() > 0 {
+		page2URL := fmt.Sprintf("%s/page/2/?s=%s", k.baseURL(), url.QueryEscape(query))
+		if doc2, err := k.fetchDocument(page2URL); err == nil {
+			results = append(results, parseKCSearchResults(doc2)...)
+		}
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found for %q", query)
+	}
+
+	sortByRelevance(results, query)
+
+	return results, nil
+}
+
+// parseKCSearchResults extracts search results from a kimcartoon search page.
+func parseKCSearchResults(doc *goquery.Document) []media.SearchResult {
+	var results []media.SearchResult
+
+	doc.Find("article.bs div.bsx a[itemprop='url']").Each(func(_ int, s *goquery.Selection) {
+		href, exists := s.Attr("href")
+		if !exists {
+			return
+		}
+
+		title := strings.TrimSpace(s.AttrOr("title", ""))
+		if title == "" {
+			title = strings.TrimSpace(s.Find(".ttzz").Text())
+		}
+
+		id := extractKCID(href)
+		if id == "" {
+			return
+		}
+
+		year := ""
+		if m := kcYearRe.FindStringSubmatch(title); len(m) > 1 {
+			year = m[1]
+		}
+
+		results = append(results, media.SearchResult{
+			ID:    id,
+			Title: title,
+			Type:  media.TV, // Cartoons are episodic
+			Year:  year,
+			URL:   href,
+		})
+	})
+
+	return results
+}
+
+var kcYearRe = regexp.MustCompile(`\((\d{4})\)`)
+
+// extractKCID extracts the path-based ID from a kimcartoon URL.
+// e.g., "https://kimcartoon.com.co/cartoon/south-park-season-28-2025/" -> "cartoon/south-park-season-28-2025"
+func extractKCID(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	path := strings.Trim(u.Path, "/")
+	if path == "" {
+		return ""
+	}
+	return path
+}
+
+// GetDetails returns detailed metadata for a content item.
+func (k *KimCartoon) GetDetails(id string) (*media.ContentDetail, error) {
+	pageURL := fmt.Sprintf("%s/%s/", k.baseURL(), id)
+	doc, err := k.fetchDocument(pageURL)
+	if err != nil {
+		return nil, fmt.Errorf("getting details: %w", err)
+	}
+
+	return parseKCDetail(doc), nil
+}
+
+// parseKCDetail extracts content details from a kimcartoon show page.
+func parseKCDetail(doc *goquery.Document) *media.ContentDetail {
+	detail := &media.ContentDetail{}
+
+	detail.Description = strings.TrimSpace(doc.Find("div.mindesc").Text())
+
+	doc.Find("div.genxed a").Each(func(_ int, s *goquery.Selection) {
+		detail.Genre = append(detail.Genre, strings.TrimSpace(s.Text()))
+	})
+
+	doc.Find("div.spe span").Each(func(_ int, s *goquery.Selection) {
+		text := strings.TrimSpace(s.Text())
+		if strings.Contains(text, "Status:") {
+			detail.Released = strings.TrimSpace(strings.TrimPrefix(text, "Status:"))
+		}
+	})
+
+	return detail
+}
+
+// GetSeasons returns a single synthetic season since kimcartoon treats
+// each season as a separate show entry.
+func (k *KimCartoon) GetSeasons(id string) ([]media.Season, error) {
+	return []media.Season{{Number: 1, ID: id}}, nil
+}
+
+// GetEpisodes returns episodes for the given show/season page.
+func (k *KimCartoon) GetEpisodes(id string, seasonID string) ([]media.Episode, error) {
+	pageURL := fmt.Sprintf("%s/%s/", k.baseURL(), seasonID)
+	doc, err := k.fetchDocument(pageURL)
+	if err != nil {
+		return nil, fmt.Errorf("getting episodes: %w", err)
+	}
+
+	episodes := parseKCEpisodes(doc)
+	if len(episodes) == 0 {
+		return nil, fmt.Errorf("no episodes found")
+	}
+
+	return episodes, nil
+}
+
+var kcEpNumRe = regexp.MustCompile(`Episode\s+(\d+)`)
+
+// parseKCEpisodes extracts episodes from a kimcartoon show page.
+// The site lists episodes newest-first, so we reverse to chronological order.
+func parseKCEpisodes(doc *goquery.Document) []media.Episode {
+	var episodes []media.Episode
+
+	doc.Find("div.eplister ul#myList li a").Each(func(_ int, s *goquery.Selection) {
+		href, exists := s.Attr("href")
+		if !exists {
+			return
+		}
+
+		titleText := strings.TrimSpace(s.Find("div.epl-title").Text())
+
+		num := 0
+		if m := kcEpNumRe.FindStringSubmatch(titleText); len(m) > 1 {
+			num, _ = strconv.Atoi(m[1])
+		}
+
+		epID := extractKCID(href)
+		if epID == "" {
+			return
+		}
+
+		episodes = append(episodes, media.Episode{
+			Number: num,
+			Title:  titleText,
+			ID:     epID,
+		})
+	})
+
+	// Reverse to chronological order (site lists newest first)
+	for i, j := 0, len(episodes)-1; i < j; i, j = i+1, j-1 {
+		episodes[i], episodes[j] = episodes[j], episodes[i]
+	}
+
+	// If episode numbers weren't parsed, assign sequential numbers
+	for i := range episodes {
+		if episodes[i].Number == 0 {
+			episodes[i].Number = i + 1
+		}
+	}
+
+	return episodes
+}
+
+// GetServers returns available streaming servers for an episode.
+// episodeID is the path to the episode page.
+func (k *KimCartoon) GetServers(id string, episodeID string) ([]media.Server, error) {
+	if episodeID == "" {
+		episodeID = id
+	}
+
+	pageURL := fmt.Sprintf("%s/%s/", k.baseURL(), episodeID)
+	doc, err := k.fetchDocument(pageURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching episode page: %w", err)
+	}
+
+	// Extract data-embed from the player div
+	embedURL, exists := doc.Find("div.pembed").Attr("data-embed")
+	if !exists || embedURL == "" {
+		return nil, fmt.Errorf("no embed URL found on episode page")
+	}
+
+	// Build servers for each known backend
+	servers := []media.Server{
+		{Name: "TServer", ID: embedURL},
+	}
+
+	// Add alternate servers by appending server param
+	base := embedURL
+	if strings.Contains(base, "?") {
+		base += "&"
+	} else {
+		base += "?"
+	}
+	servers = append(servers,
+		media.Server{Name: "VHServer", ID: base + "s=vhserver"},
+		media.Server{Name: "HServer", ID: base + "s=hserver"},
+	)
+
+	return servers, nil
+}
+
+var vidwishIframeRe = regexp.MustCompile(`<iframe[^>]*src="(https://player\.vidwish\.live[^"]+)"`)
+
+// GetEmbedURL resolves the stream.php page to get the vidwish.live player URL.
+func (k *KimCartoon) GetEmbedURL(serverID string) (string, error) {
+	if serverID == "" {
+		return "", fmt.Errorf("server ID cannot be empty")
+	}
+
+	// serverID is the full stream.php URL — fetch it to find the vidwish iframe
+	req, err := http.NewRequest(http.MethodGet, serverID, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
+	req.Header.Set("Referer", k.baseURL()+"/")
+
+	resp, err := k.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching stream page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("stream page returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return "", fmt.Errorf("reading stream page: %w", err)
+	}
+
+	match := vidwishIframeRe.FindStringSubmatch(string(body))
+	if len(match) < 2 {
+		return "", fmt.Errorf("no vidwish player URL found")
+	}
+
+	return match[1], nil
+}
+
+// Trending returns trending content from the homepage.
+func (k *KimCartoon) Trending(mediaType media.MediaType) ([]media.SearchResult, error) {
+	doc, err := k.fetchDocument(k.baseURL() + "/")
+	if err != nil {
+		return nil, fmt.Errorf("getting trending: %w", err)
+	}
+
+	return parseKCSearchResults(doc), nil
+}
+
+// Recent returns recently added content.
+func (k *KimCartoon) Recent(mediaType media.MediaType) ([]media.SearchResult, error) {
+	return k.Trending(mediaType)
+}
+
+// fetchDocument fetches a URL and parses it into a goquery Document.
+func (k *KimCartoon) fetchDocument(rawURL string) (*goquery.Document, error) {
+	resp, err := httputil.Get(k.client, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	return doc, nil
+}

--- a/internal/provider/soap2day.go
+++ b/internal/provider/soap2day.go
@@ -1,0 +1,401 @@
+package provider
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+const (
+	tmdbSearchBase = "https://www.themoviedb.org"
+	moviesapiBase  = "https://ww2.moviesapi.to"
+	flixcdnBase    = "https://flixcdn.cyou"
+	flixcdnKey     = "kiemtienmua911ca"
+	flixcdnIV      = "1234567890oiuytr"
+)
+
+// Soap2Day implements the StreamProvider interface using TMDB for search
+// and moviesapi.to + flixcdn for stream resolution.
+type Soap2Day struct {
+	client *http.Client
+}
+
+// NewSoap2Day creates a new Soap2Day provider.
+func NewSoap2Day() *Soap2Day {
+	return &Soap2Day{
+		client: httputil.NewClient(),
+	}
+}
+
+// --- TMDB search types ---
+
+type tmdbSearchResponse struct {
+	Results []json.RawMessage `json:"results"`
+}
+
+type tmdbSearchResult struct {
+	ID           int     `json:"id"`
+	Title        string  `json:"title"`        // movie
+	Name         string  `json:"name"`         // tv
+	MediaType    string  `json:"media_type"`   // "movie" or "tv"
+	Overview     string  `json:"overview"`
+	ReleaseDate  string  `json:"release_date"` // movie
+	FirstAirDate string  `json:"first_air_date"` // tv
+	VoteAverage  float64 `json:"vote_average"`
+	PosterPath   string  `json:"poster_path"`
+}
+
+func (r *tmdbSearchResult) displayTitle() string {
+	if r.Name != "" {
+		return r.Name
+	}
+	return r.Title
+}
+
+func (r *tmdbSearchResult) year() string {
+	date := r.ReleaseDate
+	if date == "" {
+		date = r.FirstAirDate
+	}
+	if len(date) >= 4 {
+		return date[:4]
+	}
+	return ""
+}
+
+// --- moviesapi types ---
+
+type moviesapiResponse struct {
+	VideoURL  string              `json:"video_url"`
+	UpnURL    string              `json:"upn_url"`
+	Subtitles []moviesapiSubtitle `json:"subtitles"`
+}
+
+type moviesapiSubtitle struct {
+	Label string `json:"label"`
+	URL   string `json:"url"`
+}
+
+type flixcdnDecrypted struct {
+	Source string `json:"source"`
+}
+
+// --- Provider interface ---
+
+// Search uses TMDB's free trending search endpoint (no API key needed).
+func (s *Soap2Day) Search(query string) ([]media.SearchResult, error) {
+	searchURL := fmt.Sprintf("%s/search/trending?query=%s",
+		tmdbSearchBase, url.QueryEscape(query))
+
+	body, err := s.fetchWithReferer(searchURL, tmdbSearchBase+"/")
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+
+	var resp tmdbSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("search: parsing response: %w", err)
+	}
+
+	var results []media.SearchResult
+	for _, raw := range resp.Results {
+		// Skip non-object entries (TMDB includes suggestion strings in the array)
+		if len(raw) == 0 || raw[0] != '{' {
+			continue
+		}
+
+		var item tmdbSearchResult
+		if err := json.Unmarshal(raw, &item); err != nil {
+			continue
+		}
+
+		if item.MediaType != "movie" && item.MediaType != "tv" {
+			continue
+		}
+
+		mt := media.Movie
+		if item.MediaType == "tv" {
+			mt = media.TV
+		}
+
+		results = append(results, media.SearchResult{
+			ID:    fmt.Sprintf("%s/%d", item.MediaType, item.ID),
+			Title: item.displayTitle(),
+			Type:  mt,
+			Year:  item.year(),
+			URL:   fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
+		})
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found for %q", query)
+	}
+
+	return results, nil
+}
+
+// GetDetails returns metadata from TMDB search results (minimal).
+func (s *Soap2Day) GetDetails(id string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+
+// GetSeasons returns seasons for a TV show by probing moviesapi.to.
+// It tests season numbers starting from 1 until one returns no real content.
+func (s *Soap2Day) GetSeasons(id string) ([]media.Season, error) {
+	tmdbID := extractTMDBID(id)
+
+	var seasons []media.Season
+	for n := 1; n <= 30; n++ {
+		apiURL := fmt.Sprintf("%s/api/tv/%s/%d/1", moviesapiBase, tmdbID, n)
+		body, err := s.fetchWithReferer(apiURL, moviesapiBase+"/")
+		if err != nil {
+			break
+		}
+		var resp moviesapiResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			break
+		}
+		// Real content has flixcdn.cyou in the video_url; fallback URLs like
+		// player.mov2day.xyz indicate the content doesn't actually exist.
+		if !strings.Contains(resp.VideoURL, "flixcdn.cyou") {
+			break
+		}
+		seasons = append(seasons, media.Season{
+			Number: n,
+			ID:     fmt.Sprintf("%s:%d", tmdbID, n),
+		})
+	}
+
+	if len(seasons) == 0 {
+		return nil, fmt.Errorf("no seasons found")
+	}
+
+	return seasons, nil
+}
+
+// GetEpisodes returns episodes for a season by probing moviesapi.to.
+func (s *Soap2Day) GetEpisodes(id string, seasonID string) ([]media.Episode, error) {
+	parts := strings.SplitN(seasonID, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid season ID: %s", seasonID)
+	}
+	tmdbID := parts[0]
+	seasonNum, _ := strconv.Atoi(parts[1])
+
+	var episodes []media.Episode
+	for ep := 1; ep <= 50; ep++ {
+		apiURL := fmt.Sprintf("%s/api/tv/%s/%d/%d", moviesapiBase, tmdbID, seasonNum, ep)
+		body, err := s.fetchWithReferer(apiURL, moviesapiBase+"/")
+		if err != nil {
+			break
+		}
+		var resp moviesapiResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			break
+		}
+		if !strings.Contains(resp.VideoURL, "flixcdn.cyou") {
+			break
+		}
+		episodes = append(episodes, media.Episode{
+			Number: ep,
+			Title:  fmt.Sprintf("Episode %d", ep),
+			ID:     fmt.Sprintf("%s:%d:%d", tmdbID, seasonNum, ep),
+		})
+	}
+
+	if len(episodes) == 0 {
+		return nil, fmt.Errorf("no episodes found")
+	}
+
+	return episodes, nil
+}
+
+// GetServers returns a single server for stream resolution.
+func (s *Soap2Day) GetServers(id string, episodeID string) ([]media.Server, error) {
+	return []media.Server{
+		{Name: "Default", ID: "default"},
+	}, nil
+}
+
+// GetEmbedURL is not used for this provider.
+func (s *Soap2Day) GetEmbedURL(serverID string) (string, error) {
+	return "", fmt.Errorf("use Watch instead")
+}
+
+// Watch resolves the stream URL through moviesapi.to and flixcdn decryption.
+func (s *Soap2Day) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	// Build moviesapi URL from the encoded IDs
+	var apiURL string
+	if episodeID != "" {
+		// TV: episodeID format is "tmdbID:season:episode"
+		parts := strings.SplitN(episodeID, ":", 3)
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("invalid episode ID: %s", episodeID)
+		}
+		apiURL = fmt.Sprintf("%s/api/tv/%s/%s/%s", moviesapiBase, parts[0], parts[1], parts[2])
+	} else {
+		// Movie: mediaID format is "movie/{tmdbID}"
+		tmdbID := extractTMDBID(mediaID)
+		apiURL = fmt.Sprintf("%s/api/movie/%s", moviesapiBase, tmdbID)
+	}
+
+	// Fetch moviesapi response
+	apiBody, err := s.fetchWithReferer(apiURL, moviesapiBase+"/")
+	if err != nil {
+		return nil, fmt.Errorf("moviesapi request: %w", err)
+	}
+
+	var apiResp moviesapiResponse
+	if err := json.Unmarshal(apiBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("parsing moviesapi response: %w", err)
+	}
+
+	if apiResp.VideoURL == "" {
+		return nil, fmt.Errorf("no video_url in response")
+	}
+
+	// Extract embed ID from video_url (after # and before first &)
+	embedID, err := extractEmbedID(apiResp.VideoURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	// Decrypt stream URL from flixcdn
+	m3u8URL, err := s.decryptFlixcdn(embedID)
+	if err != nil {
+		return nil, fmt.Errorf("stream decryption: %w", err)
+	}
+
+	// Map subtitles
+	var subtitles []media.Subtitle
+	for _, sub := range apiResp.Subtitles {
+		subtitles = append(subtitles, media.Subtitle{
+			Language: sub.Label,
+			Label:    sub.Label,
+			URL:      sub.URL,
+		})
+	}
+
+	return &media.Stream{
+		URL:       m3u8URL,
+		Quality:   quality,
+		Subtitles: subtitles,
+		Referer:   flixcdnBase + "/",
+	}, nil
+}
+
+// extractTMDBID extracts the numeric TMDB ID from a provider ID like "tv/79744" or "movie/299534".
+func extractTMDBID(id string) string {
+	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+		return id[idx+1:]
+	}
+	return id
+}
+
+// extractEmbedID extracts the embed ID from a flixcdn video_url.
+func extractEmbedID(videoURL string) (string, error) {
+	idx := strings.Index(videoURL, "#")
+	if idx < 0 {
+		return "", fmt.Errorf("no embed ID in video URL")
+	}
+	fragment := videoURL[idx+1:]
+	if ampIdx := strings.Index(fragment, "&"); ampIdx >= 0 {
+		fragment = fragment[:ampIdx]
+	}
+	if fragment == "" {
+		return "", fmt.Errorf("empty embed ID in video URL")
+	}
+	return fragment, nil
+}
+
+// decryptFlixcdn fetches encrypted stream data from flixcdn and decrypts it.
+func (s *Soap2Day) decryptFlixcdn(embedID string) (string, error) {
+	apiURL := fmt.Sprintf("%s/api/v1/video?id=%s", flixcdnBase, url.QueryEscape(embedID))
+
+	body, err := s.fetchWithReferer(apiURL, flixcdnBase+"/")
+	if err != nil {
+		return "", fmt.Errorf("flixcdn request: %w", err)
+	}
+
+	// Response is hex-encoded AES-CBC encrypted data
+	ciphertext, err := hex.DecodeString(strings.TrimSpace(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("hex decode: %w", err)
+	}
+
+	// Decrypt AES-CBC
+	block, err := aes.NewCipher([]byte(flixcdnKey))
+	if err != nil {
+		return "", fmt.Errorf("aes cipher: %w", err)
+	}
+
+	if len(ciphertext) < aes.BlockSize || len(ciphertext)%aes.BlockSize != 0 {
+		return "", fmt.Errorf("invalid ciphertext length %d", len(ciphertext))
+	}
+
+	mode := cipher.NewCBCDecrypter(block, []byte(flixcdnIV))
+	plaintext := make([]byte, len(ciphertext))
+	mode.CryptBlocks(plaintext, ciphertext)
+
+	// PKCS7 unpad
+	padLen := int(plaintext[len(plaintext)-1])
+	if padLen > 0 && padLen <= aes.BlockSize {
+		plaintext = plaintext[:len(plaintext)-padLen]
+	}
+
+	var decrypted flixcdnDecrypted
+	if err := json.Unmarshal(plaintext, &decrypted); err != nil {
+		return "", fmt.Errorf("parsing decrypted response: %w", err)
+	}
+
+	if decrypted.Source == "" {
+		return "", fmt.Errorf("empty source in decrypted response")
+	}
+
+	return decrypted.Source, nil
+}
+
+// fetchWithReferer performs a GET request with a specific Referer header.
+func (s *Soap2Day) fetchWithReferer(rawURL, referer string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
+	req.Header.Set("Accept", "application/json, text/html, */*")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+	req.Header.Set("Referer", referer)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d for %s", resp.StatusCode, rawURL)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+}
+
+// Trending is not supported.
+func (s *Soap2Day) Trending(mediaType media.MediaType) ([]media.SearchResult, error) {
+	return nil, fmt.Errorf("trending not supported by soap2day provider")
+}
+
+// Recent is not supported.
+func (s *Soap2Day) Recent(mediaType media.MediaType) ([]media.SearchResult, error) {
+	return nil, fmt.Errorf("recent not supported by soap2day provider")
+}


### PR DESCRIPTION
## Summary

- **KimCartoon provider** (`--base kimcartoon.com.co`) — cartoons/anime via kimcartoon.com.co with VidWish stream extractor
- **Soap2Day provider** (`--base soap2day`) — movies/TV via TMDB search + moviesapi.to API + flixcdn AES-CBC decryption
- **Automatic fallback** — when all primary provider servers fail, transparently tries Soap2Day's stream chain before giving up
- **Netu fix** — `/f/` to `/e/` path conversion for strcdn.org embeds
- **mpv improvements** — 15s network timeout, instant-exit detection, Referer header propagation for HLS segments

## How it works

Users don't need to change anything. The default provider (flixhq.ws) works as before. When a stream fails (CDN blocked, content missing), lobster automatically:
1. Searches TMDB for the same title
2. Resolves the stream via moviesapi.to
3. Decrypts the flixcdn response (AES-CBC)
4. Plays the m3u8 with proper Referer headers

## Test plan

- [ ] `lobster 'the rookie'` — pick S06E06, verify fallback triggers and plays
- [ ] `lobster --base kimcartoon.com.co 'south park'` — verify cartoon search and playback
- [ ] `lobster --base soap2day 'avengers endgame'` — verify direct soap2day movie playback
- [ ] Verify existing flixhq.ws content (e.g., S08E07) still plays without fallback