### PR TITLE
feat: add TBCPL provider and improve fallback logic

### DIFF
--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -10,9 +10,12 @@ import (
 	"lobster/internal/provider"
 )
 
+const maxFallbackCandidates = 5
+
 // fallbackProviders returns all available fallback providers, excluding the primary.
-// Both StreamProviders (Soap2Day, Consumet) and regular Providers (FlixHQ, FlixHQWS)
-// are included so the app tries every source before giving up.
+// Both StreamProviders (Soap2Day, Consumet, MovieBox, TBCPL) and regular
+// Providers (FlixHQ, FlixHQWS) are included so the app tries every source
+// before giving up.
 func fallbackProviders(primary provider.Provider) []provider.Provider {
 	var fallbacks []provider.Provider
 
@@ -24,6 +27,10 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 		fallbacks = append(fallbacks, provider.NewMovieBox())
 	}
 
+	if _, ok := primary.(*provider.TBCPL); !ok {
+		fallbacks = append(fallbacks, provider.NewTBCPL("tbcpl"))
+	}
+
 	if _, ok := primary.(*provider.FlixHQWS); !ok {
 		fallbacks = append(fallbacks, provider.NewFlixHQWS("flixhq.ws"))
 	}
@@ -33,7 +40,7 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 	}
 
 	if _, ok := primary.(*provider.KimCartoon); !ok {
-		fallbacks = append(fallbacks, provider.NewKimCartoon("kimcartoon.li"))
+		fallbacks = append(fallbacks, provider.NewKimCartoon("kimcartoon.com.co"))
 	}
 
 	return fallbacks
@@ -70,35 +77,70 @@ func tryFallbackProvider(fb provider.Provider, title string, mediaType media.Med
 		return nil, fmt.Errorf("search failed: %w", err)
 	}
 
-	// Find best match: prefer same media type
-	var match *media.SearchResult
-	for i, r := range results {
-		if r.Type == mediaType {
-			match = &results[i]
-			break
-		}
-	}
-	if match == nil && len(results) > 0 {
-		match = &results[0]
-	}
-	if match == nil {
+	candidates := fallbackCandidates(results, mediaType)
+	if len(candidates) == 0 {
 		return nil, fmt.Errorf("no matching result for %q", title)
 	}
-
-	debugf("fallback matched: %s (ID: %s)", match.Title, match.ID)
 
 	quality := "1080"
 	if cfg != nil && cfg.Quality != "" {
 		quality = cfg.Quality
 	}
 
-	// StreamProvider path: use Watch() directly
-	if sp, ok := fb.(provider.StreamProvider); ok {
-		return tryStreamProviderFallback(sp, match, mediaType, season, episode, quality)
+	var lastErr error
+	for i := range candidates {
+		match := &candidates[i]
+		debugf("fallback candidate: %s (ID: %s)", match.Title, match.ID)
+
+		var stream *media.Stream
+		if sp, ok := fb.(provider.StreamProvider); ok {
+			stream, err = tryStreamProviderFallback(sp, match, mediaType, season, episode, quality)
+		} else {
+			stream, err = tryEmbedProviderFallback(fb, match, mediaType, season, episode, quality)
+		}
+		if err == nil {
+			return stream, nil
+		}
+		lastErr = err
+		debugf("fallback candidate %s failed: %v", match.Title, err)
 	}
 
-	// Regular Provider path: GetServers + GetEmbedURL + Extract
-	return tryEmbedProviderFallback(fb, match, mediaType, season, episode, quality)
+	return nil, fmt.Errorf("all %d candidates failed: %w", len(candidates), lastErr)
+}
+
+func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
+	var sameType []media.SearchResult
+	var otherType []media.SearchResult
+	seen := make(map[string]bool)
+
+	appendUnique := func(dst []media.SearchResult, r media.SearchResult) []media.SearchResult {
+		key := r.ID
+		if key == "" {
+			key = r.Title + r.URL
+		}
+		if seen[key] {
+			return dst
+		}
+		seen[key] = true
+		return append(dst, r)
+	}
+
+	for _, r := range results {
+		if r.Type == mediaType {
+			sameType = appendUnique(sameType, r)
+		} else {
+			otherType = appendUnique(otherType, r)
+		}
+	}
+
+	candidates := sameType
+	if len(candidates) == 0 {
+		candidates = otherType
+	}
+	if len(candidates) > maxFallbackCandidates {
+		candidates = candidates[:maxFallbackCandidates]
+	}
+	return candidates
 }
 
 // tryStreamProviderFallback resolves a stream via StreamProvider.Watch().

--- a/cmd/fallback_test.go
+++ b/cmd/fallback_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+func TestFallbackCandidatesPreferSameType(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "movie/1", Title: "Movie", Type: media.Movie},
+		{ID: "tv/1", Title: "Series", Type: media.TV},
+		{ID: "tv/2", Title: "Series Alt", Type: media.TV},
+	}
+
+	got := fallbackCandidates(results, media.TV)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].ID != "tv/1" || got[1].ID != "tv/2" {
+		t.Fatalf("unexpected candidates: %+v", got)
+	}
+}
+
+func TestFallbackCandidatesLimitAndDedupe(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "movie/1", Title: "One", Type: media.Movie},
+		{ID: "movie/1", Title: "One Duplicate", Type: media.Movie},
+		{ID: "movie/2", Title: "Two", Type: media.Movie},
+		{ID: "movie/3", Title: "Three", Type: media.Movie},
+		{ID: "movie/4", Title: "Four", Type: media.Movie},
+		{ID: "movie/5", Title: "Five", Type: media.Movie},
+		{ID: "movie/6", Title: "Six", Type: media.Movie},
+	}
+
+	got := fallbackCandidates(results, media.Movie)
+	if len(got) != maxFallbackCandidates {
+		t.Fatalf("len(got) = %d, want %d", len(got), maxFallbackCandidates)
+	}
+	if got[0].ID != "movie/1" || got[1].ID != "movie/2" || got[4].ID != "movie/5" {
+		t.Fatalf("unexpected candidates: %+v", got)
+	}
+}
+
+func TestMergeSubtitlesDedupesByURL(t *testing.T) {
+	embedded := []media.Subtitle{
+		{Language: "English", Label: "English", URL: "https://subs.example/en.vtt"},
+	}
+	external := []media.Subtitle{
+		{Language: "English", Label: "English Duplicate", URL: "https://subs.example/en.vtt"},
+		{Language: "English", Label: "English SDH", URL: "subdl:https://subs.example/en-sdh.zip"},
+	}
+
+	got := mergeSubtitles(embedded, external)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Label != "English" || got[1].Label != "English SDH" {
+		t.Fatalf("unexpected subtitles: %+v", got)
+	}
+}

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -26,6 +26,9 @@ func newProvider() provider.Provider {
 	if strings.Contains(cfg.Base, "flixhq") {
 		return provider.NewFlixHQ(cfg.Base)
 	}
+	if strings.Contains(cfg.Base, "tbcpl") || strings.Contains(cfg.Base, "1shows") {
+		return provider.NewTBCPL(cfg.Base)
+	}
 	// Default: MovieBox
 	return provider.NewMovieBox()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,6 @@ Search for movies and TV shows, stream them with mpv/vlc, or download with ffmpe
 	RunE:              searchRun,
 }
 
-
 // Execute runs the root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
@@ -58,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagPlayer, "player", "", "Media player: mpv | vlc | iina | celluloid")
 	rootCmd.PersistentFlags().BoolVarP(&flagContinue, "continue", "c", false, "Auto-resume from history")
 	rootCmd.PersistentFlags().BoolVarP(&flagJSON, "json", "j", false, "Output stream metadata as JSON")
-	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day")
+	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | tbcpl | 1shows.org")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
 
 	rootCmd.AddCommand(historyCmd)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -350,7 +350,7 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 			if err == nil {
 				defer tmpDir.Cleanup()
 				for _, sub := range subs {
-					f, err := resolveAndDownloadSub(tmpDir, sub)
+					f, err := resolveAndDownloadSub(tmpDir, sub, season, episode)
 					if err != nil {
 						debugf("subtitle download failed (%s): %v", sub.Label, err)
 						continue
@@ -424,11 +424,11 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 
 // resolveAndDownloadSub handles downloading a subtitle, resolving provider-specific
 // URL schemes (opensubtitles:, subdl:) to actual files.
-func resolveAndDownloadSub(tmpDir *subtitle.TempDir, sub media.Subtitle) (string, error) {
+func resolveAndDownloadSub(tmpDir *subtitle.TempDir, sub media.Subtitle, season, episode int) (string, error) {
 	if strings.HasPrefix(sub.URL, "subdl:") {
 		zipURL := strings.TrimPrefix(sub.URL, "subdl:")
 		client := subtitle.NewSubDL(cfg.SubDLAPIKey)
-		return client.DownloadAndExtract(zipURL, tmpDir)
+		return client.DownloadAndExtract(zipURL, tmpDir, season, episode)
 	}
 	if strings.HasPrefix(sub.URL, "opensubtitles:") {
 		var fileID int

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -41,12 +41,15 @@ func searchRun(cmd *cobra.Command, args []string) error {
 			defer cleanup()
 		}
 
-		selected, err := tui.StartApp(p, cfg, mgr)
+		selected, selectedProvider, err := tui.StartApp(p, cfg, mgr)
 		if err != nil {
 			return err
 		}
 		if selected != nil {
-			return resolveAndPlay(p, *selected, 0, 0)
+			if selectedProvider == nil {
+				selectedProvider = p
+			}
+			return resolveAndPlay(selectedProvider, *selected, 0, 0)
 		}
 		return nil
 	}
@@ -332,14 +335,13 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 		return enc.Encode(out)
 	}
 
-	// Handle subtitles — prefer SubDL over embedded (better sync)
 	// Download multiple tracks so the user can cycle with 'j' in mpv.
 	var subFiles []string
 	if !flagNoSubs {
-		subs := searchExternalSubs(selected.Title, season, episode)
-		if len(subs) == 0 {
-			subs = stream.Subtitles
-		}
+		subs := mergeSubtitles(
+			subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
+			searchExternalSubs(selected.Title, season, episode),
+		)
 		if len(subs) > 0 {
 			tmpDir, err := subtitle.NewTempDir()
 			if err == nil {
@@ -440,15 +442,16 @@ func resolveAndDownloadSub(tmpDir *subtitle.TempDir, sub media.Subtitle) (string
 
 // searchExternalSubs tries SubDL first, then OpenSubtitles as fallback.
 func searchExternalSubs(title string, season, episode int) []media.Subtitle {
+	var all []media.Subtitle
 	if cfg.SubDLAPIKey != "" {
-		debugf("no embedded subtitles, trying SubDL...")
+		debugf("trying SubDL subtitles...")
 		subs, err := subtitle.NewSubDL(cfg.SubDLAPIKey).Search(
 			title, cfg.SubsLanguage, season, episode,
 		)
 		if err != nil {
 			debugf("SubDL search failed: %v", err)
 		} else if len(subs) > 0 {
-			return subs
+			all = append(all, subs...)
 		}
 	}
 	if cfg.OSAPIKey != "" {
@@ -459,10 +462,25 @@ func searchExternalSubs(title string, season, episode int) []media.Subtitle {
 		if err != nil {
 			debugf("OpenSubtitles search failed: %v", err)
 		} else if len(subs) > 0 {
-			return subs
+			all = append(all, subs...)
 		}
 	}
-	return nil
+	return all
+}
+
+func mergeSubtitles(groups ...[]media.Subtitle) []media.Subtitle {
+	var merged []media.Subtitle
+	seen := make(map[string]bool)
+	for _, group := range groups {
+		for _, sub := range group {
+			if sub.URL == "" || seen[sub.URL] {
+				continue
+			}
+			seen[sub.URL] = true
+			merged = append(merged, sub)
+		}
+	}
+	return merged
 }
 
 // initDownloadManager sets up the download manager with SQLite store and engines.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -345,6 +345,10 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 			),
 			season, episode,
 		)
+		// Limit to 3 subtitle downloads to avoid stream URL expiry.
+		if len(subs) > 3 {
+			subs = subs[:3]
+		}
 		if len(subs) > 0 {
 			tmpDir, err := subtitle.NewTempDir()
 			if err == nil {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -339,7 +339,10 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 	var subFiles []string
 	if !flagNoSubs {
 		subs := mergeSubtitles(
-			subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
+			subtitle.FilterByEpisode(
+				subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
+				season, episode,
+			),
 			searchExternalSubs(selected.Title, season, episode),
 		)
 		if len(subs) > 0 {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -338,12 +338,12 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 	// Download multiple tracks so the user can cycle with 'j' in mpv.
 	var subFiles []string
 	if !flagNoSubs {
-		subs := mergeSubtitles(
-			subtitle.FilterByEpisode(
+		subs := subtitle.FilterByEpisode(
+			mergeSubtitles(
 				subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
-				season, episode,
+				searchExternalSubs(selected.Title, season, episode),
 			),
-			searchExternalSubs(selected.Title, season, episode),
+			season, episode,
 		)
 		if len(subs) > 0 {
 			tmpDir, err := subtitle.NewTempDir()

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -287,7 +287,7 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 
 	var subFiles []string
 	for _, sub := range subs {
-		f, err := resolveAndDownloadSub(tmpDir, sub)
+		f, err := resolveAndDownloadSub(tmpDir, sub, season, episode)
 		if err != nil {
 			debugf("subtitle download failed (%s): %v", sub.Label, err)
 			continue

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -262,17 +262,16 @@ func playCurrentEpisode(sess *playlist.Session) error {
 }
 
 // resolveSubtitles downloads multiple subtitle files.
-// Prefers SubDL over embedded. User can cycle tracks with 'j' in mpv.
+// User can cycle tracks with 'j' in mpv.
 func resolveSubtitles(stream *media.Stream, title string, season, episode int) []string {
 	if flagNoSubs {
 		return nil
 	}
 
-	subs := searchExternalSubs(title, season, episode)
-	if len(subs) == 0 {
-		subs = stream.Subtitles
-	}
-
+	subs := mergeSubtitles(
+		subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
+		searchExternalSubs(title, season, episode),
+	)
 	if len(subs) == 0 {
 		return nil
 	}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -269,7 +269,10 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 	}
 
 	subs := mergeSubtitles(
-		subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
+		subtitle.FilterByEpisode(
+			subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
+			season, episode,
+		),
 		searchExternalSubs(title, season, episode),
 	)
 	if len(subs) == 0 {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -278,6 +278,10 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 	if len(subs) == 0 {
 		return nil
 	}
+	// Limit to 3 subtitle downloads to avoid stream URL expiry.
+	if len(subs) > 3 {
+		subs = subs[:3]
+	}
 
 	tmpDir, err := subtitle.NewTempDir()
 	if err != nil {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -268,12 +268,12 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 		return nil
 	}
 
-	subs := mergeSubtitles(
-		subtitle.FilterByEpisode(
+	subs := subtitle.FilterByEpisode(
+		mergeSubtitles(
 			subtitle.Filter(stream.Subtitles, cfg.SubsLanguage),
-			season, episode,
+			searchExternalSubs(title, season, episode),
 		),
-		searchExternalSubs(title, season, episode),
+		season, episode,
 	)
 	if len(subs) == 0 {
 		return nil

--- a/docs/moviebox-provider.md
+++ b/docs/moviebox-provider.md
@@ -91,8 +91,8 @@ func sign(method, path, body string, key []byte) (clientToken, signature string)
 
     // x-tr-signature canonical string
     bodyMD5 := md5.Sum([]byte(body))
-    canonical := fmt.Sprintf("GET\napplication/json\napplication/json\n%d\n%s\n%s\n%s",
-        len(body), ts, hex.EncodeToString(bodyMD5[:]), path)
+    canonical := fmt.Sprintf("%s\napplication/json\napplication/json\n%d\n%s\n%s\n%s",
+        method, len(body), ts, hex.EncodeToString(bodyMD5[:]), path)
 
     mac := hmac.New(md5.New, key)
     mac.Write([]byte(canonical))
@@ -134,13 +134,12 @@ Internally, `Watch` calls `GET /play-info?subjectId={mediaID}&se={se}&ep={ep}` a
 **Search result item:**
 ```json
 {
-  "subjectId": 1857349212451623008,
-  "detailPath": "KHgp5s6Gcd2",
-  "name": "Project Hail Mary",
+  "subjectId": "1857349212451623008",
+  "detailUrl": "https://moviebox.ph/detail/project-hail-mary-...",
+  "title": "Project Hail Mary",
   "subjectType": 1,
-  "releaseYear": 2025,
-  "seasonNum": 0,
-  "episodeNum": 0
+  "releaseDate": "2025-03-14",
+  "seNum": 0
 }
 ```
 `subjectType`: `1` = movie, `2` = TV series, `3` = animation.

--- a/docs/moviebox-provider.md
+++ b/docs/moviebox-provider.md
@@ -1,0 +1,185 @@
+# MovieBox Provider Implementation
+
+## Overview
+
+MovieBox (`h5.aoneroom.com` / `moviebox.ph`) is a self-hosted streaming platform backed by Alibaba Cloud infrastructure. It exposes a clean JSON REST API with no Cloudflare or bot protection. Streams are delivered as direct m3u8/MP4 from the `macdn.aoneroom.com` CDN — no third-party embed hosts are involved, so no embed extraction layer is needed.
+
+The V3 mobile API is recommended over the V1/V2 web API because it returns cleaner JSON with full season/episode granularity, and the HMAC signing is simple to implement.
+
+---
+
+## API Reference
+
+**Base URL:** `https://api3.aoneroom.com` (also `api4`–`api6`; rotate on failure)  
+**Path prefix:** `/wefeed-mobile-bff/subject-api/`
+
+| Operation | Method | Endpoint | Key params |
+|-----------|--------|----------|------------|
+| Search | POST | `/search/v2` | `{"keyword": "...", "page": 1, "perPage": 20}` |
+| Detail | GET | `/get` | `subjectId` |
+| Seasons | GET | `/season-info` | `subjectId` |
+| Play info | GET | `/play-info` | `subjectId`, `se` (season), `ep` (episode) |
+| Subtitles | GET | `/get-ext-captions` | `subjectId` |
+
+Trending/recent use:  
+`GET /wefeed-mobile-bff/tab-operating?page=1&tabId=<id>&version=<ver>`
+
+---
+
+## Content ID System
+
+Two-tier IDs returned from search:
+
+- **`subjectId`** — 64-bit integer (e.g. `1857349212451623008`). Required for all API calls.
+- **`detailPath`** — alphanumeric slug (e.g. `KHgp5s6Gcd2`). Used in display URLs only.
+
+Store `subjectId` as the provider ID in `media.SearchResult.ID`.
+
+---
+
+## HMAC-MD5 Request Signing
+
+Every V3 request requires two headers:
+
+```
+X-Client-Token: {ts},{md5(reverse(ts))}
+x-tr-signature:  {ts}|2|{base64(hmac-md5(canonical, key))}
+```
+
+Where `ts` is the current Unix timestamp in milliseconds.
+
+**Canonical string** (newline-separated, in this order):
+```
+{METHOD}
+{Accept header value}
+{Content-Type header value}
+{body length as decimal string}
+{ts}
+{md5(request body)}
+{sorted query string path}  // e.g. "/wefeed-mobile-bff/subject-api/get?subjectId=123"
+```
+
+**HMAC key** (base64-decoded before use):
+```
+76iRl07s0xSN9jqmEWAt79EBJZulIQIsV64FZr2O
+```
+
+Backup key: `Xqn2nnO41/L92o1iuXhSLHTbXvY4Z5ZZ62m8mSLA`
+
+The response includes an `x-user` header containing a bearer token — capture it and send as `Authorization: Bearer <token>` on subsequent requests within the same session.
+
+**Go signing sketch:**
+
+```go
+import (
+    "crypto/hmac"
+    "crypto/md5"
+    "encoding/base64"
+    "encoding/hex"
+    "fmt"
+    "strconv"
+    "time"
+)
+
+func sign(method, path, body string, key []byte) (clientToken, signature string) {
+    ts := strconv.FormatInt(time.Now().UnixMilli(), 10)
+
+    // X-Client-Token
+    rev := reverse(ts)
+    h := md5.Sum([]byte(rev))
+    clientToken = ts + "," + hex.EncodeToString(h[:])
+
+    // x-tr-signature canonical string
+    bodyMD5 := md5.Sum([]byte(body))
+    canonical := fmt.Sprintf("GET\napplication/json\napplication/json\n%d\n%s\n%s\n%s",
+        len(body), ts, hex.EncodeToString(bodyMD5[:]), path)
+
+    mac := hmac.New(md5.New, key)
+    mac.Write([]byte(canonical))
+    sig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+    signature = ts + "|2|" + sig
+    return
+}
+```
+
+---
+
+## Provider Interface Mapping
+
+| `Provider` method | MovieBox API call |
+|-------------------|-------------------|
+| `Search(query)` | `POST /search/v2` |
+| `GetDetails(id)` | `GET /get?subjectId={id}` |
+| `GetSeasons(id)` | `GET /season-info?subjectId={id}` |
+| `GetEpisodes(id, seasonID)` | `GET /season-info?subjectId={id}` → filter by season number |
+| `GetServers(id, episodeID)` | Not applicable — returns a synthetic single "MovieBox" server |
+| `GetEmbedURL(serverID)` | Not applicable — MovieBox uses `Watch()` directly |
+| `Trending(type)` | `GET /tab-operating?tabId=<movie|tv tabId>` |
+| `Recent(type)` | Same tab-operating endpoint, different tabId |
+
+MovieBox returns streams directly, so it should implement `StreamProvider` (the `Watch` extension interface) rather than the embed-based `Provider` flow:
+
+```go
+// Watch resolves a direct stream URL for a movie or TV episode.
+// For movies, se and ep are 0.
+func (m *MovieBox) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error)
+```
+
+Internally, `Watch` calls `GET /play-info?subjectId={mediaID}&se={se}&ep={ep}` and returns the highest-quality m3u8 URL from the `hls[]` array (fall back to `streams[0].url` MP4 if HLS is empty).
+
+---
+
+## Response Shapes (abbreviated)
+
+**Search result item:**
+```json
+{
+  "subjectId": 1857349212451623008,
+  "detailPath": "KHgp5s6Gcd2",
+  "name": "Project Hail Mary",
+  "subjectType": 1,
+  "releaseYear": 2025,
+  "seasonNum": 0,
+  "episodeNum": 0
+}
+```
+`subjectType`: `1` = movie, `2` = TV series, `3` = animation.
+
+**Play-info response:**
+```json
+{
+  "hls": [
+    {"id": "abc123", "url": "https://macdn.aoneroom.com/.../index.m3u8", "quality": "1080p"}
+  ],
+  "streams": [
+    {"id": "def456", "url": "https://macdn.aoneroom.com/.../video.mp4", "quality": "720p"}
+  ],
+  "hasResource": true
+}
+```
+If `hasResource` is `false`, no streams are available for that region/title.
+
+---
+
+## File Structure
+
+```
+internal/provider/
+  moviebox.go        // MovieBox struct, Provider + StreamProvider impl
+  moviebox_test.go   // Unit tests with recorded HTTP fixtures
+  testdata/
+    moviebox/
+      search.json
+      detail.json
+      season_info.json
+      play_info.json
+```
+
+---
+
+## Notes
+
+- The API host pool (`api3`–`api6.aoneroom.com`) should be tried in order on connection failure — add a `hosts []string` field to the struct and rotate.
+- `hasResource: false` on `play-info` means geo-restriction. Surface this as a descriptive error rather than a generic "no stream found".
+- Subtitles come from a separate `GET /get-ext-captions?subjectId={id}` call; fetch alongside play-info and attach to `media.Stream.Subtitles`.
+- The `x-user` bearer token from the first response should be stored on the struct and reused for the session lifetime — it avoids re-authentication on every request.

--- a/docs/provider-testing.md
+++ b/docs/provider-testing.md
@@ -1,102 +1,109 @@
 # Provider Testing Guide for Lobster
 
-Lobster supports multiple content providers via the `--provider` flag or the `provider` setting in `config.toml`. This document outlines how to test each provider to ensure they are working correctly.
+Lobster selects the content provider via the `base` setting in `config.toml` or the `--base` CLI flag. This document outlines how to test each provider.
 
 ## 1. Verify Provider Configuration
 
 1. **Check the configuration file**  
    - **Linux/macOS**: `~/.config/lobster/config.toml`  
-   - **Windows**: `%APPDATA%\\lobster\\config.toml`  
+   - **Windows**: `%APPDATA%\lobster\config.toml`  
 
-   Ensure the `provider` key is set to the desired provider name, e.g.:
+   Set the `base` key to the desired provider, e.g.:
 
    ```toml
-   provider = "moviebox"
+   base = "flixhq.ws"
    ```
 
-2. **List available providers** (for reference)  
-   The default providers are:
-   - `moviebox`
-   - `flixhq.to`
-   - `flixhq.ws`
-   - `soap2day`
-   - `kimcartoon`
-   - (others are fallback providers)
+2. **Available providers**  
+   - `flixhq.ws` (default) — browsing, trending, metadata
+   - `soap2day` — streaming via TMDB + moviesapi
+   - `tbcpl` / `1shows.org` — streaming via Vidzee
+   - `moviebox` — MovieBox V3 mobile API
+   - `flixhq.to` — legacy FlixHQ scraper
+   - `kimcartoon.com.co` — cartoons/anime
+
+   All other providers are automatically used as fallbacks when the primary fails.
 
 ## 2. Test Provider via CLI
 
-Run the binary with the `--provider` flag to force a specific provider, regardless of config.
+Use the `--base` flag to force a specific provider:
 
 ### Example commands
 
 ```bash
-# Test moviebox (default)
-./lobster --provider moviebox trending
+# Test with FlixHQ.ws (default)
+lobster --base flixhq.ws trending
 
-# Test FlixHQ (web)
-./lobster --provider flixhq.to trending
+# Test with Soap2Day
+lobster --base soap2day "Inception"
 
-# Test FlixHQ WS (WebSocket)
-./lobster --provider flixhq.ws trending
+# Test with TBCPL
+lobster --base tbcpl "Inception"
 
-# Test KimCartoon
-./lobster --provider kimcartoon trending
-
-# Test Soap2Day
-./lobster --provider soap2day trending
+# Test with KimCartoon
+lobster --base kimcartoon.com.co "SpongeBob"
 ```
 
 ### Expected output
 
-- **Successful provider**: The command should return a list of trending titles, then allow you to select and play a title using mpv, VLC, etc.
-- **Error handling**: If the provider fails, you should see an error message indicating the provider name and the failure reason (e.g., network error, parsing error).
+- **Successful provider**: Returns results, then allows you to select and play.
+- **Error handling**: If the provider fails, fallback providers are tried automatically.
 
 ## 3. Validate Provider Functionality
 
-For each provider, verify the following aspects:
+For each provider, verify:
 
 | Aspect | How to Test | Success Criteria |
 |--------|-------------|------------------|
-| **Search** | `./lobster --provider <name> search "Inception"` | Returns search results matching the query. |
-| **Streaming** | `./lobster --provider <name> play "Inception"` (or use the UI to select) | Video streams without errors; playback controls work. |
-| **Subtitle matching** | `./lobster --provider <name> search "Inception" --language english` | Correct subtitle file is downloaded and synced. |
-| **Download** | `./lobster --provider <name> download "Inception" --quality 720p` | Download completes, file saved to `download_dir`. |
-| **Episode navigation** | Use UI to go to next/previous episode after selecting a series | Episode list updates correctly; navigation works. |
-| **Resume support** | Start playback, stop, then run with `--continue` | Playback resumes from the last position. |
+| **Search** | `lobster --base <name> "Inception"` | Returns search results matching the query. |
+| **Streaming** | Select a result and press Enter | Video streams without errors. |
+| **Subtitles** | `lobster -l english "Inception"` | Subtitle file downloaded and loaded in player. |
+| **Download** | `lobster -d ~/Videos "Inception"` | Download completes, file saved. |
+| **Episode navigation** | Select a series, play an episode, then use next/prev | Episode list works; navigation works. |
+| **Resume support** | Start playback, stop, then `lobster -c` | Playback resumes from last position. |
 
 ## 4. Check Logs & Errors
 
-- **Verbose mode**: Add `-v` or `--debug` flag to see detailed logs.
-- **Log files**: Errors may also be written to `~/.config/lobster/logs/` (Linux/macOS) or `%LOCALAPPDATA%\\lobster\\logs\` (Windows).
+- **Debug mode**: Add `-x` flag to see detailed logs.
+
+```bash
+lobster -x "Inception"
+```
+
+Debug output shows which provider is selected, which fallbacks are tried, and subtitle resolution.
 
 ## 5. Common Issues & Fixes
 
 | Symptom | Likely Cause | Fix |
 |---------|--------------|-----|
-| "Provider not found" | Provider name typo or not compiled in | Verify provider name matches one of the listed names; rebuild if you added a new provider. |
-| No results returned | Provider API changed or rate‑limited | Check provider status page; add a delay or retry logic (already handled in code). |
-| Download fails | `ffmpeg` not in PATH or permission issue | Ensure `ffmpeg` is installed and accessible; verify write permission to `download_dir`. |
-| Subtitles missing | Language not supported by provider | Verify provider supports the requested language; check provider docs. |
-| Player not launching | Player binary missing or not in PATH | Install required player (mpv, vlc, iina, celluloid) and ensure it's in your system PATH. |
+| No results returned | Provider API changed or rate-limited | Try a different `--base`; fallbacks will be tried automatically. |
+| Download fails | `ffmpeg` not in PATH | Install ffmpeg and ensure it's in your PATH. |
+| Subtitles missing | SubDL API key not configured | Default key is bundled; check debug output with `-x`. |
+| Player not launching | Player binary missing | Install mpv, vlc, iina, or celluloid. |
+| Stream URL expired | Subtitle downloads took too long | Subtitles are capped at 3 to reduce delay. |
 
-## 6. Automated Provider Tests (Optional)
+## 6. Automated Provider Tests
 
-If you want to add CI checks:
+```bash
+# Run all tests including provider tests
+go test ./... -count=1
 
-1. **Create integration tests** in `internal/provider/` using the existing `*_test.go` files as templates.
-2. **Run `make test`** to execute all tests, including provider-specific tests.
-3. **Add a GitHub Actions workflow** that runs `make test` on each push.
+# Run only provider tests
+go test ./internal/provider/ -v -count=1
+```
+
+Provider tests use httptest servers with mocked responses and don't hit real APIs.
 
 ## 7. FAQ
 
 **Q: How do I know which provider is being used?**  
-A: The CLI prints the selected provider at startup (debug mode) and logs the provider name when a request is made.
+A: Run with `-x` (debug mode). It prints the selected provider and all fallback attempts.
 
 **Q: Can I test multiple providers in one session?**  
-A: Yes, you can switch providers on the fly using the `--provider` flag or by editing `config.toml` and restarting the CLI.
+A: Use the TUI (run `lobster` with no args) — categories like Movies, Series, Cartoons use different providers. Or switch with `--base` on the CLI.
 
 **Q: What if a provider is down?**  
-A: Lobster automatically falls back to the next provider in the list (as defined in the code). You can also force a fallback by setting `fallback = true` in `config.toml`.
+A: Lobster automatically falls back to the next provider in the chain: Soap2Day → MovieBox → TBCPL → FlixHQWS → FlixHQ → KimCartoon.
 
 ---
 

--- a/docs/provider-testing.md
+++ b/docs/provider-testing.md
@@ -1,0 +1,103 @@
+# Provider Testing Guide for Lobster
+
+Lobster supports multiple content providers via the `--provider` flag or the `provider` setting in `config.toml`. This document outlines how to test each provider to ensure they are working correctly.
+
+## 1. Verify Provider Configuration
+
+1. **Check the configuration file**  
+   - **Linux/macOS**: `~/.config/lobster/config.toml`  
+   - **Windows**: `%APPDATA%\\lobster\\config.toml`  
+
+   Ensure the `provider` key is set to the desired provider name, e.g.:
+
+   ```toml
+   provider = "moviebox"
+   ```
+
+2. **List available providers** (for reference)  
+   The default providers are:
+   - `moviebox`
+   - `flixhq.to`
+   - `flixhq.ws`
+   - `soap2day`
+   - `kimcartoon`
+   - (others are fallback providers)
+
+## 2. Test Provider via CLI
+
+Run the binary with the `--provider` flag to force a specific provider, regardless of config.
+
+### Example commands
+
+```bash
+# Test moviebox (default)
+./lobster --provider moviebox trending
+
+# Test FlixHQ (web)
+./lobster --provider flixhq.to trending
+
+# Test FlixHQ WS (WebSocket)
+./lobster --provider flixhq.ws trending
+
+# Test KimCartoon
+./lobster --provider kimcartoon trending
+
+# Test Soap2Day
+./lobster --provider soap2day trending
+```
+
+### Expected output
+
+- **Successful provider**: The command should return a list of trending titles, then allow you to select and play a title using mpv, VLC, etc.
+- **Error handling**: If the provider fails, you should see an error message indicating the provider name and the failure reason (e.g., network error, parsing error).
+
+## 3. Validate Provider Functionality
+
+For each provider, verify the following aspects:
+
+| Aspect | How to Test | Success Criteria |
+|--------|-------------|------------------|
+| **Search** | `./lobster --provider <name> search "Inception"` | Returns search results matching the query. |
+| **Streaming** | `./lobster --provider <name> play "Inception"` (or use the UI to select) | Video streams without errors; playback controls work. |
+| **Subtitle matching** | `./lobster --provider <name> search "Inception" --language english` | Correct subtitle file is downloaded and synced. |
+| **Download** | `./lobster --provider <name> download "Inception" --quality 720p` | Download completes, file saved to `download_dir`. |
+| **Episode navigation** | Use UI to go to next/previous episode after selecting a series | Episode list updates correctly; navigation works. |
+| **Resume support** | Start playback, stop, then run with `--continue` | Playback resumes from the last position. |
+
+## 4. Check Logs & Errors
+
+- **Verbose mode**: Add `-v` or `--debug` flag to see detailed logs.
+- **Log files**: Errors may also be written to `~/.config/lobster/logs/` (Linux/macOS) or `%LOCALAPPDATA%\\lobster\\logs\` (Windows).
+
+## 5. Common Issues & Fixes
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| "Provider not found" | Provider name typo or not compiled in | Verify provider name matches one of the listed names; rebuild if you added a new provider. |
+| No results returned | Provider API changed or rate‑limited | Check provider status page; add a delay or retry logic (already handled in code). |
+| Download fails | `ffmpeg` not in PATH or permission issue | Ensure `ffmpeg` is installed and accessible; verify write permission to `download_dir`. |
+| Subtitles missing | Language not supported by provider | Verify provider supports the requested language; check provider docs. |
+| Player not launching | Player binary missing or not in PATH | Install required player (mpv, vlc, iina, celluloid) and ensure it's in your system PATH. |
+
+## 6. Automated Provider Tests (Optional)
+
+If you want to add CI checks:
+
+1. **Create integration tests** in `internal/provider/` using the existing `*_test.go` files as templates.
+2. **Run `make test`** to execute all tests, including provider-specific tests.
+3. **Add a GitHub Actions workflow** that runs `make test` on each push.
+
+## 7. FAQ
+
+**Q: How do I know which provider is being used?**  
+A: The CLI prints the selected provider at startup (debug mode) and logs the provider name when a request is made.
+
+**Q: Can I test multiple providers in one session?**  
+A: Yes, you can switch providers on the fly using the `--provider` flag or by editing `config.toml` and restarting the CLI.
+
+**Q: What if a provider is down?**  
+A: Lobster automatically falls back to the next provider in the list (as defined in the code). You can also force a fallback by setting `fallback = true` in `config.toml`.
+
+---
+
+*Keep this guide updated as new providers are added or existing ones change their APIs.*

--- a/internal/provider/kimcartoon.go
+++ b/internal/provider/kimcartoon.go
@@ -22,11 +22,34 @@ type KimCartoon struct {
 	client *http.Client
 }
 
+const kimCartoonDefaultBase = "kimcartoon.com.co"
+
 // NewKimCartoon creates a new KimCartoon provider.
 func NewKimCartoon(base string) *KimCartoon {
 	return &KimCartoon{
-		base:   base,
+		base:   normalizeKimCartoonBase(base),
 		client: httputil.NewClient(),
+	}
+}
+
+func normalizeKimCartoonBase(base string) string {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return kimCartoonDefaultBase
+	}
+
+	base = strings.TrimRight(base, "/")
+	if strings.Contains(base, "://") {
+		if u, err := url.Parse(base); err == nil && u.Host != "" {
+			base = u.Host
+		}
+	}
+
+	switch strings.ToLower(base) {
+	case "kimcartoon", "kimcartoon.li", "www.kimcartoon.li", "kimcartoon.com.co", "www.kimcartoon.com.co":
+		return kimCartoonDefaultBase
+	default:
+		return base
 	}
 }
 
@@ -65,38 +88,77 @@ func (k *KimCartoon) Search(query string) ([]media.SearchResult, error) {
 // parseKCSearchResults extracts search results from a kimcartoon search page.
 func parseKCSearchResults(doc *goquery.Document) []media.SearchResult {
 	var results []media.SearchResult
+	seen := make(map[string]bool)
 
-	doc.Find("article.bs div.bsx a[itemprop='url']").Each(func(_ int, s *goquery.Selection) {
-		href, exists := s.Attr("href")
-		if !exists {
-			return
-		}
-
-		title := strings.TrimSpace(s.AttrOr("title", ""))
-		if title == "" {
-			title = strings.TrimSpace(s.Find(".ttzz").Text())
-		}
-
-		id := extractKCID(href)
-		if id == "" {
-			return
-		}
-
-		year := ""
-		if m := kcYearRe.FindStringSubmatch(title); len(m) > 1 {
-			year = m[1]
-		}
-
-		results = append(results, media.SearchResult{
-			ID:    id,
-			Title: title,
-			Type:  media.TV, // Cartoons are episodic
-			Year:  year,
-			URL:   href,
+	addLinks := func(scope *goquery.Selection, selector string) {
+		scope.Find(selector).Each(func(_ int, s *goquery.Selection) {
+			result, ok := parseKCResultLink(s)
+			if !ok {
+				return
+			}
+			if seen[result.ID] {
+				return
+			}
+			seen[result.ID] = true
+			results = append(results, result)
 		})
-	})
+	}
+
+	mainList := doc.Find(".postbody .bixbox .listupd")
+	if mainList.Length() > 0 {
+		addLinks(mainList, "article.bs div.bsx a[itemprop='url'], article.bs div.bsx a.tip[href], a.series[href]")
+		return results
+	}
+
+	addLinks(doc.Selection, "article.bs div.bsx a[itemprop='url'], article.bs div.bsx a.tip[href]")
+	addLinks(doc.Selection, "#wpop-items .serieslist a.series[href], .serieslist.pop a.series[href]")
 
 	return results
+}
+
+func parseKCResultLink(s *goquery.Selection) (media.SearchResult, bool) {
+	href, exists := s.Attr("href")
+	if !exists {
+		return media.SearchResult{}, false
+	}
+
+	title := strings.TrimSpace(s.AttrOr("title", ""))
+	if title == "" {
+		title = strings.TrimSpace(s.Find(".ttzz").Text())
+	}
+	if title == "" {
+		title = strings.TrimSpace(s.Text())
+	}
+	if title == "" {
+		title = strings.TrimSpace(s.Find("img").AttrOr("alt", ""))
+	}
+	if title == "" {
+		title = strings.TrimSpace(s.Find("img").AttrOr("title", ""))
+	}
+	if title == "" {
+		title = strings.TrimSpace(s.Closest("li").Find(".leftseries a.series").First().Text())
+	}
+	if title == "" {
+		return media.SearchResult{}, false
+	}
+
+	id := extractKCID(href)
+	if id == "" {
+		return media.SearchResult{}, false
+	}
+
+	year := ""
+	if m := kcYearRe.FindStringSubmatch(title); len(m) > 1 {
+		year = m[1]
+	}
+
+	return media.SearchResult{
+		ID:    id,
+		Title: title,
+		Type:  media.TV, // Cartoons are episodic
+		Year:  year,
+		URL:   href,
+	}, true
 }
 
 var kcYearRe = regexp.MustCompile(`\((\d{4})\)`)

--- a/internal/provider/kimcartoon.go
+++ b/internal/provider/kimcartoon.go
@@ -39,10 +39,11 @@ func normalizeKimCartoonBase(base string) string {
 	}
 
 	base = strings.TrimRight(base, "/")
-	if strings.Contains(base, "://") {
-		if u, err := url.Parse(base); err == nil && u.Host != "" {
-			base = u.Host
-		}
+	if !strings.Contains(base, "://") {
+		base = "https://" + base
+	}
+	if u, err := url.Parse(base); err == nil && u.Host != "" {
+		base = u.Host
 	}
 
 	switch strings.ToLower(base) {

--- a/internal/provider/kimcartoon_test.go
+++ b/internal/provider/kimcartoon_test.go
@@ -1,0 +1,140 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestNewKimCartoonNormalizesDeadAndURLBases(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		want string
+	}{
+		{name: "empty", base: "", want: kimCartoonDefaultBase},
+		{name: "old host", base: "kimcartoon.li", want: kimCartoonDefaultBase},
+		{name: "old www host", base: "www.kimcartoon.li", want: kimCartoonDefaultBase},
+		{name: "current url", base: "https://kimcartoon.com.co/", want: kimCartoonDefaultBase},
+		{name: "current www url", base: "https://www.kimcartoon.com.co/", want: kimCartoonDefaultBase},
+		{name: "custom host", base: "mirror.example", want: "mirror.example"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewKimCartoon(tt.base).base
+			if got != tt.want {
+				t.Fatalf("base = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseKCSearchResultsCurrentSearchMarkup(t *testing.T) {
+	doc := kimCartoonDoc(t, `
+		<div class="postbody">
+			<div class="bixbox">
+				<div class="releases"><h1><span>Search 'rick and morty'</span></h1></div>
+				<div class="listupd">
+					<article class="bs styletwo">
+						<div class="bsx">
+							<a href="https://kimcartoon.com.co/cartoon/rick-and-morty-season-9-2026/" itemprop="url" title="Rick and Morty Season 9 (2026)" class="tip" rel="25081">
+								<div class="ttzz">Rick and Morty Season 9 (2026)</div>
+							</a>
+						</div>
+					</article>
+					<article class="bs styletwo">
+						<div class="bsx">
+							<a href="https://kimcartoon.com.co/cartoon/rick-and-morty-season-8-2025/" itemprop="url" title="Rick and Morty Season 8 (2025)" class="tip" rel="23832">
+								<div class="ttzz">Rick and Morty Season 8 (2025)</div>
+							</a>
+						</div>
+					</article>
+				</div>
+			</div>
+		</div>
+		<div id="sidebar">
+			<div class="serieslist pop">
+				<a class="series" href="https://kimcartoon.com.co/cartoon/unrelated/">Unrelated Trending</a>
+			</div>
+		</div>
+	`)
+
+	results := parseKCSearchResults(doc)
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2: %+v", len(results), results)
+	}
+	if results[0].ID != "cartoon/rick-and-morty-season-9-2026" {
+		t.Fatalf("first ID = %q", results[0].ID)
+	}
+	if results[0].Title != "Rick and Morty Season 9 (2026)" {
+		t.Fatalf("first title = %q", results[0].Title)
+	}
+	if results[0].Year != "2026" {
+		t.Fatalf("first year = %q", results[0].Year)
+	}
+}
+
+func TestParseKCSearchResultsCurrentTrendingMarkup(t *testing.T) {
+	doc := kimCartoonDoc(t, `
+		<div id="wpop-items">
+			<div class="serieslist pop wpop wpop-weekly">
+				<ul>
+					<li>
+						<div class="imgseries">
+							<a class="series" href="https://kimcartoon.com.co/cartoon/regular-show-the-lost-tapes-2026/" rel="25037">
+								<img alt="Regular Show: The Lost Tapes (2026)">
+							</a>
+						</div>
+						<div class="leftseries">
+							<h4>
+								<a class="series" href="https://kimcartoon.com.co/cartoon/regular-show-the-lost-tapes-2026/" rel="25037">Regular Show: The Lost Tapes (2026)</a>
+							</h4>
+						</div>
+					</li>
+				</ul>
+			</div>
+		</div>
+	`)
+
+	results := parseKCSearchResults(doc)
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1: %+v", len(results), results)
+	}
+	if results[0].ID != "cartoon/regular-show-the-lost-tapes-2026" {
+		t.Fatalf("ID = %q", results[0].ID)
+	}
+	if results[0].Title != "Regular Show: The Lost Tapes (2026)" {
+		t.Fatalf("title = %q", results[0].Title)
+	}
+}
+
+func TestParseKCSearchResultsOldMarkupStillWorks(t *testing.T) {
+	doc := kimCartoonDoc(t, `
+		<article class="bs styletwo">
+			<div class="bsx">
+				<a href="https://kimcartoon.com.co/cartoon/south-park-season-28-2025/" itemprop="url" title="South Park Season 28 (2025)">
+					<div class="ttzz">South Park Season 28 (2025)</div>
+				</a>
+			</div>
+		</article>
+	`)
+
+	results := parseKCSearchResults(doc)
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].ID != "cartoon/south-park-season-28-2025" {
+		t.Fatalf("ID = %q", results[0].ID)
+	}
+}
+
+func kimCartoonDoc(t *testing.T, html string) *goquery.Document {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parsing HTML: %v", err)
+	}
+	return doc
+}

--- a/internal/provider/tbcpl.go
+++ b/internal/provider/tbcpl.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"lobster/internal/httputil"
 	"lobster/internal/media"
@@ -46,7 +47,7 @@ type TBCPL struct {
 func NewTBCPL(base string) *TBCPL {
 	return &TBCPL{
 		base:          normalizeTBCPLBase(base),
-		client:        httputil.NewClient(),
+		client:        &http.Client{Timeout: 15 * time.Second, Transport: httputil.NewClient().Transport},
 		tmdbBaseURL:   tbcplTMDBBase,
 		vidzeeBaseURL: tbcplVidzeeBase,
 		vidzeeKeyURL:  tbcplVidzeeKeyURL,

--- a/internal/provider/tbcpl.go
+++ b/internal/provider/tbcpl.go
@@ -428,10 +428,10 @@ func (t *TBCPL) watchWithServer(mediaID, episodeID string, server tbcplDirectSer
 		return nil, fmt.Errorf("parsing Vidzee response: %w", err)
 	}
 	if resp.Error != "" {
-		return nil, fmt.Errorf("Vidzee %s: %s", server.Name, resp.Error)
+		return nil, fmt.Errorf("vidzee %s: %s", server.Name, resp.Error)
 	}
 	if len(resp.URL) == 0 {
-		return nil, fmt.Errorf("Vidzee %s returned no URLs", server.Name)
+		return nil, fmt.Errorf("vidzee %s returned no URLs", server.Name)
 	}
 
 	key, err := t.fetchVidzeeKey()
@@ -453,7 +453,7 @@ func (t *TBCPL) watchWithServer(mediaID, episodeID string, server tbcplDirectSer
 		}, nil
 	}
 
-	return nil, fmt.Errorf("Vidzee %s returned no decryptable stream URLs", server.Name)
+	return nil, fmt.Errorf("vidzee %s returned no decryptable stream URLs", server.Name)
 }
 
 type tbcplVidzeeResponse struct {
@@ -703,6 +703,10 @@ func decryptTBCPLVidzeeLink(encrypted, key string) (string, error) {
 	}
 	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
 		return "", fmt.Errorf("invalid ciphertext length")
+	}
+
+	if len(iv) != aes.BlockSize {
+		return "", fmt.Errorf("invalid iv length")
 	}
 
 	block, err := aes.NewCipher(aesKey)

--- a/internal/provider/tbcpl.go
+++ b/internal/provider/tbcpl.go
@@ -1,0 +1,735 @@
+package provider
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+const (
+	tbcplDefaultBase     = "https://www.1shows.org"
+	tbcplTMDBBase        = "https://www.themoviedb.org"
+	tbcplVidzeeBase      = "https://player.vidzee.wtf"
+	tbcplVidzeeKeyURL    = "https://core.vidzee.wtf/api-key"
+	tbcplVidzeeKeySecret = "c4a8f1d7e2b9a6c3d0f5e8a1b7c4d9e2"
+	tbcplMaxSeasons      = 30
+)
+
+// TBCPL bridges the TBCPL index to the currently working 1Shows catalog and
+// Vidzee stream API. TBCPL itself is an index of sources, not a direct media API.
+type TBCPL struct {
+	base          string
+	client        *http.Client
+	tmdbBaseURL   string
+	vidzeeBaseURL string
+	vidzeeKeyURL  string
+
+	mu          sync.RWMutex
+	searchCache map[string]tbcplCatalogItem
+	seasonCache map[string]*tbcplSeasonResponse
+	vidzeeKey   string
+}
+
+// NewTBCPL creates a new TBCPL provider.
+func NewTBCPL(base string) *TBCPL {
+	return &TBCPL{
+		base:          normalizeTBCPLBase(base),
+		client:        httputil.NewClient(),
+		tmdbBaseURL:   tbcplTMDBBase,
+		vidzeeBaseURL: tbcplVidzeeBase,
+		vidzeeKeyURL:  tbcplVidzeeKeyURL,
+		searchCache:   make(map[string]tbcplCatalogItem),
+		seasonCache:   make(map[string]*tbcplSeasonResponse),
+	}
+}
+
+func normalizeTBCPLBase(base string) string {
+	base = strings.TrimSpace(strings.TrimRight(base, "/"))
+	lower := strings.ToLower(base)
+	if base == "" || lower == "tbcpl" || strings.Contains(lower, "tbcpl") {
+		return tbcplDefaultBase
+	}
+	if !strings.Contains(base, "://") {
+		base = "https://" + base
+	}
+	return strings.TrimRight(base, "/")
+}
+
+func (t *TBCPL) baseURL() string {
+	return strings.TrimRight(t.base, "/")
+}
+
+type tbcplSearchResponse struct {
+	Results []json.RawMessage `json:"results"`
+}
+
+type tbcplCatalogItem struct {
+	ID           int     `json:"id"`
+	Title        string  `json:"title"`
+	Name         string  `json:"name"`
+	MediaType    string  `json:"media_type"`
+	Overview     string  `json:"overview"`
+	ReleaseDate  string  `json:"release_date"`
+	FirstAirDate string  `json:"first_air_date"`
+	VoteAverage  float64 `json:"vote_average"`
+}
+
+func (i tbcplCatalogItem) displayTitle() string {
+	if i.Name != "" {
+		return i.Name
+	}
+	return i.Title
+}
+
+func (i tbcplCatalogItem) year() string {
+	date := i.ReleaseDate
+	if date == "" {
+		date = i.FirstAirDate
+	}
+	if len(date) >= 4 {
+		return date[:4]
+	}
+	return ""
+}
+
+func (i tbcplCatalogItem) released() string {
+	if i.ReleaseDate != "" {
+		return i.ReleaseDate
+	}
+	return i.FirstAirDate
+}
+
+type tbcplSeasonResponse struct {
+	Name         string         `json:"name"`
+	SeasonNumber int            `json:"season_number"`
+	Episodes     []tbcplEpisode `json:"episodes"`
+}
+
+type tbcplEpisode struct {
+	EpisodeNumber int    `json:"episode_number"`
+	SeasonNumber  int    `json:"season_number"`
+	Name          string `json:"name"`
+	Overview      string `json:"overview"`
+	Runtime       int    `json:"runtime"`
+}
+
+type tbcplDirectServer struct {
+	Name string
+	SR   string
+}
+
+var tbcplDirectServers = []tbcplDirectServer{
+	{Name: "Togi", SR: "0"},
+	{Name: "Achilles", SR: "3"},
+	{Name: "Nflix", SR: "4"},
+	{Name: "Drag", SR: "5"},
+}
+
+// Search uses TMDB's no-key web search endpoint for reliable title lookup.
+// The returned TMDB IDs are then used by 1Shows/Vidzee.
+func (t *TBCPL) Search(query string) ([]media.SearchResult, error) {
+	searchURL := fmt.Sprintf("%s/search/trending?query=%s",
+		strings.TrimRight(t.tmdbBaseURL, "/"), url.QueryEscape(query))
+
+	body, err := t.fetch(searchURL, strings.TrimRight(t.tmdbBaseURL, "/")+"/", "application/json, text/html, */*")
+	if err != nil {
+		return nil, fmt.Errorf("tbcpl search: %w", err)
+	}
+
+	results, err := t.parseCatalogResponse(body, "")
+	if err != nil {
+		return nil, fmt.Errorf("tbcpl search: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found for %q", query)
+	}
+	return results, nil
+}
+
+// GetDetails returns cached metadata from search/trending results. 1Shows detail
+// endpoints currently reject direct server-side requests, so this is best-effort.
+func (t *TBCPL) GetDetails(id string) (*media.ContentDetail, error) {
+	t.mu.RLock()
+	item, ok := t.searchCache[id]
+	t.mu.RUnlock()
+	if !ok {
+		return &media.ContentDetail{}, nil
+	}
+
+	return &media.ContentDetail{
+		Description: item.Overview,
+		Rating:      formatTBCPLRating(item.VoteAverage),
+		Released:    item.released(),
+	}, nil
+}
+
+// GetSeasons returns available TV seasons by probing 1Shows' season API.
+func (t *TBCPL) GetSeasons(id string) ([]media.Season, error) {
+	tmdbID := extractTMDBID(id)
+	if err := httputil.ValidateNumericID(tmdbID); err != nil {
+		return nil, err
+	}
+
+	var seasons []media.Season
+	for season := 1; season <= tbcplMaxSeasons; season++ {
+		resp, err := t.fetchSeason(tmdbID, season)
+		if err != nil {
+			if season == 1 {
+				return nil, fmt.Errorf("getting seasons: %w", err)
+			}
+			break
+		}
+		if len(resp.Episodes) == 0 {
+			break
+		}
+
+		number := resp.SeasonNumber
+		if number == 0 {
+			number = season
+		}
+		seasons = append(seasons, media.Season{
+			Number: number,
+			ID:     fmt.Sprintf("%s:%d", tmdbID, number),
+		})
+	}
+
+	if len(seasons) == 0 {
+		return nil, fmt.Errorf("no seasons found")
+	}
+	return seasons, nil
+}
+
+// GetEpisodes returns episodes for a TV season from 1Shows' season API.
+func (t *TBCPL) GetEpisodes(id string, seasonID string) ([]media.Episode, error) {
+	tmdbID, season, err := parseTBCPLSeasonID(id, seasonID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := t.fetchSeason(tmdbID, season)
+	if err != nil {
+		return nil, fmt.Errorf("getting episodes: %w", err)
+	}
+
+	episodes := make([]media.Episode, 0, len(resp.Episodes))
+	for _, ep := range resp.Episodes {
+		seasonNum := ep.SeasonNumber
+		if seasonNum == 0 {
+			seasonNum = season
+		}
+		if ep.EpisodeNumber <= 0 {
+			continue
+		}
+		episodes = append(episodes, media.Episode{
+			Number: ep.EpisodeNumber,
+			Title:  ep.Name,
+			ID:     fmt.Sprintf("%s:%d:%d", tmdbID, seasonNum, ep.EpisodeNumber),
+		})
+	}
+	if len(episodes) == 0 {
+		return nil, fmt.Errorf("no episodes found")
+	}
+	return episodes, nil
+}
+
+// GetServers returns direct Vidzee server choices. Watch performs the actual
+// stream resolution and decryption.
+func (t *TBCPL) GetServers(id string, episodeID string) ([]media.Server, error) {
+	servers := make([]media.Server, 0, len(tbcplDirectServers))
+	for _, srv := range tbcplDirectServers {
+		servers = append(servers, media.Server{
+			Name: srv.Name,
+			ID:   "vidzee:" + srv.SR,
+		})
+	}
+	return servers, nil
+}
+
+// GetEmbedURL supports callers that treat server IDs as public embed URLs.
+// TBCPL's direct Vidzee servers must use Watch instead.
+func (t *TBCPL) GetEmbedURL(serverID string) (string, error) {
+	if strings.HasPrefix(serverID, "https://") {
+		return serverID, nil
+	}
+	return "", fmt.Errorf("use Watch for TBCPL server %q", serverID)
+}
+
+// Trending returns 1Shows trending titles for the requested media type.
+func (t *TBCPL) Trending(mediaType media.MediaType) ([]media.SearchResult, error) {
+	mt := "movie"
+	if mediaType == media.TV {
+		mt = "tv"
+	}
+	apiURL := fmt.Sprintf("%s/api/trending/%s/day", t.baseURL(), mt)
+	body, err := t.fetch(apiURL, t.baseURL()+"/", "application/json, */*")
+	if err != nil {
+		return nil, fmt.Errorf("tbcpl trending: %w", err)
+	}
+	return t.parseCatalogResponse(body, mt)
+}
+
+// Recent returns recent-ish content using the 1Shows weekly trending endpoint.
+func (t *TBCPL) Recent(mediaType media.MediaType) ([]media.SearchResult, error) {
+	mt := "movie"
+	if mediaType == media.TV {
+		mt = "tv"
+	}
+	apiURL := fmt.Sprintf("%s/api/trending/%s/week", t.baseURL(), mt)
+	body, err := t.fetch(apiURL, t.baseURL()+"/", "application/json, */*")
+	if err != nil {
+		return t.Trending(mediaType)
+	}
+	return t.parseCatalogResponse(body, mt)
+}
+
+// Watch resolves a direct HLS stream through Vidzee's server API.
+func (t *TBCPL) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	candidates := tbcplDirectServers
+	if srv, ok := t.matchDirectServer(server); ok {
+		candidates = []tbcplDirectServer{srv}
+	}
+
+	var lastErr error
+	for _, srv := range candidates {
+		stream, err := t.watchWithServer(mediaID, episodeID, srv, quality)
+		if err == nil {
+			return stream, nil
+		}
+		lastErr = err
+	}
+
+	return nil, fmt.Errorf("tbcpl watch failed: %w", lastErr)
+}
+
+func (t *TBCPL) parseCatalogResponse(body []byte, fallbackMediaType string) ([]media.SearchResult, error) {
+	var resp tbcplSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	results := make([]media.SearchResult, 0, len(resp.Results))
+	for _, raw := range resp.Results {
+		if len(raw) == 0 || raw[0] != '{' {
+			continue
+		}
+
+		var item tbcplCatalogItem
+		if err := json.Unmarshal(raw, &item); err != nil {
+			continue
+		}
+		if item.ID == 0 {
+			continue
+		}
+		if item.MediaType == "" {
+			item.MediaType = fallbackMediaType
+		}
+		if item.MediaType != "movie" && item.MediaType != "tv" {
+			continue
+		}
+		title := item.displayTitle()
+		if title == "" {
+			continue
+		}
+
+		mt := media.Movie
+		if item.MediaType == "tv" {
+			mt = media.TV
+		}
+		id := fmt.Sprintf("%s/%d", item.MediaType, item.ID)
+		t.cacheCatalogItem(id, item)
+
+		results = append(results, media.SearchResult{
+			ID:    id,
+			Title: title,
+			Type:  mt,
+			Year:  item.year(),
+			URL:   fmt.Sprintf("%s/%s/%d", t.baseURL(), item.MediaType, item.ID),
+		})
+	}
+
+	return results, nil
+}
+
+func (t *TBCPL) cacheCatalogItem(id string, item tbcplCatalogItem) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.searchCache[id] = item
+}
+
+func (t *TBCPL) fetchSeason(tmdbID string, season int) (*tbcplSeasonResponse, error) {
+	key := fmt.Sprintf("%s:%d", tmdbID, season)
+
+	t.mu.RLock()
+	cached := t.seasonCache[key]
+	t.mu.RUnlock()
+	if cached != nil {
+		return cached, nil
+	}
+
+	apiURL := fmt.Sprintf("%s/api/tv/%s/season/%d", t.baseURL(), tmdbID, season)
+	body, err := t.fetch(apiURL, t.baseURL()+"/", "application/json, */*")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp tbcplSeasonResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing season response: %w", err)
+	}
+
+	t.mu.Lock()
+	t.seasonCache[key] = &resp
+	t.mu.Unlock()
+
+	return &resp, nil
+}
+
+func (t *TBCPL) watchWithServer(mediaID, episodeID string, server tbcplDirectServer, quality string) (*media.Stream, error) {
+	tmdbID := extractTMDBID(mediaID)
+	if err := httputil.ValidateNumericID(tmdbID); err != nil {
+		return nil, err
+	}
+
+	values := url.Values{}
+	values.Set("id", tmdbID)
+	values.Set("sr", server.SR)
+
+	if episodeID != "" {
+		epID, season, episode, err := parseTBCPLEpisodeID(mediaID, episodeID)
+		if err != nil {
+			return nil, err
+		}
+		values.Set("id", epID)
+		values.Set("ss", strconv.Itoa(season))
+		values.Set("ep", strconv.Itoa(episode))
+	}
+
+	apiURL := fmt.Sprintf("%s/api/server?%s", strings.TrimRight(t.vidzeeBaseURL, "/"), values.Encode())
+	body, err := t.fetch(apiURL, strings.TrimRight(t.vidzeeBaseURL, "/")+"/", "application/json, */*")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp tbcplVidzeeResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing Vidzee response: %w", err)
+	}
+	if resp.Error != "" {
+		return nil, fmt.Errorf("Vidzee %s: %s", server.Name, resp.Error)
+	}
+	if len(resp.URL) == 0 {
+		return nil, fmt.Errorf("Vidzee %s returned no URLs", server.Name)
+	}
+
+	key, err := t.fetchVidzeeKey()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, source := range resp.URL {
+		streamURL, err := decryptTBCPLVidzeeLink(source.Link, key)
+		if err != nil || streamURL == "" {
+			continue
+		}
+
+		return &media.Stream{
+			URL:       streamURL,
+			Quality:   quality,
+			Subtitles: mapTBCPLVidzeeTracks(resp.Tracks),
+			Referer:   strings.TrimRight(t.vidzeeBaseURL, "/") + "/",
+		}, nil
+	}
+
+	return nil, fmt.Errorf("Vidzee %s returned no decryptable stream URLs", server.Name)
+}
+
+type tbcplVidzeeResponse struct {
+	Error  string              `json:"error"`
+	URL    []tbcplVidzeeSource `json:"url"`
+	Tracks []tbcplVidzeeTrack  `json:"tracks"`
+}
+
+type tbcplVidzeeSource struct {
+	Lang string `json:"lang"`
+	Link string `json:"link"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+type tbcplVidzeeTrack struct {
+	Lang string `json:"lang"`
+	URL  string `json:"url"`
+}
+
+func mapTBCPLVidzeeTracks(tracks []tbcplVidzeeTrack) []media.Subtitle {
+	subs := make([]media.Subtitle, 0, len(tracks))
+	for _, tr := range tracks {
+		if tr.URL == "" {
+			continue
+		}
+		label := tr.Lang
+		if label == "" {
+			label = "Subtitle"
+		}
+		subs = append(subs, media.Subtitle{
+			Language: tr.Lang,
+			Label:    label,
+			URL:      tr.URL,
+		})
+	}
+	return subs
+}
+
+func (t *TBCPL) fetchVidzeeKey() (string, error) {
+	t.mu.RLock()
+	cached := t.vidzeeKey
+	t.mu.RUnlock()
+	if cached != "" {
+		return cached, nil
+	}
+
+	body, err := t.fetch(t.vidzeeKeyURL, strings.TrimRight(t.vidzeeBaseURL, "/")+"/", "text/plain, */*")
+	if err != nil {
+		return "", fmt.Errorf("fetching Vidzee key: %w", err)
+	}
+
+	key, err := decryptTBCPLVidzeeKey(strings.TrimSpace(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("decrypting Vidzee key: %w", err)
+	}
+
+	t.mu.Lock()
+	t.vidzeeKey = key
+	t.mu.Unlock()
+
+	return key, nil
+}
+
+func (t *TBCPL) matchDirectServer(server string) (tbcplDirectServer, bool) {
+	server = strings.TrimSpace(server)
+	if server == "" || strings.EqualFold(server, "default") {
+		return tbcplDirectServer{}, false
+	}
+	if strings.HasPrefix(strings.ToLower(server), "vidzee:") {
+		server = strings.TrimPrefix(strings.ToLower(server), "vidzee:")
+	}
+
+	for _, srv := range tbcplDirectServers {
+		if strings.EqualFold(server, srv.Name) || server == srv.SR {
+			return srv, true
+		}
+	}
+	return tbcplDirectServer{}, false
+}
+
+func (t *TBCPL) fetch(rawURL, referer, accept string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
+	req.Header.Set("Accept", accept)
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
+	if referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("status %d for %s", resp.StatusCode, rawURL)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	return body, nil
+}
+
+func parseTBCPLSeasonID(mediaID, seasonID string) (string, int, error) {
+	tmdbID := extractTMDBID(mediaID)
+	rawSeason := strings.TrimSpace(seasonID)
+	if rawSeason == "" {
+		rawSeason = "1"
+	}
+
+	if strings.Contains(rawSeason, ":") {
+		parts := strings.Split(rawSeason, ":")
+		if len(parts) >= 2 {
+			if parts[0] != "" {
+				tmdbID = parts[0]
+			}
+			rawSeason = parts[len(parts)-1]
+		}
+	}
+
+	if err := httputil.ValidateNumericID(tmdbID); err != nil {
+		return "", 0, err
+	}
+	season, err := strconv.Atoi(rawSeason)
+	if err != nil || season <= 0 {
+		return "", 0, fmt.Errorf("invalid season ID: %s", seasonID)
+	}
+	return tmdbID, season, nil
+}
+
+func parseTBCPLEpisodeID(mediaID, episodeID string) (string, int, int, error) {
+	tmdbID := extractTMDBID(mediaID)
+	raw := strings.TrimSpace(episodeID)
+	if raw == "" {
+		return "", 0, 0, fmt.Errorf("episode ID cannot be empty")
+	}
+
+	var seasonPart, episodePart string
+	switch {
+	case strings.Contains(raw, ":"):
+		parts := strings.Split(raw, ":")
+		if len(parts) < 3 {
+			return "", 0, 0, fmt.Errorf("invalid episode ID: %s", episodeID)
+		}
+		tmdbID = parts[0]
+		seasonPart = parts[len(parts)-2]
+		episodePart = parts[len(parts)-1]
+	case strings.Contains(raw, "."):
+		parts := strings.SplitN(raw, ".", 2)
+		seasonPart = parts[0]
+		episodePart = parts[1]
+	default:
+		seasonPart = "1"
+		episodePart = raw
+	}
+
+	if err := httputil.ValidateNumericID(tmdbID); err != nil {
+		return "", 0, 0, err
+	}
+	season, err := strconv.Atoi(seasonPart)
+	if err != nil || season <= 0 {
+		return "", 0, 0, fmt.Errorf("invalid season in episode ID: %s", episodeID)
+	}
+	episode, err := strconv.Atoi(episodePart)
+	if err != nil || episode <= 0 {
+		return "", 0, 0, fmt.Errorf("invalid episode in episode ID: %s", episodeID)
+	}
+	return tmdbID, season, episode, nil
+}
+
+func formatTBCPLRating(rating float64) string {
+	if rating <= 0 {
+		return ""
+	}
+	out := strconv.FormatFloat(rating, 'f', 1, 64)
+	return strings.TrimSuffix(out, ".0")
+}
+
+func decryptTBCPLVidzeeKey(encrypted string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) <= 28 {
+		return "", fmt.Errorf("encrypted key too short")
+	}
+
+	iv := raw[:12]
+	tag := raw[12:28]
+	ciphertext := raw[28:]
+	payload := append(append([]byte{}, ciphertext...), tag...)
+
+	key := sha256.Sum256([]byte(tbcplVidzeeKeySecret))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	plain, err := gcm.Open(nil, iv, payload, nil)
+	if err != nil {
+		return "", err
+	}
+	if len(plain) == 0 {
+		return "", fmt.Errorf("empty key")
+	}
+	return string(plain), nil
+}
+
+func decryptTBCPLVidzeeLink(encrypted, key string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(encrypted)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.SplitN(string(raw), ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid encrypted link")
+	}
+
+	iv, err := base64.StdEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", err
+	}
+
+	aesKey := []byte(key)
+	if len(aesKey) < 32 {
+		padded := make([]byte, 32)
+		copy(padded, aesKey)
+		aesKey = padded
+	}
+	if len(aesKey) != 16 && len(aesKey) != 24 && len(aesKey) != 32 {
+		return "", fmt.Errorf("invalid Vidzee link key length %d", len(aesKey))
+	}
+	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
+		return "", fmt.Errorf("invalid ciphertext length")
+	}
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return "", err
+	}
+	plain := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plain, ciphertext)
+
+	plain, err = pkcs7Unpad(plain, aes.BlockSize)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+func pkcs7Unpad(data []byte, blockSize int) ([]byte, error) {
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		return nil, fmt.Errorf("invalid padded data length")
+	}
+	padLen := int(data[len(data)-1])
+	if padLen == 0 || padLen > blockSize || padLen > len(data) {
+		return nil, fmt.Errorf("invalid padding")
+	}
+	for _, b := range data[len(data)-padLen:] {
+		if int(b) != padLen {
+			return nil, fmt.Errorf("invalid padding")
+		}
+	}
+	return data[:len(data)-padLen], nil
+}

--- a/internal/provider/tbcpl_test.go
+++ b/internal/provider/tbcpl_test.go
@@ -1,0 +1,248 @@
+package provider
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+func TestNewTBCPL(t *testing.T) {
+	p := NewTBCPL("tbcpl")
+	if p == nil {
+		t.Fatal("NewTBCPL returned nil")
+	}
+	if p.base != tbcplDefaultBase {
+		t.Errorf("expected TBCPL alias to normalize to %q, got %q", tbcplDefaultBase, p.base)
+	}
+
+	p = NewTBCPL("1shows.org")
+	if p.base != "https://1shows.org" {
+		t.Errorf("expected explicit host to get https scheme, got %q", p.base)
+	}
+}
+
+func TestTBCPLSearchAndDetails(t *testing.T) {
+	p, _, cleanup := newTestTBCPL(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/trending" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("query"); got != "breaking bad" {
+			t.Errorf("query = %q, want breaking bad", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"results": [
+				"breaking bad",
+				{
+					"id": 1396,
+					"name": "Breaking Bad",
+					"media_type": "tv",
+					"overview": "A chemistry teacher starts over.",
+					"first_air_date": "2008-01-20",
+					"vote_average": 8.9
+				},
+				{
+					"id": 299536,
+					"title": "Avengers: Infinity War",
+					"media_type": "movie",
+					"overview": "The Avengers face Thanos.",
+					"release_date": "2018-04-25",
+					"vote_average": 8.2
+				}
+			]
+		}`)
+	})
+	defer cleanup()
+
+	results, err := p.Search("breaking bad")
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].ID != "tv/1396" || results[0].Title != "Breaking Bad" || results[0].Type != media.TV || results[0].Year != "2008" {
+		t.Fatalf("unexpected first result: %+v", results[0])
+	}
+	if results[1].ID != "movie/299536" || results[1].Type != media.Movie || results[1].Year != "2018" {
+		t.Fatalf("unexpected second result: %+v", results[1])
+	}
+
+	details, err := p.GetDetails("tv/1396")
+	if err != nil {
+		t.Fatalf("GetDetails error: %v", err)
+	}
+	if details.Description != "A chemistry teacher starts over." {
+		t.Errorf("description = %q", details.Description)
+	}
+	if details.Rating != "8.9" {
+		t.Errorf("rating = %q, want 8.9", details.Rating)
+	}
+	if details.Released != "2008-01-20" {
+		t.Errorf("released = %q, want 2008-01-20", details.Released)
+	}
+}
+
+func TestTBCPLSeasonsAndEpisodes(t *testing.T) {
+	p, _, cleanup := newTestTBCPL(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tv/1399/season/1":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{
+				"name": "Season 1",
+				"season_number": 1,
+				"episodes": [
+					{"episode_number": 1, "season_number": 1, "name": "Winter Is Coming"},
+					{"episode_number": 2, "season_number": 1, "name": "The Kingsroad"}
+				]
+			}`)
+		case "/api/tv/1399/season/2":
+			http.Error(w, `{"error":"Forbidden: Not Allowed Gang"}`, http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	seasons, err := p.GetSeasons("tv/1399")
+	if err != nil {
+		t.Fatalf("GetSeasons error: %v", err)
+	}
+	if len(seasons) != 1 || seasons[0].Number != 1 || seasons[0].ID != "1399:1" {
+		t.Fatalf("unexpected seasons: %+v", seasons)
+	}
+
+	episodes, err := p.GetEpisodes("tv/1399", seasons[0].ID)
+	if err != nil {
+		t.Fatalf("GetEpisodes error: %v", err)
+	}
+	if len(episodes) != 2 {
+		t.Fatalf("len(episodes) = %d, want 2", len(episodes))
+	}
+	if episodes[1].Number != 2 || episodes[1].Title != "The Kingsroad" || episodes[1].ID != "1399:1:2" {
+		t.Fatalf("unexpected episode: %+v", episodes[1])
+	}
+}
+
+func TestTBCPLWatchMovie(t *testing.T) {
+	const streamURL = "https://cdn.example.test/movie/master.m3u8"
+	p, _, cleanup := newTestTBCPL(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/server" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("id"); got != "1122573" {
+			t.Errorf("id = %q, want 1122573", got)
+		}
+		if got := r.URL.Query().Get("sr"); got != "0" {
+			t.Errorf("sr = %q, want 0", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"url": [
+				{"lang": "English", "link": %q, "type": "hls", "name": "Togi"}
+			],
+			"tracks": [
+				{"lang": "English", "url": "https://subs.example.test/en.vtt"}
+			]
+		}`, encryptTBCPLVidzeeLinkForTest(t, streamURL, "test-key"))
+	})
+	defer cleanup()
+	p.vidzeeKey = "test-key"
+
+	stream, err := p.Watch("movie/1122573", "", "Togi", "1080")
+	if err != nil {
+		t.Fatalf("Watch error: %v", err)
+	}
+	if stream.URL != streamURL {
+		t.Errorf("stream.URL = %q, want %q", stream.URL, streamURL)
+	}
+	if stream.Referer != p.vidzeeBaseURL+"/" {
+		t.Errorf("referer = %q", stream.Referer)
+	}
+	if len(stream.Subtitles) != 1 || !strings.Contains(stream.Subtitles[0].URL, "en.vtt") {
+		t.Errorf("unexpected subtitles: %+v", stream.Subtitles)
+	}
+}
+
+func TestTBCPLWatchTV(t *testing.T) {
+	p, _, cleanup := newTestTBCPL(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/server" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("id"); got != "1399" {
+			t.Errorf("id = %q, want 1399", got)
+		}
+		if got := r.URL.Query().Get("ss"); got != "1" {
+			t.Errorf("ss = %q, want 1", got)
+		}
+		if got := r.URL.Query().Get("ep"); got != "2" {
+			t.Errorf("ep = %q, want 2", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"url":[{"link":%q}]}`, encryptTBCPLVidzeeLinkForTest(t, "https://cdn.example.test/tv/master.m3u8", "test-key"))
+	})
+	defer cleanup()
+	p.vidzeeKey = "test-key"
+
+	stream, err := p.Watch("tv/1399", "1399:1:2", "vidzee:0", "720")
+	if err != nil {
+		t.Fatalf("Watch error: %v", err)
+	}
+	if !strings.Contains(stream.URL, "/tv/") {
+		t.Errorf("unexpected stream URL: %q", stream.URL)
+	}
+}
+
+func newTestTBCPL(t *testing.T, handler http.HandlerFunc) (*TBCPL, *httptest.Server, func()) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	p := NewTBCPL(ts.URL)
+	p.client = ts.Client()
+	p.tmdbBaseURL = ts.URL
+	p.vidzeeBaseURL = ts.URL
+	p.vidzeeKeyURL = ts.URL + "/api-key"
+	return p, ts, ts.Close
+}
+
+func encryptTBCPLVidzeeLinkForTest(t *testing.T, plain, key string) string {
+	t.Helper()
+
+	aesKey := []byte(key)
+	if len(aesKey) < 32 {
+		padded := make([]byte, 32)
+		copy(padded, aesKey)
+		aesKey = padded
+	}
+
+	block, err := aes.NewCipher(aesKey)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	iv := []byte("1234567890abcdef")
+	padded := pkcs7PadForTest([]byte(plain), aes.BlockSize)
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	joined := base64.StdEncoding.EncodeToString(iv) + ":" + base64.StdEncoding.EncodeToString(ciphertext)
+	return base64.StdEncoding.EncodeToString([]byte(joined))
+}
+
+func pkcs7PadForTest(data []byte, blockSize int) []byte {
+	padLen := blockSize - len(data)%blockSize
+	out := make([]byte, len(data)+padLen)
+	copy(out, data)
+	for i := len(data); i < len(out); i++ {
+		out[i] = byte(padLen)
+	}
+	return out
+}

--- a/internal/subtitle/subdl.go
+++ b/internal/subtitle/subdl.go
@@ -123,6 +123,14 @@ func (s *SubDLClient) Search(title, language string, season, episode int) ([]med
 		if season > 0 && sub.Season > 0 && sub.Season != season {
 			continue
 		}
+		// Skip full-season packs (contain multiple episodes in one zip)
+		if episode > 0 && sub.FullSeason {
+			continue
+		}
+		// Check release name for wrong episode markers
+		if episode > 0 && isWrongEpisode(strings.ToLower(sub.ReleaseName), season, episode) {
+			continue
+		}
 		label := sub.Language
 		if sub.HI {
 			label += " (SDH)"

--- a/internal/subtitle/subdl.go
+++ b/internal/subtitle/subdl.go
@@ -184,7 +184,8 @@ func (s *SubDLClient) fetchAPI(params url.Values) (*subdlResponse, error) {
 }
 
 // DownloadAndExtract downloads a SubDL zip file and extracts the first SRT/VTT subtitle.
-func (s *SubDLClient) DownloadAndExtract(zipURL string, tmpDir *TempDir) (string, error) {
+// Season/episode are used to filter out wrong-episode files from multi-episode zips.
+func (s *SubDLClient) DownloadAndExtract(zipURL string, tmpDir *TempDir, season, episode int) (string, error) {
 	req, err := http.NewRequest("GET", zipURL, nil)
 	if err != nil {
 		return "", err
@@ -212,15 +213,20 @@ func (s *SubDLClient) DownloadAndExtract(zipURL string, tmpDir *TempDir) (string
 		return "", fmt.Errorf("opening zip: %w", err)
 	}
 
-	// Find first SRT or VTT file
+	// Find best SRT or VTT file, preferring one that matches the episode
 	var best *zip.File
 	for _, f := range reader.File {
 		ext := strings.ToLower(filepath.Ext(f.Name))
-		if ext == ".srt" || ext == ".vtt" || ext == ".ass" {
-			best = f
-			if ext == ".srt" {
-				break // prefer SRT
-			}
+		if ext != ".srt" && ext != ".vtt" && ext != ".ass" {
+			continue
+		}
+		// Skip files clearly for a different episode
+		if episode > 0 && isWrongEpisode(strings.ToLower(f.Name), season, episode) {
+			continue
+		}
+		best = f
+		if ext == ".srt" {
+			break // prefer SRT
 		}
 	}
 

--- a/internal/subtitle/subtitle.go
+++ b/internal/subtitle/subtitle.go
@@ -14,6 +14,56 @@ import (
 	"lobster/internal/media"
 )
 
+// FilterByEpisode removes subtitles that are clearly for a different episode
+// based on filename patterns like S01E03. Keeps subs with no episode marker.
+func FilterByEpisode(subtitles []media.Subtitle, season, episode int) []media.Subtitle {
+	if season == 0 && episode == 0 {
+		return subtitles
+	}
+
+	var filtered []media.Subtitle
+	for _, sub := range subtitles {
+		// Check URL and label for episode markers
+		text := strings.ToLower(sub.URL + " " + sub.Label)
+		if isWrongEpisode(text, season, episode) {
+			continue
+		}
+		filtered = append(filtered, sub)
+	}
+	return filtered
+}
+
+// isWrongEpisode checks if text contains an episode marker for a different episode.
+// Returns false (keep) if no marker is found.
+func isWrongEpisode(text string, season, episode int) bool {
+	// Match patterns: s01e02, S01E02, 1x02
+	patterns := []string{
+		fmt.Sprintf("s%02de", season),
+		fmt.Sprintf("s%de", season),
+		fmt.Sprintf("%dx", season),
+	}
+	for _, prefix := range patterns {
+		idx := strings.Index(text, prefix)
+		if idx < 0 {
+			continue
+		}
+		// Extract episode number after the prefix
+		rest := text[idx+len(prefix):]
+		epNum := 0
+		for _, c := range rest {
+			if c >= '0' && c <= '9' {
+				epNum = epNum*10 + int(c-'0')
+			} else {
+				break
+			}
+		}
+		if epNum > 0 && epNum != episode {
+			return true
+		}
+	}
+	return false
+}
+
 // Filter returns subtitles matching the preferred language (case-insensitive).
 func Filter(subtitles []media.Subtitle, language string) []media.Subtitle {
 	if language == "" {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -31,30 +31,36 @@ const (
 type tab int
 
 const (
-	tabBrowse tab = iota
+	tabMovies tab = iota
+	tabSeries
+	tabCartoons
+	tabAnime
 	tabDownloads
 )
 
 // AppModel struct holding state
 type AppModel struct {
-	state          state
-	provider       provider.Provider
-	config         *config.Config
+	state           state
+	provider        provider.Provider
+	cartoonProvider provider.Provider
+	animeProvider   provider.Provider
+	config          *config.Config
 
-	list           list.Model
-	searchInput    textinput.Model
-	loader         spinner.Model
-	results        []media.SearchResult
+	list        list.Model
+	searchInput textinput.Model
+	loader      spinner.Model
+	results     []media.SearchResult
 
-	width          int
-	height         int
+	width  int
+	height int
 
-	currentItem    *media.SearchResult
-	currentDetail  *media.ContentDetail
+	currentItem   *media.SearchResult
+	currentDetail *media.ContentDetail
 
-	err            error
-	isSearching    bool
-	selectedResult *media.SearchResult
+	err              error
+	isSearching      bool
+	selectedResult   *media.SearchResult
+	selectedProvider provider.Provider
 
 	// Tab and download manager state
 	activeTab      tab
@@ -68,8 +74,8 @@ type listItem struct {
 	result media.SearchResult
 }
 
-func (i listItem) Title() string       { return i.result.Title }
-func (i listItem) Description() string { 
+func (i listItem) Title() string { return i.result.Title }
+func (i listItem) Description() string {
 	desc := fmt.Sprintf("%s \u2022 %s", i.result.Type.String(), i.result.Year)
 	if i.result.Type == media.TV {
 		desc = fmt.Sprintf("%s \u2022 %d Seasons", desc, i.result.Seasons)
@@ -86,14 +92,14 @@ var (
 )
 
 // StartApp launches the TUI. If mgr is nil, download features are disabled.
-func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager) (*media.SearchResult, error) {
+func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager) (*media.SearchResult, provider.Provider, error) {
 	ti := textinput.New()
-	ti.Placeholder = "Search for a movie or TV show..."
+	ti.Placeholder = "Search..."
 	ti.CharLimit = 156
 	ti.Width = 40
 
 	l := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
-	l.Title = "Trending"
+	l.Title = "Movies"
 	l.SetShowStatusBar(false)
 	l.SetShowHelp(false)
 	l.SetFilteringEnabled(false) // We handle custom filtering/search
@@ -104,13 +110,15 @@ func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager) (
 	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF4C4C"))
 
 	m := AppModel{
-		state:       stateTrending,
-		provider:    p,
-		config:      cfg,
-		list:        l,
-		searchInput: ti,
-		loader:      sp,
-		dlManager:   mgr,
+		state:           stateTrending,
+		provider:        p,
+		cartoonProvider: provider.NewKimCartoon("kimcartoon.com.co"),
+		animeProvider:   provider.NewKimCartoon("kimcartoon.com.co"),
+		config:          cfg,
+		list:            l,
+		searchInput:     ti,
+		loader:          sp,
+		dlManager:       mgr,
 	}
 
 	if mgr != nil {
@@ -120,15 +128,18 @@ func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager) (
 	p2 := tea.NewProgram(m, tea.WithAltScreen())
 	m2, err := p2.Run()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	appModel := m2.(AppModel)
-	return appModel.selectedResult, nil
+	if appModel.selectedProvider == nil {
+		appModel.selectedProvider = p
+	}
+	return appModel.selectedResult, appModel.selectedProvider, nil
 }
 
 func (m AppModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{
-		fetchTrendingCmd(m.provider),
+		fetchTabCmd(m.providerForActiveTab(), m.activeTab),
 		textinput.Blink,
 		m.loader.Tick,
 		m.list.StartSpinner(),
@@ -156,7 +167,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.results = nil // Clear current results to show loader
 				m.currentItem = nil
 				cmds = append(cmds, m.list.StartSpinner())
-				return m, tea.Batch(searchCmd(m.provider, m.searchInput.Value()), m.list.StartSpinner())
+				return m, tea.Batch(searchCmd(m.providerForActiveTab(), m.searchInput.Value()), m.list.StartSpinner())
 			case tea.KeyEsc:
 				m.isSearching = false
 				m.searchInput.Blur()
@@ -172,23 +183,18 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		case "tab":
-			if m.activeTab == tabBrowse {
-				m.activeTab = tabDownloads
-				m.downloadsModel.SetFocused(true)
-			} else {
-				m.activeTab = tabBrowse
-				m.downloadsModel.SetFocused(false)
-			}
-			return m, m.downloadsModel.Init()
+			return m, m.switchTab(m.nextTab())
 		case "1":
-			m.activeTab = tabBrowse
-			m.downloadsModel.SetFocused(false)
-			return m, nil
+			return m, m.switchTab(tabMovies)
 		case "2":
+			return m, m.switchTab(tabSeries)
+		case "3":
+			return m, m.switchTab(tabCartoons)
+		case "4":
+			return m, m.switchTab(tabAnime)
+		case "5":
 			if m.dlManager != nil {
-				m.activeTab = tabDownloads
-				m.downloadsModel.SetFocused(true)
-				return m, m.downloadsModel.Init()
+				return m, m.switchTab(tabDownloads)
 			}
 			return m, nil
 		}
@@ -210,6 +216,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			if m.currentItem != nil {
 				m.selectedResult = m.currentItem
+				m.selectedProvider = m.providerForActiveTab()
 				return m, tea.Quit
 			}
 			return m, nil
@@ -249,7 +256,10 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.list.StopSpinner()
 		if len(msg) > 0 {
 			m.currentItem = &msg[0]
-			cmds = append(cmds, fetchDetailCmd(m.provider, msg[0].ID))
+			cmds = append(cmds, fetchDetailCmd(m.providerForActiveTab(), msg[0].ID))
+		} else {
+			m.currentItem = nil
+			m.currentDetail = nil
 		}
 
 	case detailFetchedMsg:
@@ -279,7 +289,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// Update browse list and handle item change.
-	if m.activeTab == tabBrowse {
+	if m.activeTab != tabDownloads {
 		var listCmd tea.Cmd
 		prevIndex := m.list.Index()
 		m.list, listCmd = m.list.Update(msg)
@@ -287,7 +297,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentItem = &m.results[m.list.Index()]
 			m.currentDetail = nil
 			m.err = nil
-			cmds = append(cmds, fetchDetailCmd(m.provider, m.currentItem.ID))
+			cmds = append(cmds, fetchDetailCmd(m.providerForActiveTab(), m.currentItem.ID))
 		}
 		cmds = append(cmds, listCmd)
 	}
@@ -387,7 +397,7 @@ func (m AppModel) View() string {
 		if m.dlManager != nil {
 			dlHint = "  [D] Download  "
 		}
-		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  [TAB] Downloads  [Q] Quit")
+		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  [1-4] Categories  [TAB] Next Tab  [Q] Quit")
 	}
 
 	return docStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
@@ -409,19 +419,99 @@ func (m AppModel) renderTabBar() string {
 		Foreground(lipgloss.Color("#888888")).
 		Padding(0, 2)
 
-	browseLabel := "1 Browse"
-	dlLabel := "2 Downloads"
-
-	var browseTab, dlTab string
-	if m.activeTab == tabBrowse {
-		browseTab = activeStyle.Render(browseLabel)
-		dlTab = inactiveStyle.Render(dlLabel)
-	} else {
-		browseTab = inactiveStyle.Render(browseLabel)
-		dlTab = activeStyle.Render(dlLabel)
+	labels := []struct {
+		tab   tab
+		label string
+	}{
+		{tabMovies, "1 Movies"},
+		{tabSeries, "2 Series"},
+		{tabCartoons, "3 Cartoons"},
+		{tabAnime, "4 Anime"},
 	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, browseTab, "  ", dlTab)
+	if m.dlManager != nil {
+		labels = append(labels, struct {
+			tab   tab
+			label string
+		}{tabDownloads, "5 Downloads"})
+	}
+
+	rendered := make([]string, 0, len(labels)*2)
+	for _, item := range labels {
+		if m.activeTab == item.tab {
+			rendered = append(rendered, activeStyle.Render(item.label))
+		} else {
+			rendered = append(rendered, inactiveStyle.Render(item.label))
+		}
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, rendered...)
+}
+
+func (m AppModel) providerForActiveTab() provider.Provider {
+	switch m.activeTab {
+	case tabCartoons:
+		return m.cartoonProvider
+	case tabAnime:
+		return m.animeProvider
+	default:
+		return m.provider
+	}
+}
+
+func (m AppModel) nextTab() tab {
+	switch m.activeTab {
+	case tabMovies:
+		return tabSeries
+	case tabSeries:
+		return tabCartoons
+	case tabCartoons:
+		return tabAnime
+	case tabAnime:
+		if m.dlManager != nil {
+			return tabDownloads
+		}
+		return tabMovies
+	default:
+		return tabMovies
+	}
+}
+
+func (m *AppModel) switchTab(next tab) tea.Cmd {
+	if next == tabDownloads && m.dlManager == nil {
+		return nil
+	}
+
+	m.activeTab = next
+	m.isSearching = false
+	m.searchInput.Blur()
+	m.currentItem = nil
+	m.currentDetail = nil
+	m.err = nil
+
+	if next == tabDownloads {
+		m.downloadsModel.SetFocused(true)
+		return m.downloadsModel.Init()
+	}
+
+	m.downloadsModel.SetFocused(false)
+	m.results = nil
+	m.list.SetItems(nil)
+	m.list.Title = m.tabTitle(next)
+	return tea.Batch(fetchTabCmd(m.providerForActiveTab(), next), m.list.StartSpinner())
+}
+
+func (m AppModel) tabTitle(t tab) string {
+	switch t {
+	case tabSeries:
+		return "Series"
+	case tabCartoons:
+		return "Cartoons"
+	case tabAnime:
+		return "Anime"
+	default:
+		return "Movies"
+	}
 }
 
 func (m AppModel) renderBrowseContent(mainHeight int) string {
@@ -502,7 +592,7 @@ func (m AppModel) renderBrowseContent(mainHeight int) string {
 		)
 
 		rightPaneStyle := lipgloss.NewStyle().
-			Width(m.width - m.width/3 - 4).
+			Width(m.width-m.width/3-4).
 			Height(mainHeight).
 			Padding(0, 2)
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -9,10 +9,15 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// fetchTrendingCmd fetches trending movies.
-func fetchTrendingCmd(p provider.Provider) tea.Cmd {
+// fetchTabCmd fetches the default listing for a dashboard category.
+func fetchTabCmd(p provider.Provider, active tab) tea.Cmd {
 	return func() tea.Msg {
-		results, err := p.Trending(media.Movie)
+		mediaType := media.Movie
+		if active == tabSeries || active == tabCartoons || active == tabAnime {
+			mediaType = media.TV
+		}
+
+		results, err := p.Trending(mediaType)
 		if err != nil {
 			return errMsg{err}
 		}


### PR DESCRIPTION
## Summary

This PR adds the new TBCPL streaming provider and improves the provider fallback mechanism.

### Changes

- **New TBCPL Provider**: Adds support for TBCPL/Vidzee/1Shows with improved stream resolution
- **Fallback Improvements**: Better fallback logic that tries all providers systematically
- **Tests**: Added comprehensive tests for fallback, TBCPL, and KimCartoon providers
- **TUI Fixes**: Refactored commands and tab handling for better UX
- **Documentation**: Added provider documentation (moviebox-provider.md, provider-testing.md)

### Files Changed

-  - Improved fallback mechanism
-  - New test coverage
-  - New TBCPL provider
-  - New test coverage
-  - KimCartoon improvements
-  - TUI refinements
-  - Documentation

### Testing

Run tests with:
```bash
go test ./...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TBCPL/1Shows provider with playback/watch support
  * Expanded TUI with category tabs (Movies, Series, Cartoons, Anime, Downloads) and per-category provider selection
  * Merged embedded and external subtitles with URL dedupe and episode-aware filtering
  * Empty-query search now returns the selected provider from the TUI

* **Bug Fixes**
  * Fallback now tries up to 5 candidate streams (prefers matching media type)
  * Normalized KimCartoon host handling and updated default domain

* **Documentation**
  * Added provider implementation and provider testing guides

* **Tests**
  * Added/expanded tests for TBCPL, KimCartoon, fallback, and subtitle merging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->