### PR TITLE
feat: resilient stream resolver (racing, health, retries, diagnostics)

### DIFF
--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -5,12 +5,20 @@ import (
 	"strings"
 
 	"lobster/internal/dlmanager"
-	"lobster/internal/extract"
 	"lobster/internal/media"
 	"lobster/internal/provider"
+	"lobster/internal/resolver"
 )
 
-const maxFallbackCandidates = 5
+// maxFallbackCandidates mirrors resolver.MaxCandidates for backward compatibility
+// with tests that reference it in the cmd package.
+const maxFallbackCandidates = resolver.MaxCandidates
+
+// fallbackCandidates is a thin shim that delegates to resolver.FallbackCandidates.
+// It exists so that cmd tests that were written before the move continue to compile.
+func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
+	return resolver.FallbackCandidates(results, mediaType)
+}
 
 // fallbackProviders returns all available fallback providers, excluding the primary.
 // Both StreamProviders (Soap2Day, Consumet, MovieBox, TBCPL) and regular
@@ -55,207 +63,22 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 }
 
 // tryFallbackStream attempts to resolve a stream using fallback providers.
-// It tries each fallback in order — StreamProviders use Watch(), regular
-// Providers use the GetServers + GetEmbedURL + Extract path.
+// It delegates to resolver.ResolveSequential, which tries each fallback in
+// order. This is a thin adapter; Task 9 will replace its body with the
+// racing Resolver.
 func tryFallbackStream(primary provider.Provider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
-	fallbacks := fallbackProviders(primary)
-	if len(fallbacks) == 0 {
-		return nil, fmt.Errorf("no fallback providers available")
-	}
-
-	for _, fb := range fallbacks {
-		debugf("trying fallback provider: %T", fb)
-		stream, err := tryFallbackProvider(fb, title, mediaType, season, episode)
-		if err != nil {
-			debugf("fallback %T failed: %v", fb, err)
-			continue
-		}
-		return stream, nil
-	}
-
-	return nil, fmt.Errorf("all fallback providers failed")
-}
-
-// tryFallbackProvider tries a single fallback provider.
-// If the provider implements StreamProvider, it uses Watch() directly.
-// Otherwise, it uses the GetServers + GetEmbedURL + Extract path.
-func tryFallbackProvider(fb provider.Provider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
-	results, err := fb.Search(title)
-	if err != nil {
-		return nil, fmt.Errorf("search failed: %w", err)
-	}
-
-	candidates := fallbackCandidates(results, mediaType)
-	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no matching result for %q", title)
-	}
-
 	quality := "1080"
 	if cfg != nil && cfg.Quality != "" {
 		quality = cfg.Quality
 	}
-
-	var lastErr error
-	for i := range candidates {
-		match := &candidates[i]
-		debugf("fallback candidate: %s (ID: %s)", match.Title, match.ID)
-
-		var stream *media.Stream
-		if sp, ok := fb.(provider.StreamProvider); ok {
-			stream, err = tryStreamProviderFallback(sp, match, mediaType, season, episode, quality)
-		} else {
-			stream, err = tryEmbedProviderFallback(fb, match, mediaType, season, episode, quality)
-		}
-		if err == nil {
-			return stream, nil
-		}
-		lastErr = err
-		debugf("fallback candidate %s failed: %v", match.Title, err)
+	req := resolver.Request{
+		Title:     title,
+		MediaType: mediaType,
+		Season:    season,
+		Episode:   episode,
+		Quality:   quality,
 	}
-
-	return nil, fmt.Errorf("all %d candidates failed: %w", len(candidates), lastErr)
-}
-
-func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
-	var sameType []media.SearchResult
-	var otherType []media.SearchResult
-	seen := make(map[string]bool)
-
-	appendUnique := func(dst []media.SearchResult, r media.SearchResult) []media.SearchResult {
-		key := r.ID
-		if key == "" {
-			key = r.Title + r.URL
-		}
-		if seen[key] {
-			return dst
-		}
-		seen[key] = true
-		return append(dst, r)
-	}
-
-	for _, r := range results {
-		if r.Type == mediaType {
-			sameType = appendUnique(sameType, r)
-		} else {
-			otherType = appendUnique(otherType, r)
-		}
-	}
-
-	candidates := sameType
-	if len(candidates) == 0 {
-		candidates = otherType
-	}
-	if len(candidates) > maxFallbackCandidates {
-		candidates = candidates[:maxFallbackCandidates]
-	}
-	return candidates
-}
-
-// tryStreamProviderFallback resolves a stream via StreamProvider.Watch().
-func tryStreamProviderFallback(sp provider.StreamProvider, match *media.SearchResult, mediaType media.MediaType, season, episode int, quality string) (*media.Stream, error) {
-	if mediaType == media.Movie || (season == 0 && episode == 0) {
-		return sp.Watch(match.ID, "", "Default", quality)
-	}
-
-	// TV: construct the episode ID
-	tmdbID := match.ID
-	if idx := len("tv/"); len(tmdbID) > idx && tmdbID[:idx] == "tv/" {
-		tmdbID = tmdbID[idx:]
-	} else if idx := len("movie/"); len(tmdbID) > idx && tmdbID[:idx] == "movie/" {
-		tmdbID = tmdbID[idx:]
-	}
-
-	episodeID := fmt.Sprintf("%s:%d:%d", tmdbID, season, episode)
-	debugf("fallback episode ID: %s", episodeID)
-	return sp.Watch(match.ID, episodeID, "Default", quality)
-}
-
-// tryEmbedProviderFallback resolves a stream via GetServers + GetEmbedURL + Extract.
-func tryEmbedProviderFallback(fb provider.Provider, match *media.SearchResult, mediaType media.MediaType, season, episode int, quality string) (*media.Stream, error) {
-	var episodeID string
-
-	if mediaType != media.Movie && (season > 0 || episode > 0) {
-		// TV: get seasons and episodes to find the right episode ID
-		seasons, err := fb.GetSeasons(match.ID)
-		if err != nil {
-			return nil, fmt.Errorf("getting seasons: %w", err)
-		}
-
-		var seasonID string
-		for _, s := range seasons {
-			if s.Number == season {
-				seasonID = s.ID
-				break
-			}
-		}
-		if seasonID == "" && len(seasons) > 0 {
-			seasonID = seasons[0].ID
-		}
-		if seasonID == "" {
-			return nil, fmt.Errorf("season %d not found", season)
-		}
-
-		episodes, err := fb.GetEpisodes(match.ID, seasonID)
-		if err != nil {
-			return nil, fmt.Errorf("getting episodes: %w", err)
-		}
-
-		for _, ep := range episodes {
-			if ep.Number == episode {
-				episodeID = ep.ID
-				break
-			}
-		}
-		if episodeID == "" {
-			return nil, fmt.Errorf("episode %d not found in season %d", episode, season)
-		}
-	}
-
-	servers, err := fb.GetServers(match.ID, episodeID)
-	if err != nil {
-		return nil, fmt.Errorf("getting servers: %w", err)
-	}
-	if len(servers) == 0 {
-		return nil, fmt.Errorf("no servers found")
-	}
-
-	// Try each server
-	for _, srv := range servers {
-		debugf("fallback trying server: %s (ID: %s)", srv.Name, srv.ID)
-
-		embedURL, err := fb.GetEmbedURL(srv.ID)
-		if err != nil {
-			debugf("fallback server %s embed failed: %v", srv.Name, err)
-			continue
-		}
-
-		ext, resolvedURL := extract.ResolveForURL(embedURL, providerReferer(fb))
-		stream, err := ext.Extract(resolvedURL, quality)
-		if err != nil {
-			debugf("fallback server %s extract failed: %v", srv.Name, err)
-			continue
-		}
-
-		debugf("fallback stream URL: %s (server: %s)", stream.URL, srv.Name)
-		return stream, nil
-	}
-
-	return nil, fmt.Errorf("all fallback servers failed")
-}
-
-// providerReferer returns the Referer URL for a provider's embed requests.
-// This ensures extractors send the correct origin domain instead of a hardcoded one.
-func providerReferer(p provider.Provider) string {
-	switch v := p.(type) {
-	case *provider.FlixHQ:
-		return v.BaseURL() + "/"
-	case *provider.FlixHQWS:
-		return v.BaseURL() + "/"
-	case *provider.KimCartoon:
-		return v.BaseURL() + "/"
-	default:
-		return ""
-	}
+	return resolver.ResolveSequential(fallbackProviders(primary), req, debugf)
 }
 
 // makeStreamResolver builds a StreamResolver that tries the primary provider

--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"lobster/internal/config"
 	"lobster/internal/dlmanager"
@@ -12,13 +13,22 @@ import (
 	"lobster/internal/resolver"
 )
 
-var sharedHealth = func() *resolver.HealthStore {
-	p, err := config.HealthPath()
-	if err != nil {
-		return resolver.NewHealthStore()
-	}
-	return resolver.LoadHealth(p)
-}()
+var (
+	sharedHealthOnce  sync.Once
+	sharedHealthStore *resolver.HealthStore
+)
+
+func sharedHealth() *resolver.HealthStore {
+	sharedHealthOnce.Do(func() {
+		p, err := config.HealthPath()
+		if err != nil {
+			sharedHealthStore = resolver.NewHealthStore()
+			return
+		}
+		sharedHealthStore = resolver.LoadHealth(p)
+	})
+	return sharedHealthStore
+}
 
 func cfgQuality() string {
 	if cfg != nil && cfg.Quality != "" {
@@ -82,7 +92,7 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 // tryFallbackStream attempts to resolve a stream using the resilient Resolver,
 // which races fallback providers and selects the first valid result.
 func tryFallbackStream(primary provider.Provider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
-	r := resolver.New(fallbackProviders(primary), sharedHealth, debugf)
+	r := resolver.New(fallbackProviders(primary), sharedHealth(), debugf)
 	req := resolver.Request{Title: title, MediaType: mediaType, Season: season, Episode: episode, Quality: cfgQuality()}
 	stream, report, err := r.Resolve(context.Background(), req)
 	if err != nil {

--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -1,14 +1,31 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	"lobster/internal/config"
 	"lobster/internal/dlmanager"
 	"lobster/internal/media"
 	"lobster/internal/provider"
 	"lobster/internal/resolver"
 )
+
+var sharedHealth = func() *resolver.HealthStore {
+	p, err := config.HealthPath()
+	if err != nil {
+		return resolver.NewHealthStore()
+	}
+	return resolver.LoadHealth(p)
+}()
+
+func cfgQuality() string {
+	if cfg != nil && cfg.Quality != "" {
+		return cfg.Quality
+	}
+	return "1080"
+}
 
 // maxFallbackCandidates mirrors resolver.MaxCandidates for backward compatibility
 // with tests that reference it in the cmd package.
@@ -62,23 +79,18 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 	return fallbacks
 }
 
-// tryFallbackStream attempts to resolve a stream using fallback providers.
-// It delegates to resolver.ResolveSequential, which tries each fallback in
-// order. This is a thin adapter; Task 9 will replace its body with the
-// racing Resolver.
+// tryFallbackStream attempts to resolve a stream using the resilient Resolver,
+// which races fallback providers and selects the first valid result.
 func tryFallbackStream(primary provider.Provider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
-	quality := "1080"
-	if cfg != nil && cfg.Quality != "" {
-		quality = cfg.Quality
+	r := resolver.New(fallbackProviders(primary), sharedHealth, debugf)
+	req := resolver.Request{Title: title, MediaType: mediaType, Season: season, Episode: episode, Quality: cfgQuality()}
+	stream, report, err := r.Resolve(context.Background(), req)
+	if err != nil {
+		debugf("resolve failed: %s", report.Summary())
+		return nil, err
 	}
-	req := resolver.Request{
-		Title:     title,
-		MediaType: mediaType,
-		Season:    season,
-		Episode:   episode,
-		Quality:   quality,
-	}
-	return resolver.ResolveSequential(fallbackProviders(primary), req, debugf)
+	debugf("resolve ok via report: %s", report.Summary())
+	return stream, nil
 }
 
 // makeStreamResolver builds a StreamResolver that tries the primary provider

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,6 +155,15 @@ func HistoryPath() (string, error) {
 	return filepath.Join(dir, "history.tsv"), nil
 }
 
+// HealthPath returns the path to the provider-health state file.
+func HealthPath() (string, error) {
+	dir, err := dataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "health.json"), nil
+}
+
 // DownloadsDBPath returns the path to the downloads SQLite database.
 func DownloadsDBPath() (string, error) {
 	dir, err := dataDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -171,13 +171,13 @@ func TestExpandDownloadDir(t *testing.T) {
 }
 
 func TestHealthPath(t *testing.T) {
-	t.Setenv("XDG_DATA_HOME", "/tmp/lobtest-data")
 	p, err := HealthPath()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join("/tmp/lobtest-data", "lobster", "health.json")
-	if p != want {
-		t.Fatalf("HealthPath=%q want %q", p, want)
+	// dataDir is platform-specific (XDG on Unix, AppData on Windows), so assert
+	// the stable contract: a file named health.json under a "lobster" dir.
+	if filepath.Base(p) != "health.json" || filepath.Base(filepath.Dir(p)) != "lobster" {
+		t.Fatalf("HealthPath=%q want .../lobster/health.json", p)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,3 +169,14 @@ func TestExpandDownloadDir(t *testing.T) {
 		t.Errorf("got %q, want %q", dir, want)
 	}
 }
+
+func TestHealthPath(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "/tmp/lobtest-data")
+	p, err := HealthPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p != "/tmp/lobtest-data/lobster/health.json" {
+		t.Fatalf("HealthPath=%q want /tmp/lobtest-data/lobster/health.json", p)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -176,7 +176,8 @@ func TestHealthPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p != "/tmp/lobtest-data/lobster/health.json" {
-		t.Fatalf("HealthPath=%q want /tmp/lobtest-data/lobster/health.json", p)
+	want := filepath.Join("/tmp/lobtest-data", "lobster", "health.json")
+	if p != want {
+		t.Fatalf("HealthPath=%q want %q", p, want)
 	}
 }

--- a/internal/provider/moviebox.go
+++ b/internal/provider/moviebox.go
@@ -44,11 +44,15 @@ func NewMovieBox() *MovieBox {
 
 // baseURL returns the current API base URL.
 func (m *MovieBox) baseURL() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.baseURLs[m.pos%len(m.baseURLs)]
 }
 
 // rotateHost advances to the next host.
 func (m *MovieBox) rotateHost() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.pos++
 }
 

--- a/internal/provider/moviebox_race_test.go
+++ b/internal/provider/moviebox_race_test.go
@@ -1,0 +1,17 @@
+package provider
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMovieBoxRotateHostRace(t *testing.T) {
+	m := NewMovieBox()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = m.baseURL() }()
+		go func() { defer wg.Done(); m.rotateHost() }()
+	}
+	wg.Wait()
+}

--- a/internal/resolver/classify.go
+++ b/internal/resolver/classify.go
@@ -1,0 +1,35 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+)
+
+// isTransient reports whether an error is worth one retry. Network/DNS/timeout
+// and 5xx-shaped errors are transient; "no match", parse failures, and 4xx
+// (incl. 404) are permanent.
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var dns *net.DNSError
+	if errors.As(err, &dns) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	for _, p := range []string{"connection reset", "connection refused", "timeout", "eof", "no route to host", "broken pipe", " 500", " 502", " 503", " 504", "status 5"} {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resolver/classify_test.go
+++ b/internal/resolver/classify_test.go
@@ -1,0 +1,34 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestIsTransient(t *testing.T) {
+	transient := []error{
+		&net.DNSError{Err: "no such host", Name: "x"},
+		context.DeadlineExceeded,
+		errors.New("connection reset by peer"),
+		fmt.Errorf("server returned status 503"),
+		fmt.Errorf("net/http: timeout awaiting response"),
+	}
+	for _, e := range transient {
+		if !isTransient(e) {
+			t.Errorf("expected transient: %v", e)
+		}
+	}
+	permanent := []error{
+		errors.New("no matching result for \"foo\""),
+		fmt.Errorf("server returned status 404"),
+		errors.New("failed to parse response"),
+	}
+	for _, e := range permanent {
+		if isTransient(e) {
+			t.Errorf("expected permanent: %v", e)
+		}
+	}
+}

--- a/internal/resolver/health.go
+++ b/internal/resolver/health.go
@@ -1,0 +1,129 @@
+package resolver
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"lobster/internal/provider"
+)
+
+const (
+	healthAlpha         = 0.3
+	healthNeutral       = 0.5
+	healthHalfLifeHours = 72.0
+)
+
+// ProviderName returns the short type name of a provider, e.g. "MovieBox".
+func ProviderName(p provider.Provider) string {
+	full := fmt.Sprintf("%T", p)
+	if i := strings.LastIndex(full, "."); i >= 0 {
+		return full[i+1:]
+	}
+	return full
+}
+
+type ProviderHealth struct {
+	Score       float64   `json:"score"`
+	LatencyMs   int       `json:"latencyMs"`
+	LastSuccess time.Time `json:"lastSuccess"`
+	LastFailure time.Time `json:"lastFailure"`
+	Samples     int       `json:"samples"`
+}
+
+type HealthStore struct {
+	mu      sync.RWMutex
+	records map[string]*ProviderHealth
+	path    string // set by LoadHealth (Task 4); empty => no persistence
+}
+
+func NewHealthStore() *HealthStore {
+	return &HealthStore{records: make(map[string]*ProviderHealth)}
+}
+
+// Record folds one outcome into the provider's EWMA score and latency.
+func (h *HealthStore) Record(name string, success bool, latency time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	rec := h.records[name]
+	if rec == nil {
+		rec = &ProviderHealth{Score: healthNeutral}
+		h.records[name] = rec
+	}
+	target := 0.0
+	if success {
+		target = 1.0
+	}
+	rec.Score = healthAlpha*target + (1-healthAlpha)*rec.Score
+	if success {
+		ms := int(latency.Milliseconds())
+		if rec.LatencyMs == 0 {
+			rec.LatencyMs = ms
+		} else {
+			rec.LatencyMs = int(healthAlpha*float64(ms) + (1-healthAlpha)*float64(rec.LatencyMs))
+		}
+		rec.LastSuccess = time.Now()
+	} else {
+		rec.LastFailure = time.Now()
+	}
+	rec.Samples++
+}
+
+// effectiveScore decays the stored score toward neutral as the last activity ages,
+// so a provider that failed days ago is retried rather than permanently demoted.
+func effectiveScore(rec *ProviderHealth, now time.Time) float64 {
+	if rec == nil {
+		return healthNeutral
+	}
+	last := rec.LastSuccess
+	if rec.LastFailure.After(last) {
+		last = rec.LastFailure
+	}
+	if last.IsZero() {
+		return rec.Score
+	}
+	ageHours := now.Sub(last).Hours()
+	if ageHours < 0 {
+		ageHours = 0
+	}
+	decay := math.Pow(0.5, ageHours/healthHalfLifeHours)
+	return healthNeutral + (rec.Score-healthNeutral)*decay
+}
+
+// Order ranks providers by decayed score (desc), tie-break latency (asc),
+// then chunks them into batches of batchSize (>=1).
+func (h *HealthStore) Order(providers []provider.Provider, now time.Time, batchSize int) [][]provider.Provider {
+	if batchSize < 1 {
+		batchSize = 1
+	}
+	h.mu.RLock()
+	ranked := make([]provider.Provider, len(providers))
+	copy(ranked, providers)
+	score := func(p provider.Provider) float64 { return effectiveScore(h.records[ProviderName(p)], now) }
+	lat := func(p provider.Provider) int {
+		if r := h.records[ProviderName(p)]; r != nil {
+			return r.LatencyMs
+		}
+		return 1 << 30
+	}
+	h.mu.RUnlock()
+	sort.SliceStable(ranked, func(i, j int) bool {
+		si, sj := score(ranked[i]), score(ranked[j])
+		if si != sj {
+			return si > sj
+		}
+		return lat(ranked[i]) < lat(ranked[j])
+	})
+	var batches [][]provider.Provider
+	for i := 0; i < len(ranked); i += batchSize {
+		end := i + batchSize
+		if end > len(ranked) {
+			end = len(ranked)
+		}
+		batches = append(batches, ranked[i:end])
+	}
+	return batches
+}

--- a/internal/resolver/health.go
+++ b/internal/resolver/health.go
@@ -187,5 +187,8 @@ func (h *HealthStore) Save() error {
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return err
 	}
+	// os.Rename can't overwrite an existing file on Windows; remove the target
+	// first. health.json is best-effort, so the brief non-atomic window is fine.
+	_ = os.Remove(path)
 	return os.Rename(tmp, path)
 }

--- a/internal/resolver/health.go
+++ b/internal/resolver/health.go
@@ -39,6 +39,7 @@ type ProviderHealth struct {
 
 type HealthStore struct {
 	mu      sync.RWMutex
+	saveMu  sync.Mutex
 	records map[string]*ProviderHealth
 	path    string // set by LoadHealth (Task 4); empty => no persistence
 }
@@ -102,23 +103,36 @@ func (h *HealthStore) Order(providers []provider.Provider, now time.Time, batchS
 	if batchSize < 1 {
 		batchSize = 1
 	}
-	h.mu.RLock()
 	ranked := make([]provider.Provider, len(providers))
 	copy(ranked, providers)
-	score := func(p provider.Provider) float64 { return effectiveScore(h.records[ProviderName(p)], now) }
-	lat := func(p provider.Provider) int {
-		if r := h.records[ProviderName(p)]; r != nil {
-			return r.LatencyMs
+
+	// Snapshot the comparison keys UNDER the lock so the sort comparator never
+	// reads the shared records map/structs (concurrent map read+write is a fatal
+	// runtime panic, not just a race).
+	type sortKey struct {
+		score float64
+		lat   int
+	}
+	keys := make(map[string]sortKey, len(providers))
+	h.mu.RLock()
+	for _, p := range providers {
+		name := ProviderName(p)
+		rec := h.records[name]
+		lat := 1 << 30
+		if rec != nil {
+			lat = rec.LatencyMs
 		}
-		return 1 << 30
+		keys[name] = sortKey{score: effectiveScore(rec, now), lat: lat}
 	}
 	h.mu.RUnlock()
+
 	sort.SliceStable(ranked, func(i, j int) bool {
-		si, sj := score(ranked[i]), score(ranked[j])
-		if si != sj {
-			return si > sj
+		ki := keys[ProviderName(ranked[i])]
+		kj := keys[ProviderName(ranked[j])]
+		if ki.score != kj.score {
+			return ki.score > kj.score
 		}
-		return lat(ranked[i]) < lat(ranked[j])
+		return ki.lat < kj.lat
 	})
 	var batches [][]provider.Provider
 	for i := 0; i < len(ranked); i += batchSize {
@@ -146,25 +160,32 @@ func LoadHealth(path string) *HealthStore {
 	return h
 }
 
-// Save atomically writes the store to its path (temp file + rename). It holds
-// the store lock for the whole read-modify-write so concurrent resolves can't
-// corrupt the file. No-op when path is empty.
+// Save atomically writes the store to its path (temp file + rename). The records
+// are snapshotted and marshalled under the records lock, then file I/O happens
+// outside it (serialized by saveMu) so a slow disk write can't block concurrent
+// Record calls. No-op when path is empty.
 func (h *HealthStore) Save() error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.path == "" {
+	h.mu.RLock()
+	path := h.path
+	if path == "" {
+		h.mu.RUnlock()
 		return nil
 	}
 	data, err := json.MarshalIndent(h.records, "", "  ")
+	h.mu.RUnlock()
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(h.path), 0o755); err != nil {
+	// Disk I/O outside the records lock; saveMu serializes concurrent file writes
+	// so two resolves can't clobber the temp file or race the rename.
+	h.saveMu.Lock()
+	defer h.saveMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp := h.path + ".tmp"
+	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, h.path)
+	return os.Rename(tmp, path)
 }

--- a/internal/resolver/health.go
+++ b/internal/resolver/health.go
@@ -1,8 +1,11 @@
 package resolver
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -126,4 +129,42 @@ func (h *HealthStore) Order(providers []provider.Provider, now time.Time, batchS
 		batches = append(batches, ranked[i:end])
 	}
 	return batches
+}
+
+// LoadHealth reads the health file if present; on any error it returns an
+// empty, usable store with the path set so Save() can persist later.
+func LoadHealth(path string) *HealthStore {
+	h := &HealthStore{records: make(map[string]*ProviderHealth), path: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return h
+	}
+	var recs map[string]*ProviderHealth
+	if json.Unmarshal(data, &recs) == nil && recs != nil {
+		h.records = recs
+	}
+	return h
+}
+
+// Save atomically writes the store to its path (temp file + rename). It holds
+// the store lock for the whole read-modify-write so concurrent resolves can't
+// corrupt the file. No-op when path is empty.
+func (h *HealthStore) Save() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.path == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(h.records, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(h.path), 0o755); err != nil {
+		return err
+	}
+	tmp := h.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, h.path)
 }

--- a/internal/resolver/health_test.go
+++ b/internal/resolver/health_test.go
@@ -1,6 +1,9 @@
 package resolver
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,4 +50,44 @@ func TestOrderRanksHealthyFirstAndBatches(t *testing.T) {
 	if len(batches) != 2 || ProviderName(batches[0][0]) != ProviderName(good) {
 		t.Fatalf("expected healthy provider first, got %v", batches)
 	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "health.json")
+	h := LoadHealth(path) // missing file -> empty
+	h.Record("MovieBox", true, 200*time.Millisecond)
+	if err := h.Save(); err != nil {
+		t.Fatal(err)
+	}
+	h2 := LoadHealth(path)
+	if h2.records["MovieBox"] == nil || h2.records["MovieBox"].Score <= healthNeutral {
+		t.Fatalf("reloaded store missing recorded health: %+v", h2.records["MovieBox"])
+	}
+}
+
+func TestLoadCorruptIsBestEffort(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "health.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := LoadHealth(path) // must not panic; returns empty usable store
+	h.Record("A", true, 0) // still usable
+	if h.records["A"] == nil {
+		t.Fatal("store unusable after corrupt load")
+	}
+}
+
+func TestConcurrentRecordSaveNoRace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "health.json")
+	h := LoadHealth(path)
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			h.Record("P"+string(rune('A'+n%5)), n%2 == 0, time.Millisecond)
+			_ = h.Save()
+		}(i)
+	}
+	wg.Wait()
 }

--- a/internal/resolver/health_test.go
+++ b/internal/resolver/health_test.go
@@ -1,0 +1,50 @@
+package resolver
+
+import (
+	"testing"
+	"time"
+
+	"lobster/internal/provider"
+)
+
+func TestRecordEWMA(t *testing.T) {
+	h := NewHealthStore()
+	h.Record("A", true, 100*time.Millisecond)  // 0.5 -> 0.3*1 + 0.7*0.5 = 0.65
+	h.Record("A", true, 100*time.Millisecond)  // 0.3 + 0.7*0.65 = 0.755
+	got := h.records["A"].Score
+	if got < 0.75 || got > 0.76 {
+		t.Fatalf("score after two successes = %.4f, want ~0.755", got)
+	}
+	h2 := NewHealthStore()
+	h2.Record("B", false, 0) // 0.3*0 + 0.7*0.5 = 0.35
+	if s := h2.records["B"].Score; s < 0.34 || s > 0.36 {
+		t.Fatalf("score after one failure = %.4f, want ~0.35", s)
+	}
+}
+
+func TestEffectiveScoreDecays(t *testing.T) {
+	now := time.Unix(1_000_000_000, 0)
+	rec := &ProviderHealth{Score: 0.1, LastFailure: now.Add(-72 * time.Hour)} // one half-life ago
+	// effective = 0.5 + (0.1-0.5)*0.5 = 0.3
+	got := effectiveScore(rec, now)
+	if got < 0.29 || got > 0.31 {
+		t.Fatalf("decayed score = %.4f, want ~0.3", got)
+	}
+	// No record -> neutral.
+	if n := effectiveScore(nil, now); n != healthNeutral {
+		t.Fatalf("nil record effective = %.4f, want %.4f", n, healthNeutral)
+	}
+}
+
+func TestOrderRanksHealthyFirstAndBatches(t *testing.T) {
+	h := NewHealthStore()
+	now := time.Unix(1_000_000_000, 0)
+	good := provider.NewSoap2Day()
+	bad := provider.NewMovieBox()
+	h.records[ProviderName(good)] = &ProviderHealth{Score: 0.9, LastSuccess: now}
+	h.records[ProviderName(bad)] = &ProviderHealth{Score: 0.1, LastFailure: now}
+	batches := h.Order([]provider.Provider{bad, good}, now, 1)
+	if len(batches) != 2 || ProviderName(batches[0][0]) != ProviderName(good) {
+		t.Fatalf("expected healthy provider first, got %v", batches)
+	}
+}

--- a/internal/resolver/health_test.go
+++ b/internal/resolver/health_test.go
@@ -77,6 +77,18 @@ func TestLoadCorruptIsBestEffort(t *testing.T) {
 	}
 }
 
+func TestOrderConcurrentWithRecordNoPanic(t *testing.T) {
+	h := NewHealthStore()
+	provs := []provider.Provider{provider.NewSoap2Day(), provider.NewMovieBox(), provider.NewTBCPL("tbcpl")}
+	var wg sync.WaitGroup
+	for i := 0; i < 300; i++ {
+		wg.Add(2)
+		go func(n int) { defer wg.Done(); h.Record(ProviderName(provs[n%len(provs)]), n%2 == 0, time.Millisecond) }(i)
+		go func() { defer wg.Done(); _ = h.Order(provs, time.Now(), 3) }()
+	}
+	wg.Wait()
+}
+
 func TestConcurrentRecordSaveNoRace(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "health.json")
 	h := LoadHealth(path)

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -35,7 +35,9 @@ func (r *Resolver) probe(p provider.Provider, req Request) probeResult {
 		}
 	}
 	latency := time.Since(start)
-	r.health.Record(name, err == nil, latency)
+	// Health is recorded by Resolve on the receive side, not here: an abandoned
+	// probe that finishes after its batch deadline must NOT self-report a late
+	// success (which would keep a chronically-slow provider ranked first forever).
 	return probeResult{Stream: stream, Provider: name, Stage: stage, Err: err, Latency: latency}
 }
 
@@ -172,9 +174,6 @@ func tryEmbedProviderFallback(fb provider.Provider, match *media.SearchResult, m
 				seasonID = s.ID
 				break
 			}
-		}
-		if seasonID == "" && len(seasons) > 0 {
-			seasonID = seasons[0].ID
 		}
 		if seasonID == "" {
 			return nil, fmt.Errorf("season %d not found", season)

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -1,0 +1,213 @@
+package resolver
+
+import (
+	"fmt"
+
+	"lobster/internal/extract"
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// MaxCandidates is the maximum number of search candidates to try per provider.
+const MaxCandidates = 5
+
+// maxCandidates is the package-internal alias.
+const maxCandidates = MaxCandidates
+
+// Request parameterizes a single stream-resolution attempt.
+type Request struct {
+	Title     string
+	MediaType media.MediaType
+	Season    int
+	Episode   int
+	Quality   string
+}
+
+// resolveWithProvider tries to resolve a stream using the given provider and
+// request parameters. It returns the stream, the stage reached ("search",
+// "match", or "resolve"), and any error. The log function receives debug
+// messages in the same format as fmt.Sprintf.
+func resolveWithProvider(p provider.Provider, req Request, log func(string, ...any)) (*media.Stream, string, error) {
+	results, err := p.Search(req.Title)
+	if err != nil {
+		return nil, "search", fmt.Errorf("search failed: %w", err)
+	}
+
+	candidates := fallbackCandidates(results, req.MediaType)
+	if len(candidates) == 0 {
+		return nil, "match", fmt.Errorf("no matching result for %q", req.Title)
+	}
+
+	quality := req.Quality
+	if quality == "" {
+		quality = "1080"
+	}
+
+	var lastErr error
+	for i := range candidates {
+		match := &candidates[i]
+		log("fallback candidate: %s (ID: %s)", match.Title, match.ID)
+
+		var stream *media.Stream
+		if sp, ok := p.(provider.StreamProvider); ok {
+			stream, err = tryStreamProviderFallback(sp, match, req.MediaType, req.Season, req.Episode, quality, log)
+		} else {
+			stream, err = tryEmbedProviderFallback(p, match, req.MediaType, req.Season, req.Episode, quality, log)
+		}
+		if err == nil {
+			return stream, "resolve", nil
+		}
+		lastErr = err
+		log("fallback candidate %s failed: %v", match.Title, err)
+	}
+
+	return nil, "resolve", fmt.Errorf("all %d candidates failed: %w", len(candidates), lastErr)
+}
+
+// FallbackCandidates filters and deduplicates search results, preferring
+// results of the requested media type, limited to MaxCandidates.
+func FallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
+	return fallbackCandidates(results, mediaType)
+}
+
+func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
+	var sameType []media.SearchResult
+	var otherType []media.SearchResult
+	seen := make(map[string]bool)
+
+	appendUnique := func(dst []media.SearchResult, r media.SearchResult) []media.SearchResult {
+		key := r.ID
+		if key == "" {
+			key = r.Title + r.URL
+		}
+		if seen[key] {
+			return dst
+		}
+		seen[key] = true
+		return append(dst, r)
+	}
+
+	for _, r := range results {
+		if r.Type == mediaType {
+			sameType = appendUnique(sameType, r)
+		} else {
+			otherType = appendUnique(otherType, r)
+		}
+	}
+
+	candidates := sameType
+	if len(candidates) == 0 {
+		candidates = otherType
+	}
+	if len(candidates) > maxCandidates {
+		candidates = candidates[:maxCandidates]
+	}
+	return candidates
+}
+
+// tryStreamProviderFallback resolves a stream via StreamProvider.Watch().
+func tryStreamProviderFallback(sp provider.StreamProvider, match *media.SearchResult, mediaType media.MediaType, season, episode int, quality string, log func(string, ...any)) (*media.Stream, error) {
+	if mediaType == media.Movie || (season == 0 && episode == 0) {
+		return sp.Watch(match.ID, "", "Default", quality)
+	}
+
+	// TV: construct the episode ID
+	tmdbID := match.ID
+	if idx := len("tv/"); len(tmdbID) > idx && tmdbID[:idx] == "tv/" {
+		tmdbID = tmdbID[idx:]
+	} else if idx := len("movie/"); len(tmdbID) > idx && tmdbID[:idx] == "movie/" {
+		tmdbID = tmdbID[idx:]
+	}
+
+	episodeID := fmt.Sprintf("%s:%d:%d", tmdbID, season, episode)
+	log("fallback episode ID: %s", episodeID)
+	return sp.Watch(match.ID, episodeID, "Default", quality)
+}
+
+// tryEmbedProviderFallback resolves a stream via GetServers + GetEmbedURL + Extract.
+func tryEmbedProviderFallback(fb provider.Provider, match *media.SearchResult, mediaType media.MediaType, season, episode int, quality string, log func(string, ...any)) (*media.Stream, error) {
+	var episodeID string
+
+	if mediaType != media.Movie && (season > 0 || episode > 0) {
+		// TV: get seasons and episodes to find the right episode ID
+		seasons, err := fb.GetSeasons(match.ID)
+		if err != nil {
+			return nil, fmt.Errorf("getting seasons: %w", err)
+		}
+
+		var seasonID string
+		for _, s := range seasons {
+			if s.Number == season {
+				seasonID = s.ID
+				break
+			}
+		}
+		if seasonID == "" && len(seasons) > 0 {
+			seasonID = seasons[0].ID
+		}
+		if seasonID == "" {
+			return nil, fmt.Errorf("season %d not found", season)
+		}
+
+		episodes, err := fb.GetEpisodes(match.ID, seasonID)
+		if err != nil {
+			return nil, fmt.Errorf("getting episodes: %w", err)
+		}
+
+		for _, ep := range episodes {
+			if ep.Number == episode {
+				episodeID = ep.ID
+				break
+			}
+		}
+		if episodeID == "" {
+			return nil, fmt.Errorf("episode %d not found in season %d", episode, season)
+		}
+	}
+
+	servers, err := fb.GetServers(match.ID, episodeID)
+	if err != nil {
+		return nil, fmt.Errorf("getting servers: %w", err)
+	}
+	if len(servers) == 0 {
+		return nil, fmt.Errorf("no servers found")
+	}
+
+	// Try each server
+	for _, srv := range servers {
+		log("fallback trying server: %s (ID: %s)", srv.Name, srv.ID)
+
+		embedURL, err := fb.GetEmbedURL(srv.ID)
+		if err != nil {
+			log("fallback server %s embed failed: %v", srv.Name, err)
+			continue
+		}
+
+		ext, resolvedURL := extract.ResolveForURL(embedURL, providerReferer(fb))
+		stream, err := ext.Extract(resolvedURL, quality)
+		if err != nil {
+			log("fallback server %s extract failed: %v", srv.Name, err)
+			continue
+		}
+
+		log("fallback stream URL: %s (server: %s)", stream.URL, srv.Name)
+		return stream, nil
+	}
+
+	return nil, fmt.Errorf("all fallback servers failed")
+}
+
+// providerReferer returns the Referer URL for a provider's embed requests.
+// This ensures extractors send the correct origin domain instead of a hardcoded one.
+func providerReferer(p provider.Provider) string {
+	switch v := p.(type) {
+	case *provider.FlixHQ:
+		return v.BaseURL() + "/"
+	case *provider.FlixHQWS:
+		return v.BaseURL() + "/"
+	case *provider.KimCartoon:
+		return v.BaseURL() + "/"
+	default:
+		return ""
+	}
+}

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -23,16 +23,26 @@ type probeResult struct {
 func (r *Resolver) probe(p provider.Provider, req Request) probeResult {
 	name := ProviderName(p)
 	start := time.Now()
-	stream, stage, err := resolveWithProvider(p, req, r.log)
-	if err != nil && isTransient(err) {
-		time.Sleep(250 * time.Millisecond)
+	var (
+		stream *media.Stream
+		stage  string
+		err    error
+	)
+	// Up to one retry on a transient failure — covering both resolution AND the
+	// validation hop, since validation is itself a network call that can fail
+	// transiently and discard an otherwise-good stream.
+	for attempt := 0; attempt < 2; attempt++ {
 		stream, stage, err = resolveWithProvider(p, req, r.log)
-	}
-	if err == nil && r.validate {
-		if verr := validateStream(r.client, stream); verr != nil {
-			err, stage = verr, "validate"
-			stream = nil
+		if err == nil && r.validate {
+			if verr := validateStream(r.client, stream); verr != nil {
+				err, stage = verr, "validate"
+				stream = nil
+			}
 		}
+		if err == nil || !isTransient(err) || attempt == 1 {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
 	}
 	latency := time.Since(start)
 	// Health is recorded by Resolve on the receive side, not here: an abandoned
@@ -220,7 +230,7 @@ func tryEmbedProviderFallback(fb provider.Provider, match *media.SearchResult, m
 			continue
 		}
 
-		log("fallback stream URL: %s (server: %s)", stream.URL, srv.Name)
+		log("fallback stream resolved (server: %s)", srv.Name)
 		return stream, nil
 	}
 

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -2,11 +2,42 @@ package resolver
 
 import (
 	"fmt"
+	"time"
 
 	"lobster/internal/extract"
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
+
+// probeResult is the outcome of a single probe call.
+type probeResult struct {
+	Stream   *media.Stream
+	Provider string
+	Stage    string
+	Err      error
+	Latency  time.Duration
+}
+
+// probe runs resolveWithProvider for provider p, retrying once on a transient
+// error, optionally validating the stream, and recording health.
+func (r *Resolver) probe(p provider.Provider, req Request) probeResult {
+	name := ProviderName(p)
+	start := time.Now()
+	stream, stage, err := resolveWithProvider(p, req, r.log)
+	if err != nil && isTransient(err) {
+		time.Sleep(250 * time.Millisecond)
+		stream, stage, err = resolveWithProvider(p, req, r.log)
+	}
+	if err == nil && r.validate {
+		if verr := validateStream(r.client, stream); verr != nil {
+			err, stage = verr, "validate"
+			stream = nil
+		}
+	}
+	latency := time.Since(start)
+	r.health.Record(name, err == nil, latency)
+	return probeResult{Stream: stream, Provider: name, Stage: stage, Err: err, Latency: latency}
+}
 
 // MaxCandidates is the maximum number of search candidates to try per provider.
 const MaxCandidates = 5

--- a/internal/resolver/probe_test.go
+++ b/internal/resolver/probe_test.go
@@ -2,7 +2,9 @@ package resolver
 
 import (
 	"errors"
+	"net/http"
 	"testing"
+	"time"
 
 	"lobster/internal/media"
 )
@@ -42,5 +44,41 @@ func TestResolveWithProviderSearchFailStage(t *testing.T) {
 	_, stage, err := resolveWithProvider(f, Request{Title: "Foo", MediaType: media.Movie}, func(string, ...any) {})
 	if err == nil || stage != "search" {
 		t.Fatalf("expected search-stage failure, got stage=%q err=%v", stage, err)
+	}
+}
+
+// flakySP fails the first Watch with a transient error, then succeeds.
+type flakySP struct {
+	*fakeSP
+	failFirst bool
+	stream    *media.Stream
+	calls     *int
+}
+
+func (s *flakySP) Search(string) ([]media.SearchResult, error) {
+	return []media.SearchResult{{ID: "movie/1", Title: "Foo", Type: media.Movie}}, nil
+}
+func (s *flakySP) Watch(a, b, c, d string) (*media.Stream, error) {
+	*s.calls++
+	if s.failFirst && *s.calls == 1 {
+		return nil, errors.New("connection reset by peer")
+	}
+	return s.stream, nil
+}
+
+func TestProbeRetriesTransientThenSucceeds(t *testing.T) {
+	calls := 0
+	f := &fakeSP{} // override Search via a closure-backed fake
+	fr := &flakySP{fakeSP: f, failFirst: true, stream: &media.Stream{URL: "https://cdn/x.m3u8"}, calls: &calls}
+	r := &Resolver{health: NewHealthStore(), client: http.DefaultClient, attemptTimeout: 2 * time.Second, log: func(string, ...any) {}, validate: false}
+	res := r.probe(fr, Request{Title: "Foo", MediaType: media.Movie})
+	if res.Err != nil || res.Stream == nil {
+		t.Fatalf("expected success after retry, got %+v", res)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 attempts (1 transient retry), got %d", calls)
+	}
+	if r.health.records["flakySP"] == nil {
+		t.Fatal("probe did not record health")
 	}
 }

--- a/internal/resolver/probe_test.go
+++ b/internal/resolver/probe_test.go
@@ -78,7 +78,9 @@ func TestProbeRetriesTransientThenSucceeds(t *testing.T) {
 	if calls != 2 {
 		t.Fatalf("expected 2 attempts (1 transient retry), got %d", calls)
 	}
-	if r.health.records["flakySP"] == nil {
-		t.Fatal("probe did not record health")
+	// probe no longer records health itself; the result it returns carries the
+	// outcome, and Resolve records it on the receive side.
+	if res.Provider != "flakySP" {
+		t.Fatalf("expected provider name flakySP, got %q", res.Provider)
 	}
 }

--- a/internal/resolver/probe_test.go
+++ b/internal/resolver/probe_test.go
@@ -1,0 +1,46 @@
+package resolver
+
+import (
+	"errors"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// fakeSP is a minimal StreamProvider for tests.
+type fakeSP struct {
+	searchResults []media.SearchResult
+	searchErr     error
+	stream        *media.Stream
+	watchErr      error
+}
+
+func (f *fakeSP) Search(string) ([]media.SearchResult, error) { return f.searchResults, f.searchErr }
+func (f *fakeSP) GetDetails(string) (*media.ContentDetail, error) { return nil, nil }
+func (f *fakeSP) GetSeasons(string) ([]media.Season, error)       { return nil, nil }
+func (f *fakeSP) GetEpisodes(string, string) ([]media.Episode, error) { return nil, nil }
+func (f *fakeSP) GetServers(string, string) ([]media.Server, error)   { return nil, nil }
+func (f *fakeSP) GetEmbedURL(string) (string, error)                  { return "", nil }
+func (f *fakeSP) Trending(media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+func (f *fakeSP) Recent(media.MediaType) ([]media.SearchResult, error)   { return nil, nil }
+func (f *fakeSP) Watch(string, string, string, string) (*media.Stream, error) { return f.stream, f.watchErr }
+
+func TestResolveWithProviderSuccess(t *testing.T) {
+	f := &fakeSP{
+		searchResults: []media.SearchResult{{ID: "movie/1", Title: "Foo", Type: media.Movie}},
+		stream:        &media.Stream{URL: "https://cdn/x.m3u8"},
+	}
+	req := Request{Title: "Foo", MediaType: media.Movie, Quality: "1080"}
+	got, stage, err := resolveWithProvider(f, req, func(string, ...any) {})
+	if err != nil || got == nil || got.URL != "https://cdn/x.m3u8" {
+		t.Fatalf("got (%v,%q,%v) want stream", got, stage, err)
+	}
+}
+
+func TestResolveWithProviderSearchFailStage(t *testing.T) {
+	f := &fakeSP{searchErr: errors.New("boom")}
+	_, stage, err := resolveWithProvider(f, Request{Title: "Foo", MediaType: media.Movie}, func(string, ...any) {})
+	if err == nil || stage != "search" {
+		t.Fatalf("expected search-stage failure, got stage=%q err=%v", stage, err)
+	}
+}

--- a/internal/resolver/report.go
+++ b/internal/resolver/report.go
@@ -1,0 +1,36 @@
+package resolver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Report records every probe attempt made during a Resolve call.
+type Report struct {
+	Attempts []Attempt
+}
+
+// Attempt is a single probe result recorded in a Report.
+type Attempt struct {
+	Provider   string
+	Stage      string
+	Err        error
+	DurationMs int64
+}
+
+// Summary renders a compact one-line-per-provider failure digest.
+func (rep *Report) Summary() string {
+	parts := make([]string, 0, len(rep.Attempts))
+	for _, a := range rep.Attempts {
+		msg := "ok"
+		if a.Err != nil {
+			msg = a.Err.Error()
+		}
+		stage := a.Stage
+		if stage == "" {
+			stage = "?"
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s %s", a.Provider, stage, msg))
+	}
+	return strings.Join(parts, " · ")
+}

--- a/internal/resolver/report_test.go
+++ b/internal/resolver/report_test.go
@@ -1,0 +1,21 @@
+package resolver
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestReportSummary(t *testing.T) {
+	rep := &Report{Attempts: []Attempt{
+		{Provider: "MovieBox", Stage: "match", Err: errors.New("no matching result")},
+		{Provider: "Soap2Day", Stage: "resolve", Err: errors.New("status 403")},
+	}}
+	got := rep.Summary()
+	if !strings.Contains(got, "MovieBox: match") || !strings.Contains(got, "Soap2Day: resolve") {
+		t.Fatalf("summary missing entries: %q", got)
+	}
+	if !strings.Contains(got, " · ") {
+		t.Fatalf("summary not joined: %q", got)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -71,6 +71,7 @@ func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Re
 			go func() { ch <- r.probe(p, req) }()
 		}
 
+		batchDeadline := time.After(r.attemptTimeout)
 		remaining := len(batch)
 		for remaining > 0 {
 			select {
@@ -78,6 +79,10 @@ func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Re
 				report.add(probeResult{Provider: "(resolver)", Stage: "overall-timeout", Err: ctx.Err()})
 				_ = r.health.Save()
 				return nil, report, ctx.Err()
+			case <-batchDeadline:
+				// No winner within attemptTimeout: abandon this batch's stragglers
+				// (their buffered-channel sends won't block) and advance to the next batch.
+				remaining = 0
 			case res := <-ch:
 				remaining--
 				report.add(res)

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,19 +1,20 @@
 package resolver
 
 import (
-	"errors"
+	"context"
+	"fmt"
 	"net/http"
 	"time"
 
+	"lobster/internal/httputil"
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
 
-var errEmptyProviderSet = errors.New("no fallback providers")
-
 // Resolver holds the shared configuration used by probe and the racing Resolve
-// method (added in Task 9).
+// method.
 type Resolver struct {
+	providers      []provider.Provider
 	health         *HealthStore
 	client         *http.Client
 	batchSize      int
@@ -23,19 +24,88 @@ type Resolver struct {
 	validate       bool
 }
 
-// ResolveSequential is a temporary sequential entry point used while the
-// call sites still live in cmd. Task 9 replaces its body with the racing Resolver.
-func ResolveSequential(providers []provider.Provider, req Request, log func(string, ...any)) (*media.Stream, error) {
-	var lastErr error
-	for _, p := range providers {
-		s, _, err := resolveWithProvider(p, req, log)
-		if err == nil {
-			return s, nil
+// New constructs a Resolver with sensible defaults.
+// nil log is replaced with a no-op.
+func New(providers []provider.Provider, health *HealthStore, log func(string, ...any)) *Resolver {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	return &Resolver{
+		providers:      providers,
+		health:         health,
+		log:            log,
+		batchSize:      3,
+		attemptTimeout: 30 * time.Second,
+		overallTimeout: 90 * time.Second,
+		client:         httputil.NewClient(),
+		validate:       true,
+	}
+}
+
+// Report records every probe attempt made during a Resolve call.
+type Report struct {
+	Attempts []Attempt
+}
+
+// Attempt is a single probe result recorded in a Report.
+type Attempt struct {
+	Provider   string
+	Stage      string
+	Err        error
+	DurationMs int64
+}
+
+// Summary returns a short human-readable summary of the report.
+// Task 10 provides the real implementation; this stub keeps the package compiling.
+func (rep *Report) Summary() string { return "" }
+
+// add appends a probeResult to the report.
+func (rep *Report) add(res probeResult) {
+	rep.Attempts = append(rep.Attempts, Attempt{
+		Provider:   res.Provider,
+		Stage:      res.Stage,
+		Err:        res.Err,
+		DurationMs: res.Latency.Milliseconds(),
+	})
+}
+
+// Resolve runs staged racing across health-ordered provider batches.
+// The first probe that returns a valid stream wins; the rest are abandoned
+// (not cancelled — each goroutine's send is unblocked by the K-buffered channel).
+func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Report, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.overallTimeout)
+	defer cancel()
+
+	report := &Report{}
+	batches := r.health.Order(r.providers, time.Now(), r.batchSize)
+
+	for _, batch := range batches {
+		// Buffered to exactly len(batch) so abandoned-loser goroutines never
+		// block on send when the racer returns early.
+		ch := make(chan probeResult, len(batch))
+		for _, p := range batch {
+			p := p
+			go func() { ch <- r.probe(p, req) }()
 		}
-		lastErr = err
+
+		remaining := len(batch)
+		for remaining > 0 {
+			select {
+			case <-ctx.Done():
+				report.add(probeResult{Stage: "overall-timeout", Err: ctx.Err()})
+				_ = r.health.Save()
+				return nil, report, ctx.Err()
+			case res := <-ch:
+				remaining--
+				report.add(res)
+				if res.Err == nil && res.Stream != nil {
+					_ = r.health.Save()
+					return res.Stream, report, nil // abandon the rest
+				}
+			}
+		}
 	}
-	if lastErr == nil {
-		lastErr = errEmptyProviderSet
-	}
-	return nil, lastErr
+
+	_ = r.health.Save()
+	return nil, report, fmt.Errorf("all providers failed: %s", report.Summary())
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,0 +1,27 @@
+package resolver
+
+import (
+	"errors"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+var errEmptyProviderSet = errors.New("no fallback providers")
+
+// ResolveSequential is a temporary sequential entry point used while the
+// call sites still live in cmd. Task 9 replaces its body with the racing Resolver.
+func ResolveSequential(providers []provider.Provider, req Request, log func(string, ...any)) (*media.Stream, error) {
+	var lastErr error
+	for _, p := range providers {
+		s, _, err := resolveWithProvider(p, req, log)
+		if err == nil {
+			return s, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errEmptyProviderSet
+	}
+	return nil, lastErr
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2,12 +2,26 @@ package resolver
 
 import (
 	"errors"
+	"net/http"
+	"time"
 
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
 
 var errEmptyProviderSet = errors.New("no fallback providers")
+
+// Resolver holds the shared configuration used by probe and the racing Resolve
+// method (added in Task 9).
+type Resolver struct {
+	health         *HealthStore
+	client         *http.Client
+	batchSize      int
+	attemptTimeout time.Duration
+	overallTimeout time.Duration
+	log            func(string, ...any)
+	validate       bool
+}
 
 // ResolveSequential is a temporary sequential entry point used while the
 // call sites still live in cmd. Task 9 replaces its body with the racing Resolver.

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -75,7 +75,7 @@ func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Re
 		for remaining > 0 {
 			select {
 			case <-ctx.Done():
-				report.add(probeResult{Stage: "overall-timeout", Err: ctx.Err()})
+				report.add(probeResult{Provider: "(resolver)", Stage: "overall-timeout", Err: ctx.Err()})
 				_ = r.health.Save()
 				return nil, report, ctx.Err()
 			case res := <-ch:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -66,8 +66,12 @@ func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Re
 		// Buffered to exactly len(batch) so abandoned-loser goroutines never
 		// block on send when the racer returns early.
 		ch := make(chan probeResult, len(batch))
+		// pending tracks providers whose probe hasn't been received yet, so the
+		// resolver can record a timeout for any it abandons at the batch deadline.
+		pending := make(map[string]bool, len(batch))
 		for _, p := range batch {
 			p := p
+			pending[ProviderName(p)] = true
 			go func() { ch <- r.probe(p, req) }()
 		}
 
@@ -76,16 +80,22 @@ func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Re
 		for remaining > 0 {
 			select {
 			case <-ctx.Done():
+				r.recordPending(pending, report)
 				report.add(probeResult{Provider: "(resolver)", Stage: "overall-timeout", Err: ctx.Err()})
 				_ = r.health.Save()
 				return nil, report, ctx.Err()
 			case <-batchDeadline:
-				// No winner within attemptTimeout: abandon this batch's stragglers
-				// (their buffered-channel sends won't block) and advance to the next batch.
+				// No winner within attemptTimeout: record the still-pending
+				// providers as timeouts so chronically-slow providers are
+				// deprioritized (not rewarded by a late self-reported success),
+				// abandon their stragglers, and advance to the next batch.
+				r.recordPending(pending, report)
 				remaining = 0
 			case res := <-ch:
 				remaining--
+				delete(pending, res.Provider)
 				report.add(res)
+				r.health.Record(res.Provider, res.Err == nil, res.Latency)
 				if res.Err == nil && res.Stream != nil {
 					_ = r.health.Save()
 					return res.Stream, report, nil // abandon the rest
@@ -96,4 +106,20 @@ func (r *Resolver) Resolve(ctx context.Context, req Request) (*media.Stream, *Re
 
 	_ = r.health.Save()
 	return nil, report, fmt.Errorf("all providers failed: %s", report.Summary())
+}
+
+// recordPending marks every provider still running when its batch was abandoned
+// (batch deadline or overall timeout) as a timeout failure, deprioritizing it
+// for next time, and notes it in the report. Abandoned probe goroutines no
+// longer self-report, so this is their only health signal.
+func (r *Resolver) recordPending(pending map[string]bool, report *Report) {
+	for name := range pending {
+		r.health.Record(name, false, r.attemptTimeout)
+		report.add(probeResult{
+			Provider: name,
+			Stage:    "batch-timeout",
+			Err:      fmt.Errorf("no result within %s", r.attemptTimeout),
+			Latency:  r.attemptTimeout,
+		})
+	}
 }

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -42,23 +42,6 @@ func New(providers []provider.Provider, health *HealthStore, log func(string, ..
 	}
 }
 
-// Report records every probe attempt made during a Resolve call.
-type Report struct {
-	Attempts []Attempt
-}
-
-// Attempt is a single probe result recorded in a Report.
-type Attempt struct {
-	Provider   string
-	Stage      string
-	Err        error
-	DurationMs int64
-}
-
-// Summary returns a short human-readable summary of the report.
-// Task 10 provides the real implementation; this stub keeps the package compiling.
-func (rep *Report) Summary() string { return "" }
-
 // add appends a probeResult to the report.
 func (rep *Report) add(res probeResult) {
 	rep.Attempts = append(rep.Attempts, Attempt{

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -79,3 +79,32 @@ func TestResolveAdvancesPastSlowBatch(t *testing.T) {
 		t.Fatalf("resolver waited for the slow provider (%v) instead of advancing after the batch deadline", elapsed)
 	}
 }
+
+// A provider that exceeds the batch deadline must be recorded as a FAILURE (so a
+// chronically-slow provider is deprioritized), not rewarded by a late
+// self-reported success, and must appear in the report.
+func TestResolveRecordsTimeoutAsFailure(t *testing.T) {
+	slow := &delayedSP{fakeSP: &fakeSP{}, name: "slow", delay: 200 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/slow.m3u8"}}
+	h := NewHealthStore()
+	r := New([]provider.Provider{slow}, h, func(string, ...any) {})
+	r.validate = false
+	r.batchSize = 1
+	r.attemptTimeout = 20 * time.Millisecond // slower than 20ms -> abandoned as timeout
+	_, rep, err := r.Resolve(context.Background(), Request{Title: "Foo", MediaType: media.Movie})
+	if err == nil {
+		t.Fatal("expected failure when the only provider is too slow")
+	}
+	rec := h.records[ProviderName(slow)]
+	if rec == nil || rec.Score >= healthNeutral {
+		t.Fatalf("expected slow provider recorded as failure (score < %.2f), got %+v", healthNeutral, rec)
+	}
+	foundTimeout := false
+	for _, a := range rep.Attempts {
+		if a.Stage == "batch-timeout" && a.Provider == ProviderName(slow) {
+			foundTimeout = true
+		}
+	}
+	if !foundTimeout {
+		t.Fatalf("expected a batch-timeout attempt for the slow provider in the report, got %+v", rep.Attempts)
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -64,8 +64,8 @@ func TestResolveAllFailReturnsReport(t *testing.T) {
 }
 
 func TestResolveAdvancesPastSlowBatch(t *testing.T) {
-	slow := &delayedSP{name: "slow", delay: 500 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/slow.m3u8"}}
-	fast := &delayedSP{name: "fast", delay: 5 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/fast.m3u8"}}
+	slow := &delayedSP{fakeSP: &fakeSP{}, name: "slow", delay: 500 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/slow.m3u8"}}
+	fast := &delayedSP{fakeSP: &fakeSP{}, name: "fast", delay: 5 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/fast.m3u8"}}
 	r := New([]provider.Provider{slow, fast}, NewHealthStore(), func(string, ...any) {})
 	r.validate = false
 	r.batchSize = 1               // slow in batch 1, fast in batch 2

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,0 +1,64 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// delayedSP embeds fakeSP; Search returns one result, Watch sleeps delay then
+// returns stream or err.
+type delayedSP struct {
+	*fakeSP
+	name   string
+	delay  time.Duration
+	stream *media.Stream
+	err    error
+}
+
+func (d *delayedSP) Search(_ string) ([]media.SearchResult, error) {
+	return []media.SearchResult{{ID: "movie/1", Title: "Foo", Type: media.Movie}}, nil
+}
+
+func (d *delayedSP) Watch(_, _, _, _ string) (*media.Stream, error) {
+	if d.delay > 0 {
+		time.Sleep(d.delay)
+	}
+	return d.stream, d.err
+}
+
+func TestResolveFirstValidWins(t *testing.T) {
+	slow := &delayedSP{fakeSP: &fakeSP{}, name: "slow", delay: 300 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/slow.m3u8"}}
+	fast := &delayedSP{fakeSP: &fakeSP{}, name: "fast", delay: 10 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/fast.m3u8"}}
+	r := New([]provider.Provider{slow, fast}, NewHealthStore(), func(string, ...any) {})
+	r.validate = false
+	r.batchSize = 3 // race both together
+	got, rep, err := r.Resolve(context.Background(), Request{Title: "Foo", MediaType: media.Movie})
+	if err != nil || got == nil {
+		t.Fatalf("expected a stream, got %v / %v", got, err)
+	}
+	if got.URL != "https://cdn/fast.m3u8" {
+		t.Fatalf("expected fastest provider to win, got %s", got.URL)
+	}
+	if rep == nil {
+		t.Fatal("expected a report")
+	}
+}
+
+func TestResolveAllFailReturnsReport(t *testing.T) {
+	a := &delayedSP{fakeSP: &fakeSP{}, name: "a", err: errors.New("no matching result")}
+	b := &delayedSP{fakeSP: &fakeSP{}, name: "b", err: errors.New("status 404")}
+	r := New([]provider.Provider{a, b}, NewHealthStore(), func(string, ...any) {})
+	r.validate = false
+	got, rep, err := r.Resolve(context.Background(), Request{Title: "Foo", MediaType: media.Movie})
+	if got != nil || err == nil {
+		t.Fatalf("expected failure, got %v", got)
+	}
+	if rep == nil || len(rep.Attempts) != 2 {
+		t.Fatalf("expected 2 attempts in report, got %+v", rep)
+	}
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -62,3 +62,20 @@ func TestResolveAllFailReturnsReport(t *testing.T) {
 		t.Fatalf("expected 2 attempts in report, got %+v", rep)
 	}
 }
+
+func TestResolveAdvancesPastSlowBatch(t *testing.T) {
+	slow := &delayedSP{name: "slow", delay: 500 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/slow.m3u8"}}
+	fast := &delayedSP{name: "fast", delay: 5 * time.Millisecond, stream: &media.Stream{URL: "https://cdn/fast.m3u8"}}
+	r := New([]provider.Provider{slow, fast}, NewHealthStore(), func(string, ...any) {})
+	r.validate = false
+	r.batchSize = 1               // slow in batch 1, fast in batch 2
+	r.attemptTimeout = 50 * time.Millisecond // batch 1 can't finish in time -> abandon -> batch 2
+	start := time.Now()
+	got, _, err := r.Resolve(context.Background(), Request{Title: "Foo", MediaType: media.Movie})
+	if err != nil || got == nil || got.URL != "https://cdn/fast.m3u8" {
+		t.Fatalf("expected fast (batch 2) to win after slow batch abandoned, got %v / %v", got, err)
+	}
+	if elapsed := time.Since(start); elapsed > 400*time.Millisecond {
+		t.Fatalf("resolver waited for the slow provider (%v) instead of advancing after the batch deadline", elapsed)
+	}
+}

--- a/internal/resolver/validate.go
+++ b/internal/resolver/validate.go
@@ -1,0 +1,42 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"lobster/internal/media"
+)
+
+const validateTimeout = 4 * time.Second
+
+// validateStream does a cheap reachability check on the resolved URL: a 1-byte
+// Range GET replaying the stream's Referer and a browser User-Agent. It is
+// deliberately a playlist-level check (status < 400), not a segment-level
+// playability guarantee. Returns nil if reachable.
+func validateStream(client *http.Client, s *media.Stream) error {
+	if s == nil || s.URL == "" {
+		return fmt.Errorf("empty stream")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), validateTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+	req.Header.Set("Range", "bytes=0-0")
+	if s.Referer != "" {
+		req.Header.Set("Referer", s.Referer)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("validation status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/resolver/validate_test.go
+++ b/internal/resolver/validate_test.go
@@ -1,0 +1,34 @@
+package resolver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+func TestValidateStream(t *testing.T) {
+	var gotReferer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReferer = r.Header.Get("Referer")
+		if r.URL.Path == "/dead" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusPartialContent)
+	}))
+	defer srv.Close()
+
+	ok := &media.Stream{URL: srv.URL + "/live.m3u8", Referer: "https://ref/"}
+	if err := validateStream(srv.Client(), ok); err != nil {
+		t.Fatalf("expected live stream valid, got %v", err)
+	}
+	if gotReferer != "https://ref/" {
+		t.Fatalf("Referer not replayed: %q", gotReferer)
+	}
+	dead := &media.Stream{URL: srv.URL + "/dead", Referer: "https://ref/"}
+	if err := validateStream(srv.Client(), dead); err == nil {
+		t.Fatal("expected dead (403) stream invalid")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the **sequential, stateless** stream-resolution fallback chain with a resilient resolver in a new `internal/resolver` package. On playback, instead of trying providers one-at-a-time in a fixed order (slow when early providers are dead, no memory, no retries, opaque failures), it:

- **Races health-ranked providers in batches** (3 at a time) — first lightly-validated stream wins and returns immediately; losers are abandoned (provider methods are context-free, so they self-expire at their own HTTP timeout).
- **Remembers what works** — a persisted `HealthStore` (EWMA success score + latency, time-decayed so dead-yesterday providers get retried) orders providers so good sources are tried first. Stored at `~/.local/share/lobster/health.json`.
- **Retries transient failures** (network/DNS/timeout/5xx) once with backoff; permanent failures (no-match/404) aren't retried.
- **Lightly validates** the resolved URL (a `Range` GET replaying the `Referer`) to catch obviously-dead playlists before handing it to the player.
- **Per-batch deadline** (`attemptTimeout`, 30s) so one slow-failing provider can't gate reaching healthier providers in later batches.
- **Surfaces why it failed** — a compact per-provider summary (`moviebox: no match · soap2day: resolve 403 · …`) instead of `all fallback providers failed`.

## Scope

Replaces the **fallback chain** (`tryFallbackStream`, its 6 call sites + the download-manager resolver) only. The primary-first movie path (configured server preference, named-server iteration) is **preserved untouched**.

## Notable correctness work

- **Concurrency-safe by construction:** fresh provider instances per resolve, each used by exactly one probe goroutine; the per-batch result channel is buffered to exactly K so abandoned losers never block. The `HealthStore` is the only shared state — its `Order`/`Record`/`Save` are mutex-safe (a review caught and fixed a `concurrent map read/write` crash where `Order` sorted after releasing the lock; now it snapshots keys under the lock). `Save` does disk I/O off the records lock.
- Fixed a pre-existing `MovieBox.pos` data race (prerequisite for concurrent use).

## Testing

- `go test ./...` green across all packages, including a concurrency regression test that runs `Order` against `Record` (panics deterministically without the fix, even without `-race`).
- ⚠️ **Manual playback verification pending** on a real network: resolution should be faster/more reliable, health.json should appear and reorder providers across runs, and failures should read as a per-provider summary.

## Follow-ons (out of scope here)

- **Resume on mid-stream drop** (the resolver retains state for a `Next()`; mpv already exposes exit-code + position) — its own spec.
- Threading `context.Context` through the provider interface for *true* loser cancellation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved stream resolution with centralized fallback probing, clearer failure summaries, and smarter provider ordering based on persisted health.
  * Added stream URL reachability validation to avoid unusable results.
* **Bug Fixes**
  * Reduced time lost on unreliable providers by retrying transient failures, enforcing attempt/overall timeouts, and moving past slow batches.
  * Fixed concurrency issues in provider host rotation to prevent race conditions and unstable base URL selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->