### PR TITLE
feat: FlixHQ listings + TMDB posters

### DIFF
--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -7,9 +7,10 @@ import (
 )
 
 // newProvider returns the configured content provider.
-// The configured Base selects the provider (default "flixhq.to" -> FlixHQ).
-// An unrecognized Base falls back to MovieBox (direct API, no scraping).
-// Other providers (Soap2Day, KimCartoon, etc.) are selected by their Base value.
+// If APIURL is set, it overrides Base entirely and uses the Consumet API.
+// Otherwise Base selects the scraping provider (default "flixhq.to" -> FlixHQ;
+// Soap2Day, KimCartoon, etc. by their Base value); an unrecognized Base falls
+// back to MovieBox (direct API, no scraping).
 //
 // For providers that use a base domain, the domain is checked for health
 // at startup. If unreachable, known alternative domains are tried in order

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -7,9 +7,9 @@ import (
 )
 
 // newProvider returns the configured content provider.
-// Default is MovieBox (direct API, no scraping required).
-// Legacy providers (FlixHQ, Soap2Day) are available via base config
-// and are always included as fallbacks.
+// The configured Base selects the provider (default "flixhq.to" -> FlixHQ).
+// An unrecognized Base falls back to MovieBox (direct API, no scraping).
+// Other providers (Soap2Day, KimCartoon, etc.) are selected by their Base value.
 //
 // For providers that use a base domain, the domain is checked for health
 // at startup. If unreachable, known alternative domains are tried in order

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagPlayer, "player", "", "Media player: mpv | vlc | iina | celluloid")
 	rootCmd.PersistentFlags().BoolVarP(&flagContinue, "continue", "c", false, "Auto-resume from history")
 	rootCmd.PersistentFlags().BoolVarP(&flagJSON, "json", "j", false, "Output stream metadata as JSON")
-	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | tbcpl | 1shows.org")
+	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | moviebox | vaplayer | vidnest | tbcpl | 1shows.org")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
 
 	rootCmd.AddCommand(historyCmd)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -76,9 +76,9 @@ func playFlow(p provider.Provider, query string) error {
 
 	// If primary returned few results, search fallback providers in parallel.
 	// The merged results may originate from fallback providers, but playback
-	// still uses the primary provider (p) because all providers share TMDB IDs
-	// as their universal content identifier — so any provider can resolve
-	// streams for results discovered by another.
+	// still uses the primary provider (p). Providers use their own ID formats
+	// (FlixHQ uses slugs, soap2day uses TMDB IDs). Stream resolution is
+	// title-based via the resolver, so cross-provider fallback works.
 	if len(results) < 3 {
 		debugf("primary returned %d results, searching fallback providers...", len(results))
 		stop = ui.StartSpinner("Searching more providers...")
@@ -452,9 +452,9 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 		debugf("fallback failed: %v", err)
 		hint := ""
 		if _, isFlixHQ := p.(*provider.FlixHQ); isFlixHQ {
-			hint = "\nTip: try --base soap2day or --base vaplayer for better stream availability"
+			hint = "\nTip: try --base moviebox or --base vaplayer for better stream availability"
 		} else if _, isFlixHQWS := p.(*provider.FlixHQWS); isFlixHQWS {
-			hint = "\nTip: try --base soap2day or --base vaplayer for better stream availability"
+			hint = "\nTip: try --base moviebox or --base vaplayer for better stream availability"
 		}
 		return fmt.Errorf("all providers failed for %s: %w%s", title, err, hint)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 // Default returns the default configuration.
 func Default() *Config {
 	return &Config{
-		Base:         "soap2day",
+		Base:         "flixhq.to",
 		Player:       "mpv",
 		Provider:     "Default",
 		SubsLanguage: "english",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,9 @@ func TestDefault(t *testing.T) {
 	if !cfg.History {
 		t.Error("default history should be true")
 	}
+	if cfg.Base != "flixhq.to" {
+		t.Fatalf("Base=%q want flixhq.to", cfg.Base)
+	}
 }
 
 func TestValidate(t *testing.T) {

--- a/internal/provider/soap2day.go
+++ b/internal/provider/soap2day.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	tmdbSearchBase = "https://www.themoviedb.org"
 	moviesapiBase  = "https://ww2.moviesapi.to"
 	flixcdnBase    = "https://flixcdn.cyou"
 	hd4uBase       = "https://hd4u.sbs"
@@ -37,43 +36,6 @@ func NewSoap2Day() *Soap2Day {
 		client: httputil.NewClient(),
 	}
 }
-
-// --- TMDB search types ---
-
-type tmdbSearchResponse struct {
-	Results []json.RawMessage `json:"results"`
-}
-
-type tmdbSearchResult struct {
-	ID           int     `json:"id"`
-	Title        string  `json:"title"`        // movie
-	Name         string  `json:"name"`         // tv
-	MediaType    string  `json:"media_type"`   // "movie" or "tv"
-	Overview     string  `json:"overview"`
-	ReleaseDate  string  `json:"release_date"` // movie
-	FirstAirDate string  `json:"first_air_date"` // tv
-	VoteAverage  float64 `json:"vote_average"`
-	PosterPath   string  `json:"poster_path"`
-}
-
-func (r *tmdbSearchResult) displayTitle() string {
-	if r.Name != "" {
-		return r.Name
-	}
-	return r.Title
-}
-
-func (r *tmdbSearchResult) year() string {
-	date := r.ReleaseDate
-	if date == "" {
-		date = r.FirstAirDate
-	}
-	if len(date) >= 4 {
-		return date[:4]
-	}
-	return ""
-}
-
 
 // --- moviesapi types ---
 
@@ -138,12 +100,11 @@ func (s *Soap2Day) Search(query string) ([]media.SearchResult, error) {
 		}
 
 		results = append(results, media.SearchResult{
-			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title:  item.displayTitle(),
-			Type:   mt,
-			Year:   item.year(),
-			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
-			Poster: tmdbPosterURL(item.PosterPath),
+			ID:    fmt.Sprintf("%s/%d", item.MediaType, item.ID),
+			Title: item.displayTitle(),
+			Type:  mt,
+			Year:  item.year(),
+			URL:   fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
 		})
 	}
 
@@ -343,14 +304,6 @@ func (s *Soap2Day) Watch(mediaID, episodeID, server, quality string) (*media.Str
 	return nil, fmt.Errorf("stream resolution failed: %w", lastErr)
 }
 
-// extractTMDBID extracts the numeric TMDB ID from a provider ID like "tv/79744" or "movie/299534".
-func extractTMDBID(id string) string {
-	if idx := strings.LastIndex(id, "/"); idx >= 0 {
-		return id[idx+1:]
-	}
-	return id
-}
-
 // extractEmbedID extracts the embed ID from a flixcdn video_url.
 func extractEmbedID(videoURL string) (string, error) {
 	idx := strings.Index(videoURL, "#")
@@ -530,12 +483,11 @@ func (s *Soap2Day) fetchTMDBTrending(mediaType string) ([]media.SearchResult, er
 		}
 
 		results = append(results, media.SearchResult{
-			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title:  item.displayTitle(),
-			Type:   mt,
-			Year:   item.year(),
-			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
-			Poster: tmdbPosterURL(item.PosterPath),
+			ID:    fmt.Sprintf("%s/%d", item.MediaType, item.ID),
+			Title: item.displayTitle(),
+			Type:  mt,
+			Year:  item.year(),
+			URL:   fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
 		})
 	}
 

--- a/internal/provider/soap2day.go
+++ b/internal/provider/soap2day.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	moviesapiBase  = "https://ww2.moviesapi.to"
-	flixcdnBase    = "https://flixcdn.cyou"
-	hd4uBase       = "https://hd4u.sbs"
-	flixcdnKey     = "kiemtienmua911ca"
-	flixcdnIV      = "1234567890oiuytr"
+	moviesapiBase = "https://ww2.moviesapi.to"
+	flixcdnBase   = "https://flixcdn.cyou"
+	hd4uBase      = "https://hd4u.sbs"
+	flixcdnKey    = "kiemtienmua911ca"
+	flixcdnIV     = "1234567890oiuytr"
 )
 
 // Soap2Day implements the StreamProvider interface using TMDB for search
@@ -100,11 +100,12 @@ func (s *Soap2Day) Search(query string) ([]media.SearchResult, error) {
 		}
 
 		results = append(results, media.SearchResult{
-			ID:    fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title: item.displayTitle(),
-			Type:  mt,
-			Year:  item.year(),
-			URL:   fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
+			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
+			Title:  item.displayTitle(),
+			Type:   mt,
+			Year:   item.year(),
+			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
+			Poster: tmdbPosterURL(item.PosterPath),
 		})
 	}
 
@@ -334,7 +335,9 @@ func (s *Soap2Day) decryptCDN(base, embedID string) (string, []media.Subtitle, e
 	// Check for JSON error responses (e.g. {"message": "Video not found or deleted"})
 	trimmed := strings.TrimSpace(string(body))
 	if len(trimmed) > 0 && trimmed[0] == '{' {
-		var errResp struct{ Message string `json:"message"` }
+		var errResp struct {
+			Message string `json:"message"`
+		}
 		if json.Unmarshal([]byte(trimmed), &errResp) == nil && errResp.Message != "" {
 			return "", nil, fmt.Errorf("%s", errResp.Message)
 		}
@@ -483,11 +486,12 @@ func (s *Soap2Day) fetchTMDBTrending(mediaType string) ([]media.SearchResult, er
 		}
 
 		results = append(results, media.SearchResult{
-			ID:    fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title: item.displayTitle(),
-			Type:  mt,
-			Year:  item.year(),
-			URL:   fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
+			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
+			Title:  item.displayTitle(),
+			Type:   mt,
+			Year:   item.year(),
+			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
+			Poster: tmdbPosterURL(item.PosterPath),
 		})
 	}
 

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -23,12 +23,12 @@ type tmdbSearchResponse struct {
 
 type tmdbSearchResult struct {
 	ID           int     `json:"id"`
-	Title        string  `json:"title"`          // movie
-	Name         string  `json:"name"`            // tv
-	MediaType    string  `json:"media_type"`      // "movie" or "tv"
+	Title        string  `json:"title"`      // movie
+	Name         string  `json:"name"`       // tv
+	MediaType    string  `json:"media_type"` // "movie" or "tv"
 	Overview     string  `json:"overview"`
-	ReleaseDate  string  `json:"release_date"`    // movie
-	FirstAirDate string  `json:"first_air_date"`  // tv
+	ReleaseDate  string  `json:"release_date"`   // movie
+	FirstAirDate string  `json:"first_air_date"` // tv
 	VoteAverage  float64 `json:"vote_average"`
 	PosterPath   string  `json:"poster_path"`
 }
@@ -125,7 +125,7 @@ var (
 // no confident match. Memoized per (title|year|isTV) for the process, including
 // negative results so a miss is never re-queried.
 func TMDBPoster(title, year string, isTV bool) string {
-	key := fmt.Sprintf("%s|%s|%t", strings.ToLower(strings.TrimSpace(title)), year, isTV)
+	key := fmt.Sprintf("%s|%s|%t", strings.ToLower(strings.TrimSpace(title)), strings.TrimSpace(year), isTV)
 	if v, ok := tmdbPosterMemo.Load(key); ok {
 		return v.(string)
 	}
@@ -141,8 +141,9 @@ func tmdbPosterLookup(title, year string, isTV bool) string {
 	if err != nil {
 		return ""
 	}
-	req.Header.Set("User-Agent", "Mozilla/5.0")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
 	req.Header.Set("Accept", "application/json, text/html, */*")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.5")
 	req.Header.Set("Referer", strings.TrimRight(tmdbBaseURL, "/")+"/")
 	resp, err := tmdbClient.Do(req)
 	if err != nil {

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -158,6 +158,9 @@ func tmdbPosterLookup(title, year string, isTV bool) (string, bool) {
 		return "", false
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", false // non-2xx (rate-limit/proxy error): transient, don't cache
+	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		return "", false

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -129,17 +129,25 @@ func TMDBPoster(title, year string, isTV bool) string {
 	if v, ok := tmdbPosterMemo.Load(key); ok {
 		return v.(string)
 	}
-	res := tmdbPosterLookup(title, year, isTV)
-	tmdbPosterMemo.Store(key, res)
+	res, cacheable := tmdbPosterLookup(title, year, isTV)
+	if cacheable {
+		// Only memoize deterministic outcomes (a parsed response — match or not).
+		// Transient errors are NOT cached, so a momentary TMDB blip doesn't stick
+		// a permanent miss for this title for the rest of the session.
+		tmdbPosterMemo.Store(key, res)
+	}
 	return res
 }
 
-func tmdbPosterLookup(title, year string, isTV bool) string {
+// tmdbPosterLookup returns the matched poster URL (or "" for a genuine no-match)
+// and whether the outcome is cacheable. A network/parse error returns ("", false)
+// so the caller retries on the next selection instead of caching the failure.
+func tmdbPosterLookup(title, year string, isTV bool) (string, bool) {
 	endpoint := fmt.Sprintf("%s/search/trending?query=%s",
 		strings.TrimRight(tmdbBaseURL, "/"), url.QueryEscape(title))
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
-		return ""
+		return "", false
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
 	req.Header.Set("Accept", "application/json, text/html, */*")
@@ -147,16 +155,16 @@ func tmdbPosterLookup(title, year string, isTV bool) string {
 	req.Header.Set("Referer", strings.TrimRight(tmdbBaseURL, "/")+"/")
 	resp, err := tmdbClient.Do(req)
 	if err != nil {
-		return ""
+		return "", false
 	}
 	defer resp.Body.Close()
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return ""
+		return "", false
 	}
 	var sr tmdbSearchResponse
 	if json.Unmarshal(data, &sr) != nil {
-		return ""
+		return "", false
 	}
 	objs := make([]tmdbSearchResult, 0, len(sr.Results))
 	for _, raw := range sr.Results {
@@ -168,5 +176,5 @@ func tmdbPosterLookup(title, year string, isTV bool) string {
 			objs = append(objs, item)
 		}
 	}
-	return pickPoster(objs, title, year, isTV)
+	return pickPoster(objs, title, year, isTV), true
 }

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -1,0 +1,171 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"lobster/internal/httputil"
+)
+
+// --- TMDB shared const, types, and helpers ---
+
+const tmdbSearchBase = "https://www.themoviedb.org"
+
+type tmdbSearchResponse struct {
+	Results []json.RawMessage `json:"results"`
+}
+
+type tmdbSearchResult struct {
+	ID           int     `json:"id"`
+	Title        string  `json:"title"`          // movie
+	Name         string  `json:"name"`            // tv
+	MediaType    string  `json:"media_type"`      // "movie" or "tv"
+	Overview     string  `json:"overview"`
+	ReleaseDate  string  `json:"release_date"`    // movie
+	FirstAirDate string  `json:"first_air_date"`  // tv
+	VoteAverage  float64 `json:"vote_average"`
+	PosterPath   string  `json:"poster_path"`
+}
+
+func (r *tmdbSearchResult) displayTitle() string {
+	if r.Name != "" {
+		return r.Name
+	}
+	return r.Title
+}
+
+func (r *tmdbSearchResult) year() string {
+	date := r.ReleaseDate
+	if date == "" {
+		date = r.FirstAirDate
+	}
+	if len(date) >= 4 {
+		return date[:4]
+	}
+	return ""
+}
+
+// tmdbPosterURL builds a full TMDB poster image URL from a poster path.
+func tmdbPosterURL(posterPath string) string {
+	if posterPath == "" {
+		return ""
+	}
+	return "https://image.tmdb.org/t/p/w500" + posterPath
+}
+
+// extractTMDBID extracts the numeric TMDB ID from a provider ID like "tv/79744" or "movie/299534".
+func extractTMDBID(id string) string {
+	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+		return id[idx+1:]
+	}
+	return id
+}
+
+// --- Confident-match poster selection ---
+
+// pickPoster returns the TMDB poster URL of the first CONFIDENT match for the
+// given title/year/type, or "" if none (caller keeps its existing poster).
+func pickPoster(results []tmdbSearchResult, title, year string, isTV bool) string {
+	wantType := "movie"
+	if isTV {
+		wantType = "tv"
+	}
+	for i := range results {
+		r := &results[i]
+		if r.MediaType != wantType {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(r.displayTitle()), strings.TrimSpace(title)) {
+			continue
+		}
+		if !yearMatches(r.year(), year) {
+			continue
+		}
+		if r.PosterPath == "" {
+			continue
+		}
+		return tmdbPosterURL(r.PosterPath)
+	}
+	return ""
+}
+
+// yearMatches is lenient when either year is unknown/unparseable, else requires
+// the years within ±1 (release vs production year commonly differ by one).
+func yearMatches(a, b string) bool {
+	if a == "" || b == "" {
+		return true
+	}
+	ai, err1 := strconv.Atoi(a)
+	bi, err2 := strconv.Atoi(b)
+	if err1 != nil || err2 != nil {
+		return true
+	}
+	d := ai - bi
+	if d < 0 {
+		d = -d
+	}
+	return d <= 1
+}
+
+// --- TMDBPoster: fetch + parse + memoize ---
+
+var (
+	tmdbBaseURL    = tmdbSearchBase // overridable in tests
+	tmdbClient     = httputil.NewClient()
+	tmdbPosterMemo sync.Map // "title|year|isTV" -> string (incl. "" misses)
+)
+
+// TMDBPoster returns a high-res TMDB poster URL for a title, or "" if there is
+// no confident match. Memoized per (title|year|isTV) for the process, including
+// negative results so a miss is never re-queried.
+func TMDBPoster(title, year string, isTV bool) string {
+	key := fmt.Sprintf("%s|%s|%t", strings.ToLower(strings.TrimSpace(title)), year, isTV)
+	if v, ok := tmdbPosterMemo.Load(key); ok {
+		return v.(string)
+	}
+	res := tmdbPosterLookup(title, year, isTV)
+	tmdbPosterMemo.Store(key, res)
+	return res
+}
+
+func tmdbPosterLookup(title, year string, isTV bool) string {
+	endpoint := fmt.Sprintf("%s/search/trending?query=%s",
+		strings.TrimRight(tmdbBaseURL, "/"), url.QueryEscape(title))
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+	req.Header.Set("Accept", "application/json, text/html, */*")
+	req.Header.Set("Referer", strings.TrimRight(tmdbBaseURL, "/")+"/")
+	resp, err := tmdbClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return ""
+	}
+	var sr tmdbSearchResponse
+	if json.Unmarshal(data, &sr) != nil {
+		return ""
+	}
+	objs := make([]tmdbSearchResult, 0, len(sr.Results))
+	for _, raw := range sr.Results {
+		if len(raw) == 0 || raw[0] != '{' { // skip autocomplete <span> strings
+			continue
+		}
+		var item tmdbSearchResult
+		if json.Unmarshal(raw, &item) == nil {
+			objs = append(objs, item)
+		}
+	}
+	return pickPoster(objs, title, year, isTV)
+}

--- a/internal/provider/tmdb_test.go
+++ b/internal/provider/tmdb_test.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func mkResult(id int, name, mediaType, year, poster string) tmdbSearchResult {
+	r := tmdbSearchResult{ID: id, Name: name, MediaType: mediaType, PosterPath: poster}
+	if mediaType == "tv" {
+		r.FirstAirDate = year + "-01-01"
+	} else {
+		r.ReleaseDate = year + "-01-01"
+	}
+	return r
+}
+
+func TestPickPoster(t *testing.T) {
+	office := []tmdbSearchResult{
+		mkResult(1, "The Office", "movie", "1996", "/uk.jpg"), // UK short, sorts first
+		mkResult(2, "The Office", "tv", "2005", "/us.jpg"),    // the US show
+		mkResult(3, "Steve Carell", "person", "", "/p.jpg"),
+	}
+	cases := []struct {
+		name        string
+		results     []tmdbSearchResult
+		title, year string
+		isTV        bool
+		want        string
+	}{
+		{"tv picks US show not results[0]", office, "The Office", "2005", true, "https://image.tmdb.org/t/p/w500/us.jpg"},
+		{"movie picks UK short", office, "The Office", "1996", false, "https://image.tmdb.org/t/p/w500/uk.jpg"},
+		{"case-insensitive name", office, "the office", "2005", true, "https://image.tmdb.org/t/p/w500/us.jpg"},
+		{"year off by one still matches", []tmdbSearchResult{mkResult(1, "Up", "movie", "2009", "/up.jpg")}, "Up", "2008", false, "https://image.tmdb.org/t/p/w500/up.jpg"},
+		{"year off by two -> no match", []tmdbSearchResult{mkResult(1, "Up", "movie", "2009", "/up.jpg")}, "Up", "2006", false, ""},
+		{"missing input year -> name+type match", []tmdbSearchResult{mkResult(1, "Up", "movie", "2009", "/up.jpg")}, "Up", "", false, "https://image.tmdb.org/t/p/w500/up.jpg"},
+		{"no name match -> empty", office, "Severance", "2022", true, ""},
+		{"person never matches", []tmdbSearchResult{mkResult(1, "Up", "person", "", "/p.jpg")}, "Up", "", false, ""},
+		{"empty poster path -> empty", []tmdbSearchResult{mkResult(1, "Up", "movie", "2009", "")}, "Up", "2009", false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pickPoster(c.results, c.title, c.year, c.isTV); got != c.want {
+				t.Fatalf("pickPoster=%q want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTMDBPosterFetchAndMemo(t *testing.T) {
+	var calls int32
+	body := `{"results":[
+		"<span>autocomplete</span>",
+		{"media_type":"tv","name":"Naruto","first_air_date":"2002-10-03","poster_path":"/n.jpg"},
+		{"media_type":"person","name":"Naruto"}
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	old := tmdbBaseURL
+	tmdbBaseURL = srv.URL
+	defer func() { tmdbBaseURL = old }()
+	tmdbPosterMemo = sync.Map{} // isolate from other tests
+
+	got := TMDBPoster("Naruto", "2002", true)
+	if got != "https://image.tmdb.org/t/p/w500/n.jpg" {
+		t.Fatalf("TMDBPoster=%q", got)
+	}
+	// Memoized: a second identical call must not hit the server.
+	_ = TMDBPoster("Naruto", "2002", true)
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Fatalf("expected 1 server call (memoized), got %d", c)
+	}
+	// Negative result is also cached.
+	tmdbBaseURL = srv.URL
+	if miss := TMDBPoster("Bleach", "2004", true); miss != "" {
+		t.Fatalf("expected miss, got %q", miss)
+	}
+}

--- a/internal/provider/tmdb_test.go
+++ b/internal/provider/tmdb_test.go
@@ -78,9 +78,14 @@ func TestTMDBPosterFetchAndMemo(t *testing.T) {
 	if c := atomic.LoadInt32(&calls); c != 1 {
 		t.Fatalf("expected 1 server call (memoized), got %d", c)
 	}
-	// Negative result is also cached.
-	tmdbBaseURL = srv.URL
+	// Negative result is also cached: prime the miss, then a second identical
+	// call must not hit the server again.
 	if miss := TMDBPoster("Bleach", "2004", true); miss != "" {
 		t.Fatalf("expected miss, got %q", miss)
+	}
+	afterMiss := atomic.LoadInt32(&calls)
+	_ = TMDBPoster("Bleach", "2004", true)
+	if c := atomic.LoadInt32(&calls); c != afterMiss {
+		t.Fatalf("negative result not memoized: server calls %d -> %d", afterMiss, c)
 	}
 }

--- a/internal/provider/tmdb_test.go
+++ b/internal/provider/tmdb_test.go
@@ -9,10 +9,12 @@ import (
 )
 
 func mkResult(id int, name, mediaType, year, poster string) tmdbSearchResult {
-	r := tmdbSearchResult{ID: id, Name: name, MediaType: mediaType, PosterPath: poster}
+	r := tmdbSearchResult{ID: id, MediaType: mediaType, PosterPath: poster}
 	if mediaType == "tv" {
+		r.Name = name // TMDB puts the TV title in "name"
 		r.FirstAirDate = year + "-01-01"
 	} else {
+		r.Title = name // ...and the movie title in "title"
 		r.ReleaseDate = year + "-01-01"
 	}
 	return r
@@ -87,5 +89,33 @@ func TestTMDBPosterFetchAndMemo(t *testing.T) {
 	_ = TMDBPoster("Bleach", "2004", true)
 	if c := atomic.LoadInt32(&calls); c != afterMiss {
 		t.Fatalf("negative result not memoized: server calls %d -> %d", afterMiss, c)
+	}
+}
+
+// A non-2xx response (rate-limit/proxy error) must NOT be cached as a miss, so a
+// later selection of the same title retries instead of being stuck blank.
+func TestTMDBPosterDoesNotCacheNon2xx(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":"rate limited"}`)) // parses with results==nil
+	}))
+	defer srv.Close()
+
+	old := tmdbBaseURL
+	tmdbBaseURL = srv.URL
+	defer func() { tmdbBaseURL = old }()
+	tmdbPosterMemo = sync.Map{}
+
+	if got := TMDBPoster("Naruto", "2002", true); got != "" {
+		t.Fatalf("expected empty on non-2xx, got %q", got)
+	}
+	// Not cached: a second call must hit the server again.
+	if got := TMDBPoster("Naruto", "2002", true); got != "" {
+		t.Fatalf("expected empty on retry, got %q", got)
+	}
+	if c := atomic.LoadInt32(&calls); c != 2 {
+		t.Fatalf("non-2xx must not be cached: expected 2 server calls, got %d", c)
 	}
 }

--- a/internal/provider/vidnest.go
+++ b/internal/provider/vidnest.go
@@ -513,14 +513,6 @@ func vidnestHasStreams(data []byte) bool {
 	return len(probe.Sources) > 0 || len(probe.Streams) > 0 || len(probe.Data) > 0
 }
 
-// tmdbPosterURL builds a full TMDB poster image URL from a poster path.
-func tmdbPosterURL(posterPath string) string {
-	if posterPath == "" {
-		return ""
-	}
-	return "https://image.tmdb.org/t/p/w500" + posterPath
-}
-
 // fetchTMDB performs a GET request to TMDB with appropriate headers.
 func (v *VidNest) fetchTMDB(rawURL string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -313,10 +313,8 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(msg) > 0 {
 			m.currentItem = &msg[0]
 			cmds = append(cmds, fetchDetailCmd(m.providerForActiveTab(), msg[0].ID))
-			if msg[0].Poster != "" {
-				pw, ph := poster.BoxDims(m.width, 0, 0)
-				cmds = append(cmds, fetchPosterCmd(msg[0].ID, msg[0].Poster, pw, ph))
-			}
+			pw, ph := poster.BoxDims(m.width, 0, 0)
+			cmds = append(cmds, fetchPosterForItemCmd(msg[0], pw, ph))
 		} else {
 			m.currentItem = nil
 			m.currentDetail = nil
@@ -382,10 +380,8 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.posterB64 = ""
 			m.err = nil
 			cmds = append(cmds, fetchDetailCmd(m.providerForActiveTab(), m.currentItem.ID))
-			if m.currentItem.Poster != "" {
-				pw, ph := poster.BoxDims(m.width, 0, 0)
-				cmds = append(cmds, fetchPosterCmd(m.currentItem.ID, m.currentItem.Poster, pw, ph))
-			}
+			pw, ph := poster.BoxDims(m.width, 0, 0)
+			cmds = append(cmds, fetchPosterForItemCmd(*m.currentItem, pw, ph))
 		}
 		cmds = append(cmds, listCmd)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -42,7 +42,7 @@ const (
 
 // AppModel struct holding state
 type AppModel struct {
-	state           state
+	state             state
 	provider          provider.Provider
 	cartoonProvider   provider.Provider
 	animeProvider     provider.Provider
@@ -314,7 +314,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentItem = &msg[0]
 			cmds = append(cmds, fetchDetailCmd(m.providerForActiveTab(), msg[0].ID))
 			pw, ph := poster.BoxDims(m.width, 0, 0)
-			cmds = append(cmds, fetchPosterForItemCmd(msg[0], pw, ph))
+			cmds = append(cmds, fetchPosterForItemCmd(msg[0], pw, ph, m.posterLookup()))
 		} else {
 			m.currentItem = nil
 			m.currentDetail = nil
@@ -381,7 +381,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = nil
 			cmds = append(cmds, fetchDetailCmd(m.providerForActiveTab(), m.currentItem.ID))
 			pw, ph := poster.BoxDims(m.width, 0, 0)
-			cmds = append(cmds, fetchPosterForItemCmd(*m.currentItem, pw, ph))
+			cmds = append(cmds, fetchPosterForItemCmd(*m.currentItem, pw, ph, m.posterLookup()))
 		}
 		cmds = append(cmds, listCmd)
 	}
@@ -564,6 +564,16 @@ func (m AppModel) providerForActiveTab() provider.Provider {
 	}
 }
 
+// posterLookup returns the poster-enrichment policy for the active tab: a TMDB
+// high-res upgrade on the Movies/Series (FlixHQ) tabs, and none elsewhere so
+// Cartoons/Anime keep their own posters and skip needless TMDB lookups.
+func (m AppModel) posterLookup() func(title, year string, isTV bool) string {
+	if m.activeTab == tabMovies || m.activeTab == tabSeries {
+		return provider.TMDBPoster
+	}
+	return func(string, string, bool) string { return "" }
+}
+
 func (m AppModel) nextTab() tab {
 	switch m.activeTab {
 	case tabMovies:
@@ -656,7 +666,7 @@ func (m AppModel) renderBrowseContent(headerH, tabBarH int) string {
 
 func (m AppModel) renderHeroBand(lm layoutMetrics) string {
 	bandStyle := lipgloss.NewStyle().
-		Width(m.width - 2*bandBorder).
+		Width(m.width-2*bandBorder).
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("#444444")).
 		Padding(bandPadV, bandPadH)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -210,7 +210,7 @@ func fetchPosterForItemCmd(item media.SearchResult, width, height int) tea.Cmd {
 	return func() tea.Msg {
 		url := posterURLForItem(item, provider.TMDBPoster)
 		if url == "" {
-			return posterFetchedMsg{id: item.ID}
+			return posterFetchedMsg{id: item.ID, inline: poster.IsInlineImage()}
 		}
 		if poster.IsInlineImage() {
 			b64, w, h, err := poster.FetchInlineImage(url)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -153,6 +153,19 @@ func tuiResultScore(r media.SearchResult) int {
 	return score
 }
 
+// posterURLForItem chooses the poster URL to render: upgrade an empty or
+// non-TMDB poster to a confidently-matched TMDB one, else keep what the item
+// already has (e.g. FlixHQ's own thumbnail). lookup is injected for testing.
+func posterURLForItem(item media.SearchResult, lookup func(title, year string, isTV bool) string) string {
+	u := item.Poster
+	if u == "" || !strings.Contains(u, "image.tmdb.org") {
+		if tu := lookup(item.Title, item.Year, item.Type == media.TV); tu != "" {
+			u = tu
+		}
+	}
+	return u
+}
+
 // fetchDetailCmd fetches detailed metadata for a specific item.
 func fetchDetailCmd(p provider.Provider, id string) tea.Cmd {
 	return func() tea.Msg {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -205,10 +205,12 @@ func queueSeasonCmd(mgr *dlmanager.Manager, downloads []*store.Download) tea.Cmd
 }
 
 // fetchPosterForItemCmd resolves the best poster URL for item (upgrading to a
-// TMDB high-res poster when possible) and renders it for the detail pane.
-func fetchPosterForItemCmd(item media.SearchResult, width, height int) tea.Cmd {
+// TMDB high-res poster when the caller's lookup policy allows) and renders it
+// for the detail pane. lookup is supplied per-tab so only the Movies/Series
+// (FlixHQ) views opt into TMDB enrichment; other tabs keep their own posters.
+func fetchPosterForItemCmd(item media.SearchResult, width, height int, lookup func(title, year string, isTV bool) string) tea.Cmd {
 	return func() tea.Msg {
-		url := posterURLForItem(item, provider.TMDBPoster)
+		url := posterURLForItem(item, lookup)
 		if url == "" {
 			return posterFetchedMsg{id: item.ID, inline: poster.IsInlineImage()}
 		}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -204,18 +204,23 @@ func queueSeasonCmd(mgr *dlmanager.Manager, downloads []*store.Download) tea.Cmd
 	}
 }
 
-// fetchPosterCmd fetches and renders a poster image for the detail pane.
-func fetchPosterCmd(id, url string, width, height int) tea.Cmd {
+// fetchPosterForItemCmd resolves the best poster URL for item (upgrading to a
+// TMDB high-res poster when possible) and renders it for the detail pane.
+func fetchPosterForItemCmd(item media.SearchResult, width, height int) tea.Cmd {
 	return func() tea.Msg {
+		url := posterURLForItem(item, provider.TMDBPoster)
+		if url == "" {
+			return posterFetchedMsg{id: item.ID}
+		}
 		if poster.IsInlineImage() {
 			b64, w, h, err := poster.FetchInlineImage(url)
 			if err != nil {
-				return posterFetchedMsg{id: id, inline: true} // empty -> placeholder box
+				return posterFetchedMsg{id: item.ID, inline: true} // empty -> placeholder box
 			}
-			return posterFetchedMsg{id: id, inline: true, b64: b64, imgW: w, imgH: h}
+			return posterFetchedMsg{id: item.ID, inline: true, b64: b64, imgW: w, imgH: h}
 		}
 		rendered := poster.RenderTUI(url, width, height)
-		return posterFetchedMsg{id: id, poster: rendered}
+		return posterFetchedMsg{id: item.ID, poster: rendered}
 	}
 }
 

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -1,0 +1,29 @@
+package tui
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+func TestPosterURLForItem(t *testing.T) {
+	tmdbHit := func(string, string, bool) string { return "https://image.tmdb.org/t/p/w500/x.jpg" }
+	tmdbMiss := func(string, string, bool) string { return "" }
+
+	flix := media.SearchResult{Title: "Foo", Year: "2020", Type: media.TV, Poster: "https://flixhq/thumb.jpg"}
+	if got := posterURLForItem(flix, tmdbHit); got != "https://image.tmdb.org/t/p/w500/x.jpg" {
+		t.Fatalf("hit should upgrade to TMDB, got %q", got)
+	}
+	if got := posterURLForItem(flix, tmdbMiss); got != "https://flixhq/thumb.jpg" {
+		t.Fatalf("miss should keep FlixHQ thumb, got %q", got)
+	}
+	already := media.SearchResult{Title: "Foo", Poster: "https://image.tmdb.org/t/p/w500/y.jpg"}
+	called := false
+	if got := posterURLForItem(already, func(string, string, bool) string { called = true; return "z" }); got != already.Poster || called {
+		t.Fatalf("already-TMDB poster must be kept without a lookup, got %q called=%v", got, called)
+	}
+	empty := media.SearchResult{Title: "Foo"}
+	if got := posterURLForItem(empty, tmdbMiss); got != "" {
+		t.Fatalf("empty+miss should be empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## What
Movies/Series browse now uses FlixHQ's richer listings while keeping high-res TMDB posters in the hero band, with FlixHQ's own thumbnail as a guaranteed fallback.

## Changes
- **Default provider → FlixHQ** (`flixhq.to`). Affects only Movies/Series browse; Cartoons/Anime and streaming (resolver) are unchanged.
- **New shared `internal/provider/tmdb.go`** — moved the TMDB helpers here (from soap2day/vidnest) and added `TMDBPoster(title, year, isTV)`: a *confident* match (media_type + case-insensitive title + year ±1; skips autocomplete spans; never `results[0]`), memoized — and only deterministic outcomes are cached, so a transient TMDB blip retries instead of sticking a permanent miss.
- **Lazy per-selection enrichment** — the hero band upgrades a non-TMDB poster to the matched TMDB one on selection, else keeps the FlixHQ thumbnail. Already-TMDB posters skip the lookup.
- Cleanups: accurate `--base` help + `newProvider` comment; fixed the stale "all providers share TMDB IDs" comment and the `--base soap2day` failure hint.

## Accepted degrades (documented, by design)
- Existing soap2day watch-history entries lose their resume position once (self-heals for new FlixHQ entries).
- If a TMDB-based fallback wins dedup on a FlixHQ selection, season fetch falls to title-based resolution (extra latency, no crash).

## Testing
- `pickPoster` / `TMDBPoster` table tests: "The Office" UK-vs-US by type+year, year ±1 tolerance, person/span skipping, memo incl. negative.
- `posterURLForItem` decision tests: TMDB hit / miss / already-TMDB / empty.
- Full suite green; `go vet` clean. Interactive smoke-test (real terminal + network) pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TMDB-backed poster selection to upgrade artwork when a more confident match is available.
  * Expanded supported content sources shown in the CLI `--base` flag (including `moviebox`, `voplayer`, and `vidnest`).

* **Bug Fixes**
  * Poster enrichment now runs consistently when switching or selecting items.
  * Improved fallback guidance for FlixHQ playback suggestions.

* **Chores**
  * Updated the default `Base` setting to use `flixhq.to`.
  * Improved CLI/help text accuracy around provider selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->