### PR TITLE
fix: default to flixhq.ws (flixhq.to is down)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 // Default returns the default configuration.
 func Default() *Config {
 	return &Config{
-		Base:         "flixhq.to",
+		Base:         "flixhq.ws",
 		Player:       "mpv",
 		Provider:     "Default",
 		SubsLanguage: "english",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,8 +21,8 @@ func TestDefault(t *testing.T) {
 	if !cfg.History {
 		t.Error("default history should be true")
 	}
-	if cfg.Base != "flixhq.to" {
-		t.Fatalf("Base=%q want flixhq.to", cfg.Base)
+	if cfg.Base != "flixhq.ws" {
+		t.Fatalf("Base=%q want flixhq.ws", cfg.Base)
 	}
 }
 


### PR DESCRIPTION
flixhq.to currently returns no response (HTTP 000) — the FlixHQ provider's domain is dead, so the default Movies/Series browse showed no results. flixhq.ws (FlixHQWS provider, verified returning results with posters) is up; switch the default to it. TMDB poster enrichment is unaffected (it runs per-tab regardless of provider).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s default base URL to use a new site address.
  * Kept validation and loading behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->