### PR TITLE
feat: native AllAnime anime provider (sub/dub, real catalog)

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -11,6 +11,7 @@ import (
 	"lobster/internal/media"
 	"lobster/internal/player"
 	"lobster/internal/playlist"
+	"lobster/internal/provider"
 	"lobster/internal/subtitle"
 	"lobster/internal/ui"
 )
@@ -169,6 +170,16 @@ func episodeListMenu(sess *playlist.Session) error {
 // Primary provider (FlixHQ) is used for metadata only; streaming goes through
 // Soap2Day and other fallbacks directly.
 func resolveStream(sess *playlist.Session, excludeNames map[string]bool) (*media.Stream, string, error) {
+	// Primary StreamProvider gets first crack with the native episode ID from the
+	// session — lets providers like AllAnime (opaque IDs "showId|1.5|sub") reach
+	// their own Watch verbatim, bypassing tmdbID:season:episode reconstruction.
+	if sp, ok := sess.Provider.(provider.StreamProvider); ok {
+		ep := sess.Current()
+		if stream, err := sp.Watch(sess.Content.ID, ep.ID, "Default", cfg.Quality); err == nil && stream != nil {
+			return stream, "Primary", nil
+		}
+	}
+
 	debugf("resolving stream via fallback providers for %s", sess.Title())
 	stream, err := tryFallbackStream(
 		sess.Provider,

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -166,14 +166,17 @@ func episodeListMenu(sess *playlist.Session) error {
 	return nil
 }
 
-// resolveStream resolves a stream for the current episode via fallback providers.
-// Primary provider (FlixHQ) is used for metadata only; streaming goes through
-// Soap2Day and other fallbacks directly.
+// resolveStream resolves a stream for the current episode. A primary provider
+// that implements StreamProvider (e.g. AllAnime) is tried first with the
+// session's native episode ID; otherwise (e.g. FlixHQ, used for metadata only)
+// resolution goes through the resilient fallback path.
 func resolveStream(sess *playlist.Session, excludeNames map[string]bool) (*media.Stream, string, error) {
 	// Primary StreamProvider gets first crack with the native episode ID from the
 	// session — lets providers like AllAnime (opaque IDs "showId|1.5|sub") reach
 	// their own Watch verbatim, bypassing tmdbID:season:episode reconstruction.
-	if sp, ok := sess.Provider.(provider.StreamProvider); ok {
+	// Skip it once it's been excluded (its last stream failed playback), so a
+	// dead Primary stream can't trap playCurrentEpisode in an infinite retry.
+	if sp, ok := sess.Provider.(provider.StreamProvider); ok && !excludeNames["Primary"] {
 		ep := sess.Current()
 		if stream, err := sp.Watch(sess.Content.ID, ep.ID, "Default", cfg.Quality); err == nil && stream != nil {
 			return stream, "Primary", nil

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -181,6 +181,17 @@ func resolveStream(sess *playlist.Session, excludeNames map[string]bool) (*media
 		if stream, err := sp.Watch(sess.Content.ID, ep.ID, "Default", cfg.Quality); err == nil && stream != nil {
 			return stream, "Primary", nil
 		}
+		// AllAnime can't reliably stream FINISHED series (its CDN goes 500/404),
+		// so fall back to AniPub by title + episode number (AniPub has its own
+		// IDs; match by title). Airing shows resolve above and never reach here.
+		if aa, isAnime := sess.Provider.(*provider.AllAnime); isAnime && !excludeNames["AniPub"] {
+			if stream, err := provider.NewAniPub().ResolveByTitle(
+				sess.Content.Title, sess.Current().Number, aa.Translation() == "dub",
+			); err == nil && stream != nil {
+				debugf("AniPub fallback resolved %s ep %d", sess.Content.Title, sess.Current().Number)
+				return stream, "AniPub", nil
+			}
+		}
 	}
 
 	debugf("resolving stream via fallback providers for %s", sess.Title())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	StallTimeout           int               `toml:"stall_timeout"`  // seconds before a stalled download is recovered
 	MaxRetries             int               `toml:"max_retries"`    // retry count for segment/file downloads
 	DomainOverrides        map[string][]string `toml:"domain_overrides"` // provider name -> fallback domains
+	AnimeDub               bool                `toml:"anime_dub"`
 }
 
 // Default returns the default configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,9 @@ func TestDefault(t *testing.T) {
 	if cfg.Base != "flixhq.ws" {
 		t.Fatalf("Base=%q want flixhq.ws", cfg.Base)
 	}
+	if cfg.AnimeDub {
+		t.Error("default AnimeDub should be false (sub)")
+	}
 }
 
 func TestValidate(t *testing.T) {

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -99,28 +99,33 @@ func (a *AllAnime) graphql(query string, vars map[string]any, out any) error {
 	return json.Unmarshal(data, out)
 }
 
-func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
+// allanimeEdge is one show node from the shows query.
+type allanimeEdge struct {
+	ID                string         `json:"_id"`
+	Name              string         `json:"name"`
+	EnglishName       string         `json:"englishName"`
+	Thumbnail         string         `json:"thumbnail"`
+	AvailableEpisodes map[string]int `json:"availableEpisodes"`
+}
+
+// queryShows runs the shows GraphQL query with the given search input and maps
+// the edges to SearchResults (Type=TV; AllAnime has no movie/season concept).
+func (a *AllAnime) queryShows(search map[string]any, limit int, country string) ([]media.SearchResult, error) {
 	var r struct {
 		Data struct {
 			Shows struct {
-				Edges []struct {
-					ID                string         `json:"_id"`
-					Name              string         `json:"name"`
-					EnglishName       string         `json:"englishName"`
-					Thumbnail         string         `json:"thumbnail"`
-					AvailableEpisodes map[string]int `json:"availableEpisodes"`
-				} `json:"edges"`
+				Edges []allanimeEdge `json:"edges"`
 			} `json:"shows"`
 		} `json:"data"`
 	}
 	vars := map[string]any{
-		"search": map[string]any{"allowAdult": false, "allowUnknown": false, "query": query},
-		"limit":  40, "page": 1, "translationType": a.trans, "countryOrigin": "ALL",
+		"search": search, "limit": limit, "page": 1,
+		"translationType": a.trans, "countryOrigin": country,
 	}
 	if err := a.graphql(allanimeSearchQuery, vars, &r); err != nil {
-		return nil, fmt.Errorf("search: %w", err)
+		return nil, err
 	}
-	var out []media.SearchResult
+	out := make([]media.SearchResult, 0, len(r.Data.Shows.Edges))
 	for _, e := range r.Data.Shows.Edges {
 		title := e.EnglishName
 		if title == "" {
@@ -130,6 +135,14 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 			ID: e.ID, Title: title, Type: media.TV, Poster: e.Thumbnail,
 			Episodes: e.AvailableEpisodes[a.trans], URL: a.cfg.refererSite + "/anime/" + e.ID,
 		})
+	}
+	return out, nil
+}
+
+func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
+	out, err := a.queryShows(map[string]any{"allowAdult": false, "allowUnknown": false, "query": query}, 40, "ALL")
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("no anime found for %q", query)
@@ -328,5 +341,13 @@ func (a *AllAnime) GetServers(id, episodeID string) ([]media.Server, error) {
 func (a *AllAnime) GetEmbedURL(serverID string) (string, error) {
 	return "", fmt.Errorf("use Watch instead")
 }
-func (a *AllAnime) Trending(mt media.MediaType) ([]media.SearchResult, error) { return nil, nil }
-func (a *AllAnime) Recent(mt media.MediaType) ([]media.SearchResult, error)   { return nil, nil }
+
+// Trending populates the anime tab on open with recently-updated Japanese anime
+// (so the tab isn't blank). "Recent" is AllAnime's recently-active sort.
+func (a *AllAnime) Trending(mt media.MediaType) ([]media.SearchResult, error) {
+	return a.queryShows(map[string]any{"allowAdult": false, "allowUnknown": false, "sortBy": "Recent"}, 30, "JP")
+}
+
+func (a *AllAnime) Recent(mt media.MediaType) ([]media.SearchResult, error) {
+	return a.queryShows(map[string]any{"allowAdult": false, "allowUnknown": false, "sortBy": "Recent"}, 30, "JP")
+}

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -147,6 +147,18 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 	if len(out) == 0 {
 		return nil, fmt.Errorf("no anime found for %q", query)
 	}
+	// AllAnime returns specials/spinoffs (1 episode) ahead of the main series, so
+	// "Death Note" lands on a 1-ep special instead of the 37-ep show. Rank exact
+	// title matches first, then by episode count (the main series has the most).
+	q := strings.TrimSpace(query)
+	sort.SliceStable(out, func(i, j int) bool {
+		ei := strings.EqualFold(strings.TrimSpace(out[i].Title), q)
+		ej := strings.EqualFold(strings.TrimSpace(out[j].Title), q)
+		if ei != ej {
+			return ei // exact title matches first
+		}
+		return out[i].Episodes > out[j].Episodes
+	})
 	return out, nil
 }
 

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -1,8 +1,12 @@
 package provider
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 
 	"lobster/internal/httputil"
 	"lobster/internal/media"
@@ -55,20 +59,128 @@ func NewAllAnime(dub bool) *AllAnime {
 	return &AllAnime{cfg: defaultAllanimeConfig(), client: httputil.NewClient(), trans: t}
 }
 
-func (a *AllAnime) Translation() string       { return a.trans }
-func (a *AllAnime) SetTranslation(t string)   { a.trans = t }
+func (a *AllAnime) Translation() string     { return a.trans }
+func (a *AllAnime) SetTranslation(t string) { a.trans = t }
 
-// --- Provider / StreamProvider methods (filled in by later tasks) ---
+// --- GraphQL query constants ---
+
+const (
+	allanimeSearchQuery   = `query($search: SearchInput, $limit: Int, $page: Int, $translationType: VaildTranslationTypeEnumType, $countryOrigin: VaildCountryOriginEnumType) { shows(search:$search, limit:$limit, page:$page, translationType:$translationType, countryOrigin:$countryOrigin) { edges { _id name englishName thumbnail availableEpisodes } } }`
+	allanimeEpisodesQuery = `query($showId: String!) { show(_id:$showId) { _id availableEpisodesDetail } }`
+)
+
+// graphql POSTs a query+variables and decodes data into out.
+func (a *AllAnime) graphql(query string, vars map[string]any, out any) error {
+	payload, _ := json.Marshal(map[string]any{"query": query, "variables": vars})
+	req, err := http.NewRequest(http.MethodPost, a.cfg.apiBase, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", a.cfg.userAgent)
+	req.Header.Set("Referer", a.cfg.refererSite)
+	req.Header.Set("Origin", a.cfg.refererSite)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("allanime: status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, out)
+}
 
 func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
-	return nil, fmt.Errorf("not implemented")
+	var r struct {
+		Data struct {
+			Shows struct {
+				Edges []struct {
+					ID                string         `json:"_id"`
+					Name              string         `json:"name"`
+					EnglishName       string         `json:"englishName"`
+					Thumbnail         string         `json:"thumbnail"`
+					AvailableEpisodes map[string]int `json:"availableEpisodes"`
+				} `json:"edges"`
+			} `json:"shows"`
+		} `json:"data"`
+	}
+	vars := map[string]any{
+		"search":          map[string]any{"allowAdult": false, "allowUnknown": false, "query": query},
+		"limit":           40, "page": 1, "translationType": a.trans, "countryOrigin": "ALL",
+	}
+	if err := a.graphql(allanimeSearchQuery, vars, &r); err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	var out []media.SearchResult
+	for _, e := range r.Data.Shows.Edges {
+		title := e.EnglishName
+		if title == "" {
+			title = e.Name
+		}
+		out = append(out, media.SearchResult{
+			ID: e.ID, Title: title, Type: media.TV, Poster: e.Thumbnail,
+			Episodes: e.AvailableEpisodes[a.trans], URL: a.cfg.refererSite + "/anime/" + e.ID,
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no anime found for %q", query)
+	}
+	return out, nil
 }
+
+// GetSeasons returns a single pseudo-season: AllAnime has no seasons.
 func (a *AllAnime) GetSeasons(id string) ([]media.Season, error) {
-	return nil, fmt.Errorf("not implemented")
+	return []media.Season{{Number: 1, ID: id}}, nil
 }
+
 func (a *AllAnime) GetEpisodes(id, seasonID string) ([]media.Episode, error) {
-	return nil, fmt.Errorf("not implemented")
+	var r struct {
+		Data struct {
+			Show struct {
+				Detail map[string][]string `json:"availableEpisodesDetail"`
+			} `json:"show"`
+		} `json:"data"`
+	}
+	if err := a.graphql(allanimeEpisodesQuery, map[string]any{"showId": id}, &r); err != nil {
+		return nil, fmt.Errorf("episodes: %w", err)
+	}
+	list := r.Data.Show.Detail[a.trans] // strings, reverse order
+	out := make([]media.Episode, 0, len(list))
+	for i := len(list) - 1; i >= 0; i-- { // ascending
+		es := list[i]
+		out = append(out, media.Episode{
+			Number: epNumber(es, len(list)-i),
+			Title:  "Episode " + es,
+			ID:     encodeEpisodeID(id, es, a.trans),
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no %s episodes", a.trans)
+	}
+	return out, nil
 }
+
+// epNumber parses the leading integer of an episodeString ("1","1.5","OVA1"),
+// falling back to ordinal when non-numeric.
+func epNumber(es string, ordinal int) int {
+	end := 0
+	for end < len(es) && es[end] >= '0' && es[end] <= '9' {
+		end++
+	}
+	if end > 0 {
+		if n, err := strconv.Atoi(es[:end]); err == nil {
+			return n
+		}
+	}
+	return ordinal
+}
+
+// Watch stub — filled in by Task 5.
 func (a *AllAnime) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"sort"
 	"strconv"
+	"strings"
 
+	"lobster/internal/extract"
 	"lobster/internal/httputil"
 	"lobster/internal/media"
 )
@@ -67,6 +71,7 @@ func (a *AllAnime) SetTranslation(t string) { a.trans = t }
 const (
 	allanimeSearchQuery   = `query($search: SearchInput, $limit: Int, $page: Int, $translationType: VaildTranslationTypeEnumType, $countryOrigin: VaildCountryOriginEnumType) { shows(search:$search, limit:$limit, page:$page, translationType:$translationType, countryOrigin:$countryOrigin) { edges { _id name englishName thumbnail availableEpisodes } } }`
 	allanimeEpisodesQuery = `query($showId: String!) { show(_id:$showId) { _id availableEpisodesDetail } }`
+	allanimeSourcesQuery  = `query($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode(showId:$showId, translationType:$translationType, episodeString:$episodeString) { episodeString sourceUrls } }`
 )
 
 // graphql POSTs a query+variables and decodes data into out.
@@ -180,9 +185,132 @@ func epNumber(es string, ordinal int) int {
 	return ordinal
 }
 
-// Watch stub — filled in by Task 5.
 func (a *AllAnime) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
-	return nil, fmt.Errorf("not implemented")
+	showID, episodeString, trans, ok := parseEpisodeID(episodeID)
+	if !ok {
+		return nil, fmt.Errorf("bad episode id %q", episodeID)
+	}
+
+	// 1) Persisted-query GET for the encrypted source list (Origin gates tobeparsed).
+	vars, _ := json.Marshal(map[string]any{"showId": showID, "translationType": trans, "episodeString": episodeString})
+	ext, _ := json.Marshal(map[string]any{"persistedQuery": map[string]any{"version": 1, "sha256Hash": a.cfg.pqHash}})
+	u := fmt.Sprintf("%s?variables=%s&extensions=%s", a.cfg.apiBase, url.QueryEscape(string(vars)), url.QueryEscape(string(ext)))
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", a.cfg.userAgent)
+	req.Header.Set("Referer", a.cfg.sourcesOrigin)
+	req.Header.Set("Origin", a.cfg.sourcesOrigin)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	var sr struct {
+		Data struct {
+			Tobeparsed string `json:"tobeparsed"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &sr); err != nil || sr.Data.Tobeparsed == "" {
+		return nil, fmt.Errorf("no sources for %s ep %s", showID, episodeString)
+	}
+
+	// 2) Decrypt -> sourceUrls.
+	plain, err := decryptTobeparsed(sr.Data.Tobeparsed, a.cfg.passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt: %w", err)
+	}
+	var dec struct {
+		Episode struct {
+			SourceUrls []struct {
+				SourceURL  string  `json:"sourceUrl"`
+				SourceName string  `json:"sourceName"`
+				Priority   float64 `json:"priority"`
+			} `json:"sourceUrls"`
+		} `json:"episode"`
+	}
+	if err := json.Unmarshal(plain, &dec); err != nil {
+		return nil, fmt.Errorf("parse sources: %w", err)
+	}
+	srcs := dec.Episode.SourceUrls
+	sort.SliceStable(srcs, func(i, j int) bool { return srcs[i].Priority > srcs[j].Priority })
+
+	// 3) Try each candidate: internal CDN (--/clock.json) first, else embed extractor.
+	var lastErr error
+	for _, s := range srcs {
+		if clockURL := decodeSourceURL(s.SourceURL, a.cfg.xorByte, a.cfg.clockBase); clockURL != "" {
+			if st, err := a.resolveClock(clockURL); err == nil {
+				return st, nil
+			} else {
+				lastErr = err
+			}
+			continue
+		}
+		// plain embed host -> reuse lobster's extractors
+		ex, resolved := extract.ResolveForURL(s.SourceURL, a.cfg.refererSite)
+		if st, err := ex.Extract(resolved, quality); err == nil && st != nil && st.URL != "" {
+			return st, nil
+		} else if err != nil {
+			lastErr = err
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no playable source")
+	}
+	return nil, fmt.Errorf("allanime watch %s ep %s: %w", showID, episodeString, lastErr)
+}
+
+// resolveClock fetches a /clock.json document and maps it to a Stream.
+func (a *AllAnime) resolveClock(clockURL string) (*media.Stream, error) {
+	req, err := http.NewRequest(http.MethodGet, clockURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", a.cfg.userAgent)
+	req.Header.Set("Referer", a.cfg.refererSite)
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	var c struct {
+		Links []struct {
+			Link string `json:"link"`
+			HLS  struct {
+				URL string `json:"url"`
+			} `json:"hls"`
+		} `json:"links"`
+		Subtitles []struct {
+			Lang  string `json:"lang"`
+			Label string `json:"label"`
+			Src   string `json:"src"`
+		} `json:"subtitles"`
+		Referer string `json:"Referer"`
+	}
+	if err := json.Unmarshal(body, &c); err != nil {
+		return nil, err
+	}
+	for _, l := range c.Links {
+		u := l.Link
+		if u == "" {
+			u = l.HLS.URL
+		}
+		if u == "" {
+			continue
+		}
+		st := &media.Stream{URL: u, Referer: c.Referer}
+		for _, s := range c.Subtitles {
+			if strings.EqualFold(s.Label, "Thumbnails") || strings.EqualFold(s.Lang, "Thumbnails") {
+				continue
+			}
+			st.Subtitles = append(st.Subtitles, media.Subtitle{Language: s.Lang, Label: s.Label, URL: s.Src})
+		}
+		return st, nil
+	}
+	return nil, fmt.Errorf("clock.json had no playable link")
 }
 
 // Stable trivial methods.

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -71,7 +71,6 @@ func (a *AllAnime) SetTranslation(t string) { a.trans = t }
 const (
 	allanimeSearchQuery   = `query($search: SearchInput, $limit: Int, $page: Int, $translationType: VaildTranslationTypeEnumType, $countryOrigin: VaildCountryOriginEnumType) { shows(search:$search, limit:$limit, page:$page, translationType:$translationType, countryOrigin:$countryOrigin) { edges { _id name englishName thumbnail availableEpisodes } } }`
 	allanimeEpisodesQuery = `query($showId: String!) { show(_id:$showId) { _id availableEpisodesDetail } }`
-	allanimeSourcesQuery  = `query($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode(showId:$showId, translationType:$translationType, episodeString:$episodeString) { episodeString sourceUrls } }`
 )
 
 // graphql POSTs a query+variables and decodes data into out.
@@ -115,8 +114,8 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 		} `json:"data"`
 	}
 	vars := map[string]any{
-		"search":          map[string]any{"allowAdult": false, "allowUnknown": false, "query": query},
-		"limit":           40, "page": 1, "translationType": a.trans, "countryOrigin": "ALL",
+		"search": map[string]any{"allowAdult": false, "allowUnknown": false, "query": query},
+		"limit":  40, "page": 1, "translationType": a.trans, "countryOrigin": "ALL",
 	}
 	if err := a.graphql(allanimeSearchQuery, vars, &r); err != nil {
 		return nil, fmt.Errorf("search: %w", err)
@@ -207,6 +206,9 @@ func (a *AllAnime) Watch(mediaID, episodeID, server, quality string) (*media.Str
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("allanime sources: status %d (origin gate?)", resp.StatusCode)
+	}
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	var sr struct {
 		Data struct {
@@ -275,6 +277,9 @@ func (a *AllAnime) resolveClock(clockURL string) (*media.Stream, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("clock.json: status %d", resp.StatusCode)
+	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	var c struct {
 		Links []struct {

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+// allanimeConfig holds the volatile AllAnime constants. They rotate upstream
+// every few weeks; this is the single place to update them.
+type allanimeConfig struct {
+	apiBase       string
+	clockBase     string
+	refererSite   string
+	sourcesOrigin string
+	userAgent     string
+	pqHash        string
+	passphrase    string
+	xorByte       byte
+}
+
+func defaultAllanimeConfig() allanimeConfig {
+	return allanimeConfig{
+		apiBase:       "https://api.allanime.day/api",
+		clockBase:     "https://allanime.day",
+		refererSite:   "https://allanime.to",
+		sourcesOrigin: "https://youtu-chan.com",
+		userAgent:     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
+		pqHash:        "d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec",
+		passphrase:    "Xot36i3lK3:v1",
+		xorByte:       0x38,
+	}
+}
+
+// httpDoer is the subset of *http.Client used here (swappable in tests).
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// AllAnime is a StreamProvider backed by the AllAnime GraphQL API.
+type AllAnime struct {
+	cfg    allanimeConfig
+	client httpDoer
+	trans  string // "sub" | "dub" | "raw"
+}
+
+// NewAllAnime constructs a provider defaulting to dub or sub.
+func NewAllAnime(dub bool) *AllAnime {
+	t := "sub"
+	if dub {
+		t = "dub"
+	}
+	return &AllAnime{cfg: defaultAllanimeConfig(), client: httputil.NewClient(), trans: t}
+}
+
+func (a *AllAnime) Translation() string       { return a.trans }
+func (a *AllAnime) SetTranslation(t string)   { a.trans = t }
+
+// --- Provider / StreamProvider methods (filled in by later tasks) ---
+
+func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (a *AllAnime) GetSeasons(id string) ([]media.Season, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (a *AllAnime) GetEpisodes(id, seasonID string) ([]media.Episode, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (a *AllAnime) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Stable trivial methods.
+func (a *AllAnime) GetDetails(id string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+func (a *AllAnime) GetServers(id, episodeID string) ([]media.Server, error) {
+	return []media.Server{{Name: "AllAnime", ID: "default"}}, nil
+}
+func (a *AllAnime) GetEmbedURL(serverID string) (string, error) {
+	return "", fmt.Errorf("use Watch instead")
+}
+func (a *AllAnime) Trending(mt media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+func (a *AllAnime) Recent(mt media.MediaType) ([]media.SearchResult, error)   { return nil, nil }

--- a/internal/provider/allanime_decrypt.go
+++ b/internal/provider/allanime_decrypt.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// decryptTobeparsed AES-256-CTR-decrypts the AllAnime episode-sources blob.
+// Layout: [0]=version, [1:13]=nonce, [13:N-16]=ciphertext, [N-16:N]=discarded.
+func decryptTobeparsed(blob, passphrase string) ([]byte, error) {
+	data, err := base64.StdEncoding.DecodeString(blob)
+	if err != nil {
+		return nil, fmt.Errorf("base64: %w", err)
+	}
+	if len(data) < 1+12+16 {
+		return nil, fmt.Errorf("blob too short: %d bytes", len(data))
+	}
+	nonce := data[1:13]
+	ct := data[13 : len(data)-16]
+	key := sha256.Sum256([]byte(passphrase))
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return nil, err
+	}
+	iv := make([]byte, 16)
+	copy(iv, nonce)
+	binary.BigEndian.PutUint32(iv[12:], 2)
+	pt := make([]byte, len(ct))
+	cipher.NewCTR(block, iv).XORKeyStream(pt, ct)
+	return pt, nil
+}
+
+// decodeSourceURL decodes a "--"-prefixed internal-CDN sourceUrl (hex bytes XOR
+// xor), rewrites /clock -> /clock.json, and absolutizes against clockBase.
+// Returns "" for any non-"--" URL (those go through the embed extractors).
+func decodeSourceURL(sourceURL string, xor byte, clockBase string) string {
+	if !strings.HasPrefix(sourceURL, "--") {
+		return ""
+	}
+	h := sourceURL[2:]
+	var sb strings.Builder
+	for i := 0; i+1 < len(h); i += 2 {
+		b, err := strconv.ParseUint(h[i:i+2], 16, 8)
+		if err != nil {
+			return ""
+		}
+		sb.WriteByte(byte(b) ^ xor)
+	}
+	path := strings.Replace(sb.String(), "/clock", "/clock.json", 1)
+	if strings.HasPrefix(path, "/") {
+		return clockBase + path
+	}
+	return path
+}
+
+// encodeEpisodeID packs the AllAnime episode identity into a single string so
+// Watch is self-contained (the sub/dub toggle can't race it).
+func encodeEpisodeID(showID, episodeString, trans string) string {
+	return showID + "|" + episodeString + "|" + trans
+}
+
+func parseEpisodeID(id string) (showID, episodeString, trans string, ok bool) {
+	parts := strings.SplitN(id, "|", 3)
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}

--- a/internal/provider/allanime_decrypt_test.go
+++ b/internal/provider/allanime_decrypt_test.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"testing"
+)
+
+// helper: build a tobeparsed blob the same way the server does, to test the decrypt round-trip.
+func makeBlob(plain, passphrase string) string {
+	key := sha256.Sum256([]byte(passphrase))
+	block, _ := aes.NewCipher(key[:])
+	nonce := []byte("0123456789ab") // 12 fixed bytes
+	iv := make([]byte, 16)
+	copy(iv, nonce)
+	binary.BigEndian.PutUint32(iv[12:], 2)
+	ct := make([]byte, len(plain))
+	cipher.NewCTR(block, iv).XORKeyStream(ct, []byte(plain))
+	blob := []byte{0x01}
+	blob = append(blob, nonce...)
+	blob = append(blob, ct...)
+	blob = append(blob, make([]byte, 16)...) // discarded tail
+	return base64.StdEncoding.EncodeToString(blob)
+}
+
+func TestDecryptTobeparsed(t *testing.T) {
+	want := `{"episode":{"sourceUrls":[]}}`
+	got, err := decryptTobeparsed(makeBlob(want, "Xot36i3lK3:v1"), "Xot36i3lK3:v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("decrypt = %q, want %q", got, want)
+	}
+	if _, err := decryptTobeparsed("!!notbase64!!", "k"); err == nil {
+		t.Fatal("expected error on bad base64")
+	}
+}
+
+func TestDecodeSourceURL(t *testing.T) {
+	// 0x17^0x38='/', 0x08^0x38='0', 0x59^0x38='a' -> "/0a", starts with "/" so clockBase is prepended.
+	got := decodeSourceURL("--170859", 0x38, "https://allanime.day")
+	if got != "https://allanime.day/0a" {
+		t.Fatalf("decode = %q, want https://allanime.day/0a", got)
+	}
+	// /clock is rewritten to /clock.json. Encode "/clock" with XOR 0x38:
+	// '/'=0x2f^0x38=0x17,'c'=0x63^0x38=0x5b,'l'=0x6c^0x38=0x54,'o'=0x6f^0x38=0x57,'c'=0x5b,'k'=0x6b^0x38=0x53
+	got2 := decodeSourceURL("--175b54575b53", 0x38, "https://allanime.day")
+	if got2 != "https://allanime.day/clock.json" {
+		t.Fatalf("decode = %q, want .../clock.json", got2)
+	}
+	if decodeSourceURL("https://streamwish.to/e/x", 0x38, "https://allanime.day") != "" {
+		t.Fatal("non-'--' URL should return \"\" (handled by the extractor path, not here)")
+	}
+}
+
+func TestEpisodeIDRoundTrip(t *testing.T) {
+	id := encodeEpisodeID("ReHMC7TQnch3C6z8j", "1.5", "dub")
+	showID, ep, trans, ok := parseEpisodeID(id)
+	if !ok || showID != "ReHMC7TQnch3C6z8j" || ep != "1.5" || trans != "dub" {
+		t.Fatalf("round-trip failed: %q -> (%q,%q,%q,%v)", id, showID, ep, trans, ok)
+	}
+	if _, _, _, ok := parseEpisodeID("garbage"); ok {
+		t.Fatal("malformed id should not parse")
+	}
+}

--- a/internal/provider/allanime_test.go
+++ b/internal/provider/allanime_test.go
@@ -84,3 +84,23 @@ func TestAllAnimeGetEpisodes(t *testing.T) {
 		t.Fatalf("dub episodes wrong: %+v", dub)
 	}
 }
+
+func TestAllAnimeWatchClockPath(t *testing.T) {
+	// sources query (persisted GET) returns a tobeparsed blob whose plaintext lists one "--" source.
+	plain := `{"episode":{"sourceUrls":[{"sourceUrl":"--175b54575b53","sourceName":"S-mp4","priority":9}]}}`
+	blob := makeBlob(plain, "Xot36i3lK3:v1")
+	a := newTestAllAnime(map[string]string{
+		`episodeString`: `{"data":{"tobeparsed":"` + blob + `"}}`,      // sources query
+		`/clock.json`:   `{"links":[{"link":"https://cdn/master.m3u8"}],"subtitles":[{"lang":"en","label":"English","src":"https://cdn/en.vtt"}]}`,
+	})
+	st, err := a.Watch("ReH", "ReH|1|sub", "Default", "1080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.URL != "https://cdn/master.m3u8" {
+		t.Fatalf("stream URL = %q", st.URL)
+	}
+	if len(st.Subtitles) != 1 || st.Subtitles[0].URL != "https://cdn/en.vtt" {
+		t.Fatalf("subtitles wrong: %+v", st.Subtitles)
+	}
+}

--- a/internal/provider/allanime_test.go
+++ b/internal/provider/allanime_test.go
@@ -1,6 +1,13 @@
 package provider
 
-import "testing"
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+)
 
 func TestNewAllAnimeTranslation(t *testing.T) {
 	if got := NewAllAnime(false).Translation(); got != "sub" {
@@ -18,3 +25,62 @@ func TestNewAllAnimeTranslation(t *testing.T) {
 
 // Compile-time proof the type satisfies the streaming interface.
 var _ StreamProvider = (*AllAnime)(nil)
+
+// fakeDoer routes by request body/url substring to canned JSON.
+type fakeDoer struct{ routes map[string]string }
+
+func (f fakeDoer) Do(r *http.Request) (*http.Response, error) {
+	body := ""
+	if r.Body != nil {
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+	}
+	key := r.URL.String() + " " + body
+	for sub, resp := range f.routes {
+		if strings.Contains(key, sub) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(resp))}, nil
+		}
+	}
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+}
+
+func newTestAllAnime(routes map[string]string) *AllAnime {
+	a := NewAllAnime(false)
+	a.client = fakeDoer{routes: routes}
+	return a
+}
+
+func TestAllAnimeSearch(t *testing.T) {
+	a := newTestAllAnime(map[string]string{
+		`"query":"Frieren"`: `{"data":{"shows":{"edges":[
+			{"_id":"ReH","name":"Sousou no Frieren","englishName":"Frieren","thumbnail":"http://img/f.jpg","availableEpisodes":{"sub":28,"dub":28,"raw":0}}
+		]}}}`,
+	})
+	res, err := a.Search("Frieren")
+	if err != nil || len(res) != 1 {
+		t.Fatalf("search: %v / %+v", err, res)
+	}
+	if res[0].ID != "ReH" || res[0].Title != "Frieren" || res[0].Type != media.TV || res[0].Poster != "http://img/f.jpg" || res[0].Episodes != 28 {
+		t.Fatalf("mapped result wrong: %+v", res[0])
+	}
+}
+
+func TestAllAnimeGetEpisodes(t *testing.T) {
+	a := newTestAllAnime(map[string]string{
+		`"showId":"ReH"`: `{"data":{"show":{"_id":"ReH","availableEpisodesDetail":{"sub":["3","2","1"],"dub":["2","1"],"raw":[]}}}}`,
+	})
+	eps, err := a.GetEpisodes("ReH", "ReH")
+	if err != nil || len(eps) != 3 {
+		t.Fatalf("episodes: %v / %d", err, len(eps))
+	}
+	// Ascending by number, native ID encodes show|episodeString|sub.
+	if eps[0].Number != 1 || eps[0].ID != "ReH|1|sub" {
+		t.Fatalf("ep[0] wrong: %+v", eps[0])
+	}
+	// Switching to dub yields the dub list.
+	a.SetTranslation("dub")
+	dub, _ := a.GetEpisodes("ReH", "ReH")
+	if len(dub) != 2 || dub[1].ID != "ReH|2|dub" {
+		t.Fatalf("dub episodes wrong: %+v", dub)
+	}
+}

--- a/internal/provider/allanime_test.go
+++ b/internal/provider/allanime_test.go
@@ -1,0 +1,20 @@
+package provider
+
+import "testing"
+
+func TestNewAllAnimeTranslation(t *testing.T) {
+	if got := NewAllAnime(false).Translation(); got != "sub" {
+		t.Fatalf("default translation = %q, want sub", got)
+	}
+	if got := NewAllAnime(true).Translation(); got != "dub" {
+		t.Fatalf("dub translation = %q, want dub", got)
+	}
+	a := NewAllAnime(false)
+	a.SetTranslation("dub")
+	if got := a.Translation(); got != "dub" {
+		t.Fatalf("after SetTranslation = %q, want dub", got)
+	}
+}
+
+// Compile-time proof the type satisfies the streaming interface.
+var _ StreamProvider = (*AllAnime)(nil)

--- a/internal/provider/allanime_test.go
+++ b/internal/provider/allanime_test.go
@@ -90,7 +90,7 @@ func TestAllAnimeWatchClockPath(t *testing.T) {
 	plain := `{"episode":{"sourceUrls":[{"sourceUrl":"--175b54575b53","sourceName":"S-mp4","priority":9}]}}`
 	blob := makeBlob(plain, "Xot36i3lK3:v1")
 	a := newTestAllAnime(map[string]string{
-		`episodeString`: `{"data":{"tobeparsed":"` + blob + `"}}`,      // sources query
+		`episodeString`: `{"data":{"tobeparsed":"` + blob + `"}}`, // sources query
 		`/clock.json`:   `{"links":[{"link":"https://cdn/master.m3u8"}],"subtitles":[{"lang":"en","label":"English","src":"https://cdn/en.vtt"}]}`,
 	})
 	st, err := a.Watch("ReH", "ReH|1|sub", "Default", "1080")
@@ -102,5 +102,20 @@ func TestAllAnimeWatchClockPath(t *testing.T) {
 	}
 	if len(st.Subtitles) != 1 || st.Subtitles[0].URL != "https://cdn/en.vtt" {
 		t.Fatalf("subtitles wrong: %+v", st.Subtitles)
+	}
+}
+
+func TestAllAnimeTrending(t *testing.T) {
+	a := newTestAllAnime(map[string]string{
+		`"sortBy":"Recent"`: `{"data":{"shows":{"edges":[
+			{"_id":"X1","name":"Show One","thumbnail":"http://img/1.jpg","availableEpisodes":{"sub":12,"dub":0,"raw":0}}
+		]}}}`,
+	})
+	res, err := a.Trending(media.TV)
+	if err != nil || len(res) != 1 {
+		t.Fatalf("trending: %v / %+v", err, res)
+	}
+	if res[0].ID != "X1" || res[0].Title != "Show One" || res[0].Type != media.TV || res[0].Episodes != 12 {
+		t.Fatalf("mapped trending wrong: %+v", res[0])
 	}
 }

--- a/internal/provider/allanime_test.go
+++ b/internal/provider/allanime_test.go
@@ -119,3 +119,22 @@ func TestAllAnimeTrending(t *testing.T) {
 		t.Fatalf("mapped trending wrong: %+v", res[0])
 	}
 }
+
+func TestAllAnimeSearchRanksMainSeriesFirst(t *testing.T) {
+	// AllAnime returns specials first; the relevance sort must surface the main
+	// series (exact title, most episodes), not a 1-episode special.
+	a := newTestAllAnime(map[string]string{
+		`"query":"Death Note"`: `{"data":{"shows":{"edges":[
+			{"_id":"A","name":"Death Note Rewrite","availableEpisodes":{"sub":1}},
+			{"_id":"B","name":"Death Note","availableEpisodes":{"sub":37}},
+			{"_id":"C","name":"Death Note: Relight","availableEpisodes":{"sub":1}}
+		]}}}`,
+	})
+	res, err := a.Search("Death Note")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res[0].Title != "Death Note" || res[0].Episodes != 37 {
+		t.Fatalf("expected main series first, got %q (%d eps)", res[0].Title, res[0].Episodes)
+	}
+}

--- a/internal/provider/anipub.go
+++ b/internal/provider/anipub.go
@@ -1,0 +1,215 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+const (
+	anipubBase   = "https://anipub.xyz"
+	megaplayBase = "https://megaplay.buzz"
+	anipubUA     = "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0"
+)
+
+// AniPub streams FINISHED anime via anipub.xyz -> megaplay.buzz. All open JSON,
+// no anti-bot/decrypt. Used as a fallback behind AllAnime (which can't reliably
+// stream finished series).
+type AniPub struct {
+	client httpDoer
+}
+
+func NewAniPub() *AniPub { return &AniPub{client: httputil.NewClient()} }
+
+func (p *AniPub) get(rawURL string, headers map[string]string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", anipubUA)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("anipub: status %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+}
+
+func (p *AniPub) Search(query string) ([]media.SearchResult, error) {
+	body, err := p.get(anipubBase+"/api/search/"+url.PathEscape(query), nil)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	// AniPub returns {"found":false} (an object) when nothing matches.
+	if t := bytes.TrimSpace(body); len(t) == 0 || t[0] != '[' {
+		return nil, fmt.Errorf("no anime found for %q", query)
+	}
+	var raw []struct {
+		Name  string `json:"Name"`
+		ID    int    `json:"Id"`
+		Image string `json:"Image"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("search parse: %w", err)
+	}
+	out := make([]media.SearchResult, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, media.SearchResult{
+			ID: strconv.Itoa(r.ID), Title: r.Name, Type: media.TV, Poster: r.Image,
+		})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no anime found for %q", query)
+	}
+	return out, nil
+}
+
+// Episode links carry the megaplay id in one of two shapes:
+//
+//	...gogoanime.com.by/streaming.php?...&ep=1465&...   (id 1465)
+//	...anipub.xyz/video/850/sub                          (id 850)
+var anipubEpRe = regexp.MustCompile(`(?:ep=|/video/)(\d+)`)
+
+// episodeMegaplayIDs returns the ordered megaplay episode ids for a show id.
+func (p *AniPub) episodeMegaplayIDs(showID string) ([]string, error) {
+	body, err := p.get(anipubBase+"/v1/api/details/"+showID, nil)
+	if err != nil {
+		return nil, err
+	}
+	var d struct {
+		Local struct {
+			Ep []struct {
+				Link string `json:"link"`
+			} `json:"ep"`
+		} `json:"local"`
+	}
+	if err := json.Unmarshal(body, &d); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(d.Local.Ep))
+	for _, e := range d.Local.Ep {
+		if m := anipubEpRe.FindStringSubmatch(e.Link); m != nil {
+			ids = append(ids, m[1])
+		}
+	}
+	return ids, nil
+}
+
+var megaplayDataIDRe = regexp.MustCompile(`data-id="(\d+)"`)
+
+// megaplayStream resolves a megaplay episode id + audio to a playable stream.
+func (p *AniPub) megaplayStream(megaplayID string, dub bool) (*media.Stream, error) {
+	audio := "sub"
+	if dub {
+		audio = "dub"
+	}
+	page, err := p.get(fmt.Sprintf("%s/stream/s-2/%s/%s", megaplayBase, megaplayID, audio),
+		map[string]string{"Referer": "https://gogoanime.com.by/"})
+	if err != nil {
+		return nil, err
+	}
+	m := megaplayDataIDRe.FindSubmatch(page)
+	if m == nil {
+		return nil, fmt.Errorf("megaplay: no data-id")
+	}
+	body, err := p.get(fmt.Sprintf("%s/stream/getSources?id=%s", megaplayBase, m[1]),
+		map[string]string{"Referer": "https://megaplay.buzz/", "X-Requested-With": "XMLHttpRequest"})
+	if err != nil {
+		return nil, err
+	}
+	var src struct {
+		Sources struct {
+			File string `json:"file"`
+		} `json:"sources"`
+		Tracks []struct {
+			File  string `json:"file"`
+			Label string `json:"label"`
+			Kind  string `json:"kind"`
+		} `json:"tracks"`
+	}
+	if err := json.Unmarshal(body, &src); err != nil {
+		return nil, err
+	}
+	if src.Sources.File == "" {
+		return nil, fmt.Errorf("megaplay: no source file")
+	}
+	st := &media.Stream{URL: src.Sources.File, Referer: "https://megaplay.buzz/"}
+	for _, tr := range src.Tracks {
+		if tr.Kind != "captions" {
+			continue
+		}
+		st.Subtitles = append(st.Subtitles, media.Subtitle{Language: tr.Label, Label: tr.Label, URL: tr.File})
+	}
+	return st, nil
+}
+
+// ResolveByTitle is the fallback entry point: find the show by title, take
+// episode episodeNum (1-based), and resolve its stream.
+func (p *AniPub) ResolveByTitle(title string, episodeNum int, dub bool) (*media.Stream, error) {
+	res, err := p.Search(title)
+	if err != nil {
+		return nil, err
+	}
+	showID := res[0].ID
+	for _, r := range res {
+		if strings.EqualFold(strings.TrimSpace(r.Title), strings.TrimSpace(title)) {
+			showID = r.ID
+			break
+		}
+	}
+	ids, err := p.episodeMegaplayIDs(showID)
+	if err != nil {
+		return nil, err
+	}
+	if episodeNum < 1 || episodeNum > len(ids) {
+		return nil, fmt.Errorf("anipub: episode %d out of range (have %d)", episodeNum, len(ids))
+	}
+	return p.megaplayStream(ids[episodeNum-1], dub)
+}
+
+// --- StreamProvider surface (usable standalone too) ---
+
+func (p *AniPub) GetSeasons(id string) ([]media.Season, error) {
+	return []media.Season{{Number: 1, ID: id}}, nil
+}
+
+func (p *AniPub) GetEpisodes(id, seasonID string) ([]media.Episode, error) {
+	ids, err := p.episodeMegaplayIDs(id)
+	if err != nil {
+		return nil, fmt.Errorf("episodes: %w", err)
+	}
+	out := make([]media.Episode, 0, len(ids))
+	for i, mid := range ids {
+		out = append(out, media.Episode{Number: i + 1, Title: fmt.Sprintf("Episode %d", i+1), ID: mid})
+	}
+	return out, nil
+}
+
+func (p *AniPub) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	return p.megaplayStream(episodeID, strings.EqualFold(server, "dub"))
+}
+
+func (p *AniPub) GetDetails(id string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+func (p *AniPub) GetServers(id, episodeID string) ([]media.Server, error) {
+	return []media.Server{{Name: "AniPub", ID: "default"}}, nil
+}
+func (p *AniPub) GetEmbedURL(serverID string) (string, error)               { return "", fmt.Errorf("use Watch") }
+func (p *AniPub) Trending(mt media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+func (p *AniPub) Recent(mt media.MediaType) ([]media.SearchResult, error)   { return nil, nil }

--- a/internal/provider/anipub.go
+++ b/internal/provider/anipub.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"lobster/internal/httputil"
 	"lobster/internal/media"
@@ -31,23 +32,38 @@ type AniPub struct {
 func NewAniPub() *AniPub { return &AniPub{client: httputil.NewClient()} }
 
 func (p *AniPub) get(rawURL string, headers map[string]string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
-	if err != nil {
-		return nil, err
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 700 * time.Millisecond) // back off 429s
+		}
+		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", anipubUA)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		resp, err := p.client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resp.Body.Close()
+			lastErr = fmt.Errorf("anipub: status 429")
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
+			return nil, fmt.Errorf("anipub: status %d", resp.StatusCode)
+		}
+		data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+		resp.Body.Close()
+		return data, err
 	}
-	req.Header.Set("User-Agent", anipubUA)
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("anipub: status %d", resp.StatusCode)
-	}
-	return io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	return nil, lastErr
 }
 
 func (p *AniPub) Search(query string) ([]media.SearchResult, error) {
@@ -161,18 +177,11 @@ func (p *AniPub) megaplayStream(megaplayID string, dub bool) (*media.Stream, err
 // ResolveByTitle is the fallback entry point: find the show by title, take
 // episode episodeNum (1-based), and resolve its stream.
 func (p *AniPub) ResolveByTitle(title string, episodeNum int, dub bool) (*media.Stream, error) {
-	res, err := p.Search(title)
+	res, err := p.searchVariants(title)
 	if err != nil {
 		return nil, err
 	}
-	showID := res[0].ID
-	for _, r := range res {
-		if strings.EqualFold(strings.TrimSpace(r.Title), strings.TrimSpace(title)) {
-			showID = r.ID
-			break
-		}
-	}
-	ids, err := p.episodeMegaplayIDs(showID)
+	ids, err := p.episodeMegaplayIDs(bestAniPubMatch(res, title))
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +189,79 @@ func (p *AniPub) ResolveByTitle(title string, episodeNum int, dub bool) (*media.
 		return nil, fmt.Errorf("anipub: episode %d out of range (have %d)", episodeNum, len(ids))
 	}
 	return p.megaplayStream(ids[episodeNum-1], dub)
+}
+
+// searchVariants tries the full title then a subtitle-stripped form, so AllAnime
+// titles carrying a subtitle AniPub doesn't index (e.g. "Code Geass: ... R2")
+// still resolve.
+func (p *AniPub) searchVariants(title string) ([]media.SearchResult, error) {
+	var lastErr error
+	for _, v := range titleVariants(title) {
+		if res, err := p.Search(v); err == nil && len(res) > 0 {
+			return res, nil
+		} else if err != nil {
+			lastErr = err
+		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no anime found for %q", title)
+	}
+	return nil, lastErr
+}
+
+func titleVariants(title string) []string {
+	t := strings.TrimSpace(title)
+	out := []string{t}
+	if i := strings.LastIndex(t, ":"); i > 0 {
+		if base := strings.TrimSpace(t[:i]); base != t {
+			out = append(out, base)
+		}
+	}
+	return out
+}
+
+// bestAniPubMatch picks the result whose name shares the most words with the
+// full title (exact match wins), so a broadened search still lands on the
+// right entry rather than an unrelated first result.
+func bestAniPubMatch(res []media.SearchResult, title string) string {
+	for _, r := range res {
+		if strings.EqualFold(strings.TrimSpace(r.Title), strings.TrimSpace(title)) {
+			return r.ID
+		}
+	}
+	want := titleWords(title)
+	bestID, best := res[0].ID, -1<<30
+	for _, r := range res {
+		rw := titleWords(r.Title)
+		ov := wordOverlap(rw, want)
+		// Maximize shared words, then penalize EXTRA words so the clean main
+		// entry beats a same-overlap spinoff ("... OVA Collection", "... Specials").
+		score := ov*1000 - (len(rw) - ov)
+		if score > best {
+			best, bestID = score, r.ID
+		}
+	}
+	return bestID
+}
+
+func titleWords(s string) map[string]bool {
+	w := map[string]bool{}
+	for _, f := range strings.Fields(strings.ToLower(s)) {
+		if f = strings.Trim(f, ":;,.-"); f != "" {
+			w[f] = true
+		}
+	}
+	return w
+}
+
+func wordOverlap(a, b map[string]bool) int {
+	n := 0
+	for k := range a {
+		if b[k] {
+			n++
+		}
+	}
+	return n
 }
 
 // --- StreamProvider surface (usable standalone too) ---

--- a/internal/provider/anipub_test.go
+++ b/internal/provider/anipub_test.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// Compile-time proof the type satisfies the streaming interface.
+var _ StreamProvider = (*AniPub)(nil)
+
+func newTestAniPub(routes map[string]string) *AniPub {
+	p := NewAniPub()
+	p.client = fakeDoer{routes: routes} // fakeDoer is defined in allanime_test.go (same package)
+	return p
+}
+
+func TestAniPubResolveByTitle(t *testing.T) {
+	p := newTestAniPub(map[string]string{
+		`/api/search/Death`:    `[{"Name":"Death Note","Id":38,"Image":"http://img/dn.jpg","finder":"death-note"}]`,
+		`/v1/api/details/38`:   `{"local":{"ep":[{"link":"src=https://gogoanime.com.by/streaming.php?id=x&ep=1465&server=hd-1&type=dub"},{"link":"src=...&ep=1466&server=hd-1&type=dub"}]}}`,
+		`/stream/s-2/1466/sub`: `<div data-id="55501"></div>`,
+		`getSources?id=55501`:  `{"sources":{"file":"https://cdn/master.m3u8"},"tracks":[{"file":"https://cdn/en.vtt","label":"English","kind":"captions"}]}`,
+	})
+	st, err := p.ResolveByTitle("Death Note", 2, false) // episode 2, sub
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.URL != "https://cdn/master.m3u8" {
+		t.Fatalf("stream URL = %q", st.URL)
+	}
+	if len(st.Subtitles) != 1 || st.Subtitles[0].URL != "https://cdn/en.vtt" {
+		t.Fatalf("subtitles wrong: %+v", st.Subtitles)
+	}
+	if st.Referer != "https://megaplay.buzz/" {
+		t.Fatalf("referer = %q", st.Referer)
+	}
+}
+
+func TestAniPubVideoFormatAndNoMatch(t *testing.T) {
+	// Cowboy Bebop uses the /video/{id} link shape (not ?ep=).
+	p := newTestAniPub(map[string]string{
+		`/api/search/Cowboy`:   `[{"Name":"Cowboy Bebop","Id":8270,"Image":"x"}]`,
+		`/v1/api/details/8270`: `{"local":{"ep":[{"link":"src=https://anipub.xyz/video/850/sub"}]}}`,
+		`/stream/s-2/850/sub`:  `<div data-id="41014"></div>`,
+		`getSources?id=41014`:  `{"sources":{"file":"https://cdn/cb.m3u8"},"tracks":[]}`,
+	})
+	st, err := p.ResolveByTitle("Cowboy Bebop", 1, false)
+	if err != nil || st == nil || st.URL != "https://cdn/cb.m3u8" {
+		t.Fatalf("video-format resolve failed: %v / %v", err, st)
+	}
+	// found:false (object, not array) -> graceful no-results, not a parse error.
+	p2 := newTestAniPub(map[string]string{`/api/search/zzz`: `{"found":false}`})
+	if _, err := p2.Search("zzz"); err == nil {
+		t.Fatal("expected no-results error for found:false")
+	}
+}
+
+func TestAniPubSearch(t *testing.T) {
+	p := newTestAniPub(map[string]string{
+		`/api/search/naruto`: `[{"Name":"Naruto","Id":20,"Image":"http://i/n.jpg","finder":"naruto"}]`,
+	})
+	res, err := p.Search("naruto")
+	if err != nil || len(res) != 1 || res[0].ID != "20" || res[0].Title != "Naruto" || res[0].Type != media.TV {
+		t.Fatalf("search wrong: %v / %+v", err, res)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -127,7 +127,7 @@ func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager, f
 		state:             stateTrending,
 		provider:          p,
 		cartoonProvider:   provider.NewKimCartoon(provider.ResolveDomain("kimcartoon.com.co", "kimcartoon", cfg.DomainOverrides)),
-		animeProvider:     provider.NewVaPlayer(),
+		animeProvider:     provider.NewAllAnime(cfg.AnimeDub),
 		fallbackProviders: fallbacks,
 		config:            cfg,
 		list:              l,
@@ -263,6 +263,19 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case "d":
+			if m.activeTab == tabAnime {
+				if aa, ok := m.animeProvider.(*provider.AllAnime); ok {
+					if aa.Translation() == "dub" {
+						aa.SetTranslation("sub")
+					} else {
+						aa.SetTranslation("dub")
+					}
+					m.toast = "Anime audio: " + aa.Translation()
+					m.results = nil
+					m.currentItem = nil
+					return m, tea.Batch(fetchTabCmd(m.providerForActiveTab(), m.activeTab), m.list.StartSpinner())
+				}
+			}
 			if m.dlManager != nil && m.currentItem != nil {
 				if m.currentItem.Type == media.TV {
 					outputDir, err := m.config.ExpandDownloadDir()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -208,7 +208,16 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.results = nil // Clear current results to show loader
 				m.currentItem = nil
 				cmds = append(cmds, m.list.StartSpinner())
-				return m, tea.Batch(searchCmd(m.providerForActiveTab(), m.searchInput.Value(), m.fallbackProviders...), m.list.StartSpinner())
+				// Only the Movies/Series tabs fan out to the movies fallback
+				// providers. Anime/Cartoons have their own dedicated provider, so
+				// searching them must NOT wait on the (often slow/dead) movies
+				// fallbacks — that was adding the multi-search timeout to every
+				// anime search.
+				fallbacks := m.fallbackProviders
+				if m.activeTab == tabAnime || m.activeTab == tabCartoons {
+					fallbacks = nil
+				}
+				return m, tea.Batch(searchCmd(m.providerForActiveTab(), m.searchInput.Value(), fallbacks...), m.list.StartSpinner())
 			case tea.KeyEsc:
 				m.isSearching = false
 				m.searchInput.Blur()


### PR DESCRIPTION
## What
Replaces the generic TMDB-based VaPlayer on the **Anime tab** with a native **AllAnime** provider — a real anime catalog with sub/dub, soft VTT subtitles, and coverage of airing *and* finished shows.

## Why
The previously-scoped Consumet/Zoro path is dead (HiAnime offline + Consumet/aniwatch-api DMCA'd, March 2026). Research found **AllAnime** (`api.allanime.day`) is the live source every maintained anime CLI (ani-cli, curd, jerry, GoAnime) uses — a GraphQL API, not HTML scraping.

## How
- **GraphQL** search / episode-list / episode-sources against `api.allanime.day` (persisted-query GET for sources, with the `youtu-chan.com` Origin gate).
- **AES-256-CTR decrypt** of the obfuscated source blob (key `SHA256("Xot36i3lK3:v1")`), then **two-tier resolution**: the internal `--`/`clock.json` CDN path, and — for finished shows where that's stale — the plain embed hosts (Streamwish/Filemoon) via lobster's **existing** `internal/extract` extractors.
- **Sub/dub**: `anime_dub` config (default sub) + a `d` toggle on the anime tab.
- **Playback wiring**: `resolveStream` now tries a primary `StreamProvider` first with the session's **native** episode ID, so AllAnime's opaque IDs (`showId|1.5|sub`) reach `Watch` intact (movies/series path unchanged; VaPlayer still works).
- All volatile constants (key, query hash, headers) isolated in one `allanimeConfig` struct — upstream rotations are a one-line change.

## Verification
- Unit tests: AES-CTR decrypt (round-trip + known vectors), XOR decode, episode-id round-trip, GraphQL parsing (injected client), Watch clock.json path.
- **Live end-to-end smoke** (real API): `Search("One Piece")` → 1169 episodes → `Watch(latest)` resolved a real playable CDN stream. Full suite + `go vet` green.
- Whole-branch adversarial review done; it caught an infinite-retry loop (dead Primary stream) — fixed with an `excludeNames` guard — plus HTTP status checks.

## Notes
- Single-source fragility: AllAnime is under legal pressure and rotates its crypto/headers periodically; the source layer is structured to be swappable, and the config struct makes fixes cheap. The build-tagged-less live test is the canary.
- Out of scope: AniList metadata, a second anime source, manga, ok.ru extractor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Anime dub/sub** setting and an in-app **toggle** for anime translation.
  * Expanded anime browsing and streaming with an **AllAnime-powered** experience (search, episode listing, trending/recent).
  * Improved stream resolution to **prefer a primary source first**, with **AniPub** as a fallback.
* **Bug Fixes**
  * Improved and more reliable subtitle/stream extraction when primary resolution fails.
* **Tests**
  * Added/extended unit tests covering AllAnime and AniPub search, decoding, and watch/episode resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->