### PR TITLE
feat: Live TV (IPTV) tab

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -46,17 +47,28 @@ func searchRun(cmd *cobra.Command, args []string) error {
 			defer cleanup()
 		}
 
-		selected, selectedProvider, err := tui.StartApp(p, cfg, mgr, fallbackSearchProviders(p)...)
-		if err != nil {
-			return err
-		}
-		if selected != nil {
+		for {
+			selected, lineup, startIdx, selectedProvider, err := tui.StartApp(p, cfg, mgr, fallbackSearchProviders(p)...)
+			if err != nil {
+				return err
+			}
+			if selected == nil {
+				return nil // user quit the browser without selecting
+			}
 			if selectedProvider == nil {
 				selectedProvider = p
 			}
+			if lineup != nil { // a Live TV channel was chosen -> surf the category
+				if sp, ok := selectedProvider.(provider.StreamProvider); ok {
+					if surfErr := playLiveSurf(sp, lineup, startIdx); errors.Is(surfErr, errSurfBackToList) {
+						continue // reopen the browser
+					} else {
+						return surfErr
+					}
+				}
+			}
 			return resolveAndPlay(selectedProvider, *selected, 0, 0)
 		}
-		return nil
 	}
 
 	debugf("searching for: %s", query)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -19,8 +19,8 @@ import (
 	"lobster/internal/httputil"
 	"lobster/internal/media"
 	"lobster/internal/player"
-	"lobster/internal/poster"
 	"lobster/internal/playlist"
+	"lobster/internal/poster"
 	"lobster/internal/provider"
 	"lobster/internal/subtitle"
 	"lobster/internal/tui"
@@ -226,6 +226,11 @@ func printDetail(r media.SearchResult, d *media.ContentDetail) {
 func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, episode int) error {
 	episodeID := ""
 	title := selected.Title
+
+	// Live channels are endless streams; ffmpeg-to-file would never finish.
+	if _, isLive := p.(*provider.LiveTV); isLive && flagDownload != "" {
+		return fmt.Errorf("live channels cannot be downloaded")
+	}
 
 	if selected.Type == media.TV {
 		// Get seasons

--- a/cmd/surf.go
+++ b/cmd/surf.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"lobster/internal/media"
+	"lobster/internal/player"
+	"lobster/internal/playlist"
+	"lobster/internal/provider"
+	"lobster/internal/ui"
+)
+
+// maxSurfFailures caps consecutive dead channels before surf gives up, so a
+// fully-unreachable network can't loop forever.
+const maxSurfFailures = 12
+
+// errSurfBackToList signals the user chose "Back to channel list"; the caller
+// (searchRun) reopens the browser.
+var errSurfBackToList = errors.New("surf: back to channel list")
+
+type surfAction int
+
+const (
+	surfNext surfAction = iota
+	surfPrev
+	surfBack
+	surfQuit
+)
+
+// playLiveSurf surfs a Live TV category lineup starting at startIdx. On mpv it
+// auto-advances past channels that fail to load (up to maxSurfFailures in a
+// row); on any player it shows a Next/Previous/Back/Quit menu after a channel
+// plays. Returns errSurfBackToList when the user picks "Back to channel list",
+// nil on quit or when the failure cap is hit.
+func playLiveSurf(p provider.StreamProvider, lineup []media.SearchResult, startIdx int) error {
+	if len(lineup) == 0 {
+		return nil
+	}
+	pl := player.New(cfg.Player)
+	if !pl.Available() {
+		return player.NotFoundError(cfg.Player)
+	}
+	autoSkip := pl.Name() == "mpv"
+	if !autoSkip {
+		fmt.Fprintf(os.Stderr, "Auto-skip of dead channels needs mpv; on %s use the menu to change channels.\n", pl.Name())
+	}
+
+	i := startIdx
+	failCount := 0
+	for {
+		ch := lineup[i]
+		res, perr := surfPlayOne(pl, p, ch)
+		switch playlist.DecideSurf(res.Position, perr, autoSkip) {
+		case playlist.SurfAdvance:
+			failCount++
+			if failCount >= maxSurfFailures {
+				fmt.Fprintf(os.Stderr, "No playable channel found after %d tries.\n", failCount)
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "%s unavailable, trying next...\n", ch.Title)
+			i = playlist.NextIndex(i, len(lineup))
+		default: // playlist.SurfMenu
+			failCount = 0
+			action, err := surfMenu(ch.Title)
+			if err != nil {
+				return nil // menu error (e.g. fzf ctrl-c) -> quit
+			}
+			switch action {
+			case surfNext:
+				i = playlist.NextIndex(i, len(lineup))
+			case surfPrev:
+				i = playlist.PrevIndex(i, len(lineup))
+			case surfBack:
+				return errSurfBackToList
+			case surfQuit:
+				return nil
+			}
+		}
+	}
+}
+
+// surfPlayOne resolves and plays one channel. A resolve error is returned as a
+// load failure (zero result + error) so it advances like a dead stream on mpv.
+func surfPlayOne(pl player.Player, p provider.StreamProvider, ch media.SearchResult) (player.PlayResult, error) {
+	stream, err := p.Watch(ch.ID, "", "LiveTV", cfg.Quality)
+	if err != nil {
+		return player.PlayResult{}, err
+	}
+	return pl.Play(stream, ch.Title, 0, nil)
+}
+
+// surfMenu shows the post-play channel menu and returns the chosen action.
+func surfMenu(title string) (surfAction, error) {
+	labels := []string{"Next channel", "Previous channel", "Back to channel list", "Quit"}
+	idx, err := ui.Select("Now: "+title, labels)
+	if err != nil {
+		return surfQuit, err
+	}
+	return []surfAction{surfNext, surfPrev, surfBack, surfQuit}[idx], nil
+}

--- a/cmd/surf.go
+++ b/cmd/surf.go
@@ -65,7 +65,10 @@ func playLiveSurf(p provider.StreamProvider, lineup []media.SearchResult, startI
 			failCount = 0
 			action, err := surfMenu(ch.Title)
 			if err != nil {
-				return nil // menu error (e.g. fzf ctrl-c) -> quit
+				if errors.Is(err, ui.ErrCancelled) {
+					return nil // user aborted the menu -> quit cleanly
+				}
+				return fmt.Errorf("channel menu failed: %w", err) // real selector/TTY failure
 			}
 			switch action {
 			case surfNext:
@@ -93,7 +96,7 @@ func surfPlayOne(pl player.Player, p provider.StreamProvider, ch media.SearchRes
 
 // surfMenu shows the post-play channel menu and returns the chosen action.
 func surfMenu(title string) (surfAction, error) {
-	labels := []string{"Next channel", "Previous channel", "Back to channel list", "Quit"}
+	labels := []string{"Next channel", "Previous channel", "Back to browser", "Quit"}
 	idx, err := ui.Select("Now: "+title, labels)
 	if err != nil {
 		return surfQuit, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,9 +60,13 @@ func (c LiveTVConfig) Sources() []string {
 	}
 	s = append(s, c.Playlists...)
 	if c.Xtream.Server != "" {
+		server := c.Xtream.Server
+		if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
+			server = "http://" + server
+		}
 		s = append(s, fmt.Sprintf(
-			"http://%s/get.php?username=%s&password=%s&type=m3u_plus&output=m3u8",
-			c.Xtream.Server,
+			"%s/get.php?username=%s&password=%s&type=m3u_plus&output=m3u8",
+			server,
 			url.QueryEscape(c.Xtream.Username),
 			url.QueryEscape(c.Xtream.Password),
 		))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,41 +15,78 @@ import (
 
 // Config holds all application configuration.
 type Config struct {
-	Base         string `toml:"base"`
-	APIURL       string `toml:"api_url"`
-	Player       string `toml:"player"`
-	Provider     string `toml:"provider"`
-	SubsLanguage string `toml:"subs_language"`
-	Quality      string `toml:"quality"`
-	History      bool   `toml:"history"`
-	AutoNext     bool   `toml:"auto_next"`
-	DownloadDir  string `toml:"download_dir"`
-	OSAPIKey     string `toml:"opensubtitles_api_key"`
-	SubDLAPIKey  string `toml:"subdl_api_key"`
-	Debug                  bool              `toml:"debug"`
-	MaxConcurrentDownloads int               `toml:"max_concurrent_downloads"`
-	StallTimeout           int               `toml:"stall_timeout"`  // seconds before a stalled download is recovered
-	MaxRetries             int               `toml:"max_retries"`    // retry count for segment/file downloads
+	Base                   string              `toml:"base"`
+	APIURL                 string              `toml:"api_url"`
+	Player                 string              `toml:"player"`
+	Provider               string              `toml:"provider"`
+	SubsLanguage           string              `toml:"subs_language"`
+	Quality                string              `toml:"quality"`
+	History                bool                `toml:"history"`
+	AutoNext               bool                `toml:"auto_next"`
+	DownloadDir            string              `toml:"download_dir"`
+	OSAPIKey               string              `toml:"opensubtitles_api_key"`
+	SubDLAPIKey            string              `toml:"subdl_api_key"`
+	Debug                  bool                `toml:"debug"`
+	MaxConcurrentDownloads int                 `toml:"max_concurrent_downloads"`
+	StallTimeout           int                 `toml:"stall_timeout"`    // seconds before a stalled download is recovered
+	MaxRetries             int                 `toml:"max_retries"`      // retry count for segment/file downloads
 	DomainOverrides        map[string][]string `toml:"domain_overrides"` // provider name -> fallback domains
 	AnimeDub               bool                `toml:"anime_dub"`
+	LiveTV                 LiveTVConfig        `toml:"live_tv"`
+}
+
+// XtreamConfig holds optional Xtream-codes credentials for a paid IPTV sub.
+type XtreamConfig struct {
+	Server   string `toml:"server"` // host:port
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+}
+
+// LiveTVConfig configures the Live TV tab's playlist sources.
+type LiveTVConfig struct {
+	IPTVOrg   bool         `toml:"iptv_org"`  // include the built-in iptv-org playlist (default true)
+	Playlists []string     `toml:"playlists"` // extra M3U URLs or local file paths
+	Xtream    XtreamConfig `toml:"xtream"`    // optional Xtream-codes subscription
+}
+
+const iptvOrgPlaylist = "https://iptv-org.github.io/iptv/index.category.m3u"
+
+// Sources returns the resolved playlist URLs/paths in priority order:
+// iptv-org (if enabled), then custom playlists, then a templated Xtream URL.
+func (c LiveTVConfig) Sources() []string {
+	var s []string
+	if c.IPTVOrg {
+		s = append(s, iptvOrgPlaylist)
+	}
+	s = append(s, c.Playlists...)
+	if c.Xtream.Server != "" {
+		s = append(s, fmt.Sprintf(
+			"http://%s/get.php?username=%s&password=%s&type=m3u_plus&output=m3u8",
+			c.Xtream.Server,
+			url.QueryEscape(c.Xtream.Username),
+			url.QueryEscape(c.Xtream.Password),
+		))
+	}
+	return s
 }
 
 // Default returns the default configuration.
 func Default() *Config {
 	return &Config{
-		Base:         "flixhq.ws",
-		Player:       "mpv",
-		Provider:     "Default",
-		SubsLanguage: "english",
-		Quality:      "1080",
-		History:      true,
-		AutoNext:     true,
+		Base:                   "flixhq.ws",
+		Player:                 "mpv",
+		Provider:               "Default",
+		SubsLanguage:           "english",
+		Quality:                "1080",
+		History:                true,
+		AutoNext:               true,
 		DownloadDir:            "~/Videos/lobster",
 		Debug:                  false,
 		MaxConcurrentDownloads: 2,
 		StallTimeout:           60,
 		MaxRetries:             3,
 		SubDLAPIKey:            "KCCm2v2q5ZObZOPQgQX8jpQ3-07IEY2c",
+		LiveTV:                 LiveTVConfig{IPTVOrg: true},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -187,3 +187,37 @@ func TestHealthPath(t *testing.T) {
 		t.Fatalf("HealthPath=%q want .../lobster/health.json", p)
 	}
 }
+
+func TestLiveTVDefaultsOn(t *testing.T) {
+	if !Default().LiveTV.IPTVOrg {
+		t.Fatal("LiveTV.IPTVOrg should default to true")
+	}
+}
+
+func TestLiveTVSources(t *testing.T) {
+	c := LiveTVConfig{
+		IPTVOrg:   true,
+		Playlists: []string{"https://x/p.m3u", "/home/u/local.m3u"},
+		Xtream:    XtreamConfig{Server: "h:8080", Username: "u s", Password: "p&p"},
+	}
+	got := c.Sources()
+	if len(got) != 4 {
+		t.Fatalf("want 4 sources, got %d: %v", len(got), got)
+	}
+	if got[0] != "https://iptv-org.github.io/iptv/index.category.m3u" {
+		t.Fatalf("iptv-org first, got %q", got[0])
+	}
+	if got[1] != "https://x/p.m3u" || got[2] != "/home/u/local.m3u" {
+		t.Fatalf("playlists out of order: %v", got)
+	}
+	if got[3] != "http://h:8080/get.php?username=u+s&password=p%26p&type=m3u_plus&output=m3u8" {
+		t.Fatalf("xtream url wrong: %q", got[3])
+	}
+}
+
+func TestLiveTVSourcesOmitsIPTVOrgWhenOff(t *testing.T) {
+	c := LiveTVConfig{IPTVOrg: false}
+	if len(c.Sources()) != 0 {
+		t.Fatalf("want no sources, got %v", c.Sources())
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -221,3 +221,11 @@ func TestLiveTVSourcesOmitsIPTVOrgWhenOff(t *testing.T) {
 		t.Fatalf("want no sources, got %v", c.Sources())
 	}
 }
+
+func TestLiveTVSourcesHTTPSXtream(t *testing.T) {
+	c := LiveTVConfig{Xtream: XtreamConfig{Server: "https://h:8443", Username: "u", Password: "p"}}
+	got := c.Sources()
+	if len(got) != 1 || got[0] != "https://h:8443/get.php?username=u&password=p&type=m3u_plus&output=m3u8" {
+		t.Fatalf("https xtream url wrong: %v", got)
+	}
+}

--- a/internal/media/types.go
+++ b/internal/media/types.go
@@ -69,6 +69,7 @@ type Stream struct {
 	Subtitles []Subtitle // Available subtitle tracks
 	Quality   string     // Resolved quality
 	Referer   string     // Referer header required by the CDN (if any)
+	UserAgent string     // User-Agent header required by the CDN (if any)
 }
 
 // Subtitle represents a subtitle track.

--- a/internal/player/generic.go
+++ b/internal/player/generic.go
@@ -27,6 +27,7 @@ func (g *Generic) Play(stream *media.Stream, title string, startPos float64, sub
 
 	// Both iina and celluloid accept mpv-style flags
 	args = append(args, "--force-media-title="+title)
+	args = append(args, genericHeaderArgs(stream)...)
 
 	if startPos > 0 {
 		args = append(args, fmt.Sprintf("--start=+%.0f", startPos))

--- a/internal/player/headers.go
+++ b/internal/player/headers.go
@@ -1,0 +1,54 @@
+package player
+
+import (
+	"strings"
+
+	"lobster/internal/media"
+)
+
+// mpvHeaderArgs builds mpv args for Referer/User-Agent. The HLS demuxer headers
+// MUST be combined into a single --demuxer-lavf-o=headers= value: mpv treats
+// "headers" as one key, so a second --demuxer-lavf-o=headers= would overwrite
+// the first and drop a header on segment requests.
+func mpvHeaderArgs(s *media.Stream) []string {
+	if s.Referer == "" && s.UserAgent == "" {
+		return nil
+	}
+	var args []string
+	var hdr strings.Builder
+	if s.Referer != "" {
+		args = append(args, "--http-header-fields=Referer: "+s.Referer)
+		hdr.WriteString("Referer: " + s.Referer + "\r\n")
+		args = append(args, "--tls-verify=no")
+	}
+	if s.UserAgent != "" {
+		args = append(args, "--user-agent="+s.UserAgent)
+		hdr.WriteString("User-Agent: " + s.UserAgent + "\r\n")
+	}
+	args = append(args, "--demuxer-lavf-o=headers="+hdr.String())
+	return args
+}
+
+// vlcHeaderArgs builds VLC args for Referer/User-Agent.
+func vlcHeaderArgs(s *media.Stream) []string {
+	var args []string
+	if s.Referer != "" {
+		args = append(args, "--http-referrer", s.Referer)
+	}
+	if s.UserAgent != "" {
+		args = append(args, "--http-user-agent", s.UserAgent)
+	}
+	return args
+}
+
+// genericHeaderArgs builds best-effort mpv-style header args for iina/celluloid.
+func genericHeaderArgs(s *media.Stream) []string {
+	var args []string
+	if s.Referer != "" {
+		args = append(args, "--http-header-fields=Referer: "+s.Referer)
+	}
+	if s.UserAgent != "" {
+		args = append(args, "--user-agent="+s.UserAgent)
+	}
+	return args
+}

--- a/internal/player/headers.go
+++ b/internal/player/headers.go
@@ -42,13 +42,22 @@ func vlcHeaderArgs(s *media.Stream) []string {
 }
 
 // genericHeaderArgs builds best-effort mpv-style header args for iina/celluloid.
+// Like mpvHeaderArgs, it also emits the combined --demuxer-lavf-o=headers= form
+// so HLS segment requests keep the same headers (without --tls-verify=no).
 func genericHeaderArgs(s *media.Stream) []string {
+	if s.Referer == "" && s.UserAgent == "" {
+		return nil
+	}
 	var args []string
+	var hdr strings.Builder
 	if s.Referer != "" {
 		args = append(args, "--http-header-fields=Referer: "+s.Referer)
+		hdr.WriteString("Referer: " + s.Referer + "\r\n")
 	}
 	if s.UserAgent != "" {
 		args = append(args, "--user-agent="+s.UserAgent)
+		hdr.WriteString("User-Agent: " + s.UserAgent + "\r\n")
 	}
+	args = append(args, "--demuxer-lavf-o=headers="+hdr.String())
 	return args
 }

--- a/internal/player/headers.go
+++ b/internal/player/headers.go
@@ -19,7 +19,6 @@ func mpvHeaderArgs(s *media.Stream) []string {
 	if s.Referer != "" {
 		args = append(args, "--http-header-fields=Referer: "+s.Referer)
 		hdr.WriteString("Referer: " + s.Referer + "\r\n")
-		args = append(args, "--tls-verify=no")
 	}
 	if s.UserAgent != "" {
 		args = append(args, "--user-agent="+s.UserAgent)

--- a/internal/player/headers_test.go
+++ b/internal/player/headers_test.go
@@ -1,0 +1,62 @@
+package player
+
+import (
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+func has(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMPVHeaderArgsCombinesRefererAndUA(t *testing.T) {
+	args := mpvHeaderArgs(&media.Stream{Referer: "https://ref/", UserAgent: "UA/1.0"})
+	if !has(args, "--http-header-fields=Referer: https://ref/") {
+		t.Fatalf("missing referer field: %v", args)
+	}
+	if !has(args, "--user-agent=UA/1.0") {
+		t.Fatalf("missing user-agent: %v", args)
+	}
+	// Exactly one demuxer headers arg, carrying BOTH (Referer not clobbered).
+	var hdr string
+	n := 0
+	for _, a := range args {
+		if strings.HasPrefix(a, "--demuxer-lavf-o=headers=") {
+			hdr = a
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("want exactly 1 demuxer headers arg, got %d: %v", n, args)
+	}
+	if !strings.Contains(hdr, "Referer: https://ref/") || !strings.Contains(hdr, "User-Agent: UA/1.0") {
+		t.Fatalf("combined headers missing one value: %q", hdr)
+	}
+}
+
+func TestMPVHeaderArgsEmpty(t *testing.T) {
+	if args := mpvHeaderArgs(&media.Stream{}); len(args) != 0 {
+		t.Fatalf("want no args, got %v", args)
+	}
+}
+
+func TestVLCHeaderArgs(t *testing.T) {
+	args := vlcHeaderArgs(&media.Stream{Referer: "https://ref/", UserAgent: "UA/1.0"})
+	if !has(args, "--http-referrer") || !has(args, "--http-user-agent") {
+		t.Fatalf("vlc header flags missing: %v", args)
+	}
+}
+
+func TestGenericHeaderArgs(t *testing.T) {
+	args := genericHeaderArgs(&media.Stream{UserAgent: "UA/1.0"})
+	if !has(args, "--user-agent=UA/1.0") {
+		t.Fatalf("generic UA missing: %v", args)
+	}
+}

--- a/internal/player/headers_test.go
+++ b/internal/player/headers_test.go
@@ -39,6 +39,10 @@ func TestMPVHeaderArgsCombinesRefererAndUA(t *testing.T) {
 	if !strings.Contains(hdr, "Referer: https://ref/") || !strings.Contains(hdr, "User-Agent: UA/1.0") {
 		t.Fatalf("combined headers missing one value: %q", hdr)
 	}
+	// A Referer must NOT silently disable TLS verification.
+	if has(args, "--tls-verify=no") {
+		t.Fatalf("Referer should not disable TLS verification: %v", args)
+	}
 }
 
 func TestMPVHeaderArgsEmpty(t *testing.T) {

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
-	"math"
 
 	"lobster/internal/media"
 )
@@ -50,12 +50,7 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 		"--network-timeout=15",
 	}
 
-	if stream.Referer != "" {
-		args = append(args, "--http-header-fields=Referer: "+stream.Referer)
-		// Propagate referer to ffmpeg's HLS demuxer for segment requests
-		args = append(args, "--demuxer-lavf-o=headers=Referer: "+stream.Referer+"\r\n")
-		args = append(args, "--tls-verify=no")
-	}
+	args = append(args, mpvHeaderArgs(stream)...)
 
 	if startPos > 0 {
 		args = append(args, fmt.Sprintf("--start=+%.0f", startPos))

--- a/internal/player/vlc.go
+++ b/internal/player/vlc.go
@@ -32,9 +32,7 @@ func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFile
 		"--play-and-exit",
 	}
 
-	if stream.Referer != "" {
-		args = append(args, "--http-referrer", stream.Referer)
-	}
+	args = append(args, vlcHeaderArgs(stream)...)
 
 	if startPos > 0 {
 		args = append(args, fmt.Sprintf("--start-time=%.0f", startPos))

--- a/internal/playlist/surf.go
+++ b/internal/playlist/surf.go
@@ -1,0 +1,27 @@
+package playlist
+
+// SurfDecision is what the Live TV surf loop should do after a play attempt.
+type SurfDecision int
+
+const (
+	SurfAdvance SurfDecision = iota // stream failed to load -> try the next channel
+	SurfMenu                        // channel played (or non-mpv) -> show the menu
+)
+
+// DecideSurf maps a play attempt's outcome to the next action. autoSkip is true
+// only when the active player can report load failures (mpv): mpv returns a
+// non-nil error with position 0 when a stream never loaded, vs a nil error with
+// position > 0 when the user watched then quit. When autoSkip is false (VLC and
+// other players give no usable signal), every outcome goes to the menu.
+func DecideSurf(position float64, err error, autoSkip bool) SurfDecision {
+	if autoSkip && err != nil && position == 0 {
+		return SurfAdvance
+	}
+	return SurfMenu
+}
+
+// NextIndex returns the next index in a lineup of length n (n > 0), wrapping.
+func NextIndex(i, n int) int { return (i + 1) % n }
+
+// PrevIndex returns the previous index in a lineup of length n (n > 0), wrapping.
+func PrevIndex(i, n int) int { return (i - 1 + n) % n }

--- a/internal/playlist/surf_test.go
+++ b/internal/playlist/surf_test.go
@@ -1,0 +1,41 @@
+package playlist
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDecideSurf(t *testing.T) {
+	loadErr := errors.New("stream failed to load")
+	cases := []struct {
+		name     string
+		position float64
+		err      error
+		autoSkip bool
+		want     SurfDecision
+	}{
+		{"mpv load failure -> advance", 0, loadErr, true, SurfAdvance},
+		{"mpv played then quit -> menu", 42, nil, true, SurfMenu},
+		{"mpv crash after watching -> menu (not a load failure)", 42, loadErr, true, SurfMenu},
+		{"mpv clean quit no progress -> menu", 0, nil, true, SurfMenu},
+		{"non-mpv error+zero -> menu (no reliable signal)", 0, loadErr, false, SurfMenu},
+		{"non-mpv success -> menu", 0, nil, false, SurfMenu},
+	}
+	for _, c := range cases {
+		if got := DecideSurf(c.position, c.err, c.autoSkip); got != c.want {
+			t.Errorf("%s: DecideSurf(%v,%v,%v) = %v, want %v", c.name, c.position, c.err, c.autoSkip, got, c.want)
+		}
+	}
+}
+
+func TestNextPrevIndexWrap(t *testing.T) {
+	if NextIndex(0, 3) != 1 || NextIndex(2, 3) != 0 {
+		t.Fatalf("NextIndex wrap wrong: %d %d", NextIndex(0, 3), NextIndex(2, 3))
+	}
+	if PrevIndex(0, 3) != 2 || PrevIndex(1, 3) != 0 {
+		t.Fatalf("PrevIndex wrap wrong: %d %d", PrevIndex(0, 3), PrevIndex(1, 3))
+	}
+	if NextIndex(0, 1) != 0 || PrevIndex(0, 1) != 0 {
+		t.Fatalf("single-element lineup must stay at 0")
+	}
+}

--- a/internal/provider/livetv.go
+++ b/internal/provider/livetv.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -72,6 +74,9 @@ func (p *LiveTV) fetch(src string) ([]byte, error) {
 	return os.ReadFile(src)
 }
 
+// maxPlaylistBytes caps a single playlist download.
+const maxPlaylistBytes = 32 << 20
+
 func (p *LiveTV) httpGet(c httpDoer, src string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, src, nil)
 	if err != nil {
@@ -80,13 +85,39 @@ func (p *LiveTV) httpGet(c httpDoer, src string) ([]byte, error) {
 	req.Header.Set("User-Agent", liveTVUA)
 	resp, err := c.Do(req)
 	if err != nil {
-		return nil, err
+		// A *url.Error embeds the full URL (which may carry Xtream
+		// username/password); return the redacted URL plus the underlying cause.
+		cause := err
+		var ue *url.Error
+		if errors.As(err, &ue) {
+			cause = ue.Err
+		}
+		return nil, fmt.Errorf("livetv: fetch %s failed: %w", redactURL(src), cause)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("livetv: status %d for %s", resp.StatusCode, src)
+		return nil, fmt.Errorf("livetv: status %d for %s", resp.StatusCode, redactURL(src))
 	}
-	return io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxPlaylistBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxPlaylistBytes {
+		return nil, fmt.Errorf("livetv: playlist %s exceeds %d MiB limit", redactURL(src), maxPlaylistBytes>>20)
+	}
+	return data, nil
+}
+
+// redactURL strips the query string and userinfo so credentials (e.g. Xtream
+// username/password) never appear in error messages or logs.
+func redactURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<url>"
+	}
+	u.RawQuery = ""
+	u.User = nil
+	return u.String()
 }
 
 // load fetches+parses+merges all sources once. A failed source is skipped; only

--- a/internal/provider/livetv.go
+++ b/internal/provider/livetv.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"lobster/internal/httputil"
 	"lobster/internal/media"
@@ -24,7 +25,7 @@ type LiveTV struct {
 	byID     map[string]Channel
 	byCat    map[string][]Channel
 	cats     []string
-	loaded   bool
+	once     sync.Once
 	loadErr  error
 }
 
@@ -55,11 +56,9 @@ func (p *LiveTV) fetch(src string) ([]byte, error) {
 
 // load fetches+parses+merges all sources once. A failed source is skipped; only
 // if every source fails is loadErr set.
-func (p *LiveTV) load() {
-	if p.loaded {
-		return
-	}
-	p.loaded = true
+func (p *LiveTV) load() { p.once.Do(p.doLoad) }
+
+func (p *LiveTV) doLoad() {
 	p.byID = map[string]Channel{}
 	p.byCat = map[string][]Channel{}
 	var anyOK bool
@@ -168,6 +167,9 @@ func (p *LiveTV) Search(query string) ([]media.SearchResult, error) {
 
 func (p *LiveTV) Watch(mediaID, _, _, _ string) (*media.Stream, error) {
 	p.load()
+	if p.loadErr != nil {
+		return nil, p.loadErr
+	}
 	ch, ok := p.byID[mediaID]
 	if !ok {
 		return nil, fmt.Errorf("livetv: unknown channel %q", mediaID)

--- a/internal/provider/livetv.go
+++ b/internal/provider/livetv.go
@@ -1,0 +1,192 @@
+package provider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"lobster/internal/httputil"
+	"lobster/internal/media"
+)
+
+const liveTVUA = "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0"
+
+// LiveTV streams free public IPTV (iptv-org) plus user playlists. Channels are
+// loaded lazily and cached for the session. It implements StreamProvider; the
+// TUI also calls Categories/Channels for two-level browsing.
+type LiveTV struct {
+	client   httpDoer
+	sources  []string
+	channels []Channel
+	byID     map[string]Channel
+	byCat    map[string][]Channel
+	cats     []string
+	loaded   bool
+	loadErr  error
+}
+
+func NewLiveTV(sources []string) *LiveTV {
+	return &LiveTV{client: httputil.NewClient(), sources: sources}
+}
+
+// fetch reads a source: http(s) via the client, anything else via os.ReadFile.
+func (p *LiveTV) fetch(src string) ([]byte, error) {
+	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		req, err := http.NewRequest(http.MethodGet, src, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", liveTVUA)
+		resp, err := p.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("livetv: status %d for %s", resp.StatusCode, src)
+		}
+		return io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	}
+	return os.ReadFile(src)
+}
+
+// load fetches+parses+merges all sources once. A failed source is skipped; only
+// if every source fails is loadErr set.
+func (p *LiveTV) load() {
+	if p.loaded {
+		return
+	}
+	p.loaded = true
+	p.byID = map[string]Channel{}
+	p.byCat = map[string][]Channel{}
+	var anyOK bool
+	for _, src := range p.sources {
+		data, err := p.fetch(src)
+		if err != nil {
+			continue
+		}
+		anyOK = true
+		for _, ch := range ParseM3U(data) {
+			if ch.URL == "" {
+				continue
+			}
+			ch.ID = p.uniqueID(ch.ID)
+			p.byID[ch.ID] = ch
+			p.channels = append(p.channels, ch)
+			for _, cat := range ch.Categories {
+				p.byCat[cat] = append(p.byCat[cat], ch)
+			}
+		}
+	}
+	if !anyOK && len(p.sources) > 0 {
+		p.loadErr = fmt.Errorf("livetv: all %d source(s) failed", len(p.sources))
+		return
+	}
+	for c := range p.byCat {
+		p.cats = append(p.cats, c)
+	}
+	sort.Slice(p.cats, func(i, j int) bool { return liveCatLess(p.cats[i], p.cats[j]) })
+}
+
+func (p *LiveTV) uniqueID(base string) string {
+	if base == "" {
+		base = "channel"
+	}
+	id := base
+	for n := 2; ; n++ {
+		if _, exists := p.byID[id]; !exists {
+			return id
+		}
+		id = fmt.Sprintf("%s-%d", base, n)
+	}
+}
+
+var liveCatPriority = map[string]int{"sports": 0, "news": 1, "movies": 2}
+
+func liveCatLess(a, b string) bool {
+	pa, oka := liveCatPriority[strings.ToLower(a)]
+	pb, okb := liveCatPriority[strings.ToLower(b)]
+	if oka && okb {
+		return pa < pb
+	}
+	if oka != okb {
+		return oka
+	}
+	return strings.ToLower(a) < strings.ToLower(b)
+}
+
+func channelResult(ch Channel) media.SearchResult {
+	return media.SearchResult{ID: ch.ID, Title: ch.Name, Type: media.Movie, Poster: ch.Logo}
+}
+
+// Categories returns one result per category, with the channel count in Episodes.
+func (p *LiveTV) Categories() ([]media.SearchResult, error) {
+	p.load()
+	if p.loadErr != nil {
+		return nil, p.loadErr
+	}
+	out := make([]media.SearchResult, 0, len(p.cats))
+	for _, c := range p.cats {
+		out = append(out, media.SearchResult{ID: c, Title: c, Episodes: len(p.byCat[c])})
+	}
+	return out, nil
+}
+
+// Channels returns the channels in a category as Movie-typed results.
+func (p *LiveTV) Channels(category string) ([]media.SearchResult, error) {
+	p.load()
+	if p.loadErr != nil {
+		return nil, p.loadErr
+	}
+	chans := p.byCat[category]
+	out := make([]media.SearchResult, 0, len(chans))
+	for _, ch := range chans {
+		out = append(out, channelResult(ch))
+	}
+	return out, nil
+}
+
+// --- StreamProvider surface ---
+
+func (p *LiveTV) Search(query string) ([]media.SearchResult, error) {
+	p.load()
+	if p.loadErr != nil {
+		return nil, p.loadErr
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	var out []media.SearchResult
+	for _, ch := range p.channels {
+		if q == "" || strings.Contains(strings.ToLower(ch.Name), q) {
+			out = append(out, channelResult(ch))
+		}
+	}
+	return out, nil
+}
+
+func (p *LiveTV) Watch(mediaID, _, _, _ string) (*media.Stream, error) {
+	p.load()
+	ch, ok := p.byID[mediaID]
+	if !ok {
+		return nil, fmt.Errorf("livetv: unknown channel %q", mediaID)
+	}
+	return &media.Stream{URL: ch.URL, Referer: ch.Referer, UserAgent: ch.UserAgent}, nil
+}
+
+func (p *LiveTV) GetDetails(id string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+func (p *LiveTV) GetSeasons(id string) ([]media.Season, error) {
+	return []media.Season{{Number: 1, ID: id}}, nil
+}
+func (p *LiveTV) GetEpisodes(id, seasonID string) ([]media.Episode, error) {
+	return []media.Episode{{Number: 1, ID: id}}, nil
+}
+func (p *LiveTV) GetServers(id, episodeID string) ([]media.Server, error) {
+	return []media.Server{{Name: "LiveTV", ID: "default"}}, nil
+}
+func (p *LiveTV) GetEmbedURL(serverID string) (string, error)               { return "", fmt.Errorf("use Watch") }
+func (p *LiveTV) Trending(mt media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+func (p *LiveTV) Recent(mt media.MediaType) ([]media.SearchResult, error)   { return nil, nil }

--- a/internal/provider/livetv.go
+++ b/internal/provider/livetv.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,8 +9,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
-	"lobster/internal/httputil"
 	"lobster/internal/media"
 )
 
@@ -19,7 +20,8 @@ const liveTVUA = "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firef
 // loaded lazily and cached for the session. It implements StreamProvider; the
 // TUI also calls Categories/Channels for two-level browsing.
 type LiveTV struct {
-	client   httpDoer
+	client   httpDoer // primary fetch client (TLS 1.3 capable)
+	fallback httpDoer // retried when the primary errors (TLS 1.2-capped; nil in tests)
 	sources  []string
 	channels []Channel
 	byID     map[string]Channel
@@ -30,28 +32,61 @@ type LiveTV struct {
 }
 
 func NewLiveTV(sources []string) *LiveTV {
-	return &LiveTV{client: httputil.NewClient(), sources: sources}
+	return &LiveTV{
+		client:   liveTVHTTPClient(tls.VersionTLS13),
+		fallback: liveTVHTTPClient(tls.VersionTLS12),
+		sources:  sources,
+	}
+}
+
+// liveTVHTTPClient builds a playlist-fetch client. A short TLSHandshakeTimeout
+// makes a stalled handshake fail fast instead of hanging on the overall timeout,
+// and maxVer lets the caller cap the TLS version: some networks (e.g. certain
+// phone hotspots / middleboxes) break TLS 1.3 handshakes to CDNs like GitHub
+// Pages, so we retry capped at TLS 1.2.
+func liveTVHTTPClient(maxVer uint16) *http.Client {
+	return &http.Client{
+		Timeout: 60 * time.Second, // a slow CDN serving a ~3 MB playlist
+		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
+			TLSHandshakeTimeout: 12 * time.Second,
+			ForceAttemptHTTP2:   true,
+			IdleConnTimeout:     30 * time.Second,
+			TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12, MaxVersion: maxVer},
+		},
+	}
 }
 
 // fetch reads a source: http(s) via the client, anything else via os.ReadFile.
+// On an http error it retries once with the TLS 1.2-capped fallback client.
 func (p *LiveTV) fetch(src string) ([]byte, error) {
 	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
-		req, err := http.NewRequest(http.MethodGet, src, nil)
-		if err != nil {
-			return nil, err
+		data, err := p.httpGet(p.client, src)
+		if err != nil && p.fallback != nil {
+			if data2, err2 := p.httpGet(p.fallback, src); err2 == nil {
+				return data2, nil
+			}
 		}
-		req.Header.Set("User-Agent", liveTVUA)
-		resp, err := p.client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, fmt.Errorf("livetv: status %d for %s", resp.StatusCode, src)
-		}
-		return io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+		return data, err
 	}
 	return os.ReadFile(src)
+}
+
+func (p *LiveTV) httpGet(c httpDoer, src string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, src, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", liveTVUA)
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("livetv: status %d for %s", resp.StatusCode, src)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 32<<20))
 }
 
 // load fetches+parses+merges all sources once. A failed source is skipped; only
@@ -62,9 +97,11 @@ func (p *LiveTV) doLoad() {
 	p.byID = map[string]Channel{}
 	p.byCat = map[string][]Channel{}
 	var anyOK bool
+	var lastErr error
 	for _, src := range p.sources {
 		data, err := p.fetch(src)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		anyOK = true
@@ -81,7 +118,7 @@ func (p *LiveTV) doLoad() {
 		}
 	}
 	if !anyOK && len(p.sources) > 0 {
-		p.loadErr = fmt.Errorf("livetv: all %d source(s) failed", len(p.sources))
+		p.loadErr = fmt.Errorf("livetv: all %d source(s) failed: %w", len(p.sources), lastErr)
 		return
 	}
 	for c := range p.byCat {

--- a/internal/provider/livetv_test.go
+++ b/internal/provider/livetv_test.go
@@ -38,6 +38,7 @@ func (d statusDoer) Do(r *http.Request) (*http.Response, error) {
 func newTestLiveTV(sources []string, d httpDoer) *LiveTV {
 	p := NewLiveTV(sources)
 	p.client = d
+	p.fallback = d // keep tests network-free: fallback uses the same mock
 	return p
 }
 

--- a/internal/provider/livetv_test.go
+++ b/internal/provider/livetv_test.go
@@ -1,0 +1,139 @@
+package provider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+var _ StreamProvider = (*LiveTV)(nil)
+
+// statusDoer routes by URL substring to (status, body); unmatched routes return
+// a transport error so "failed source" can be simulated (fakeDoer always 200s).
+type statusDoer struct {
+	routes map[string]struct {
+		status int
+		body   string
+	}
+}
+
+func (d statusDoer) Do(r *http.Request) (*http.Response, error) {
+	for sub, resp := range d.routes {
+		if strings.Contains(r.URL.String(), sub) {
+			return &http.Response{
+				StatusCode: resp.status,
+				Body:       io.NopCloser(strings.NewReader(resp.body)),
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("no route for %s", r.URL.String())
+}
+
+func newTestLiveTV(sources []string, d httpDoer) *LiveTV {
+	p := NewLiveTV(sources)
+	p.client = d
+	return p
+}
+
+func TestLiveTVCategoriesAndChannels(t *testing.T) {
+	body := `#EXTINF:-1 group-title="Sports",A
+http://a
+#EXTINF:-1 group-title="News",B
+http://b
+#EXTINF:-1 group-title="Sports",C
+http://c
+`
+	d := statusDoer{routes: map[string]struct {
+		status int
+		body   string
+	}{"index.category.m3u": {200, body}}}
+	p := newTestLiveTV([]string{"https://iptv-org.github.io/iptv/index.category.m3u"}, d)
+
+	cats, err := p.Categories()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sports surfaced before News, Sports count = 2.
+	if len(cats) != 2 || cats[0].Title != "Sports" || cats[0].Episodes != 2 {
+		t.Fatalf("categories wrong: %+v", cats)
+	}
+	chans, err := p.Channels("Sports")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chans) != 2 || chans[0].Type != media.Movie {
+		t.Fatalf("channels wrong: %+v", chans)
+	}
+}
+
+func TestLiveTVWatchAndUniqueIDs(t *testing.T) {
+	// Two channels, empty tvg-id, identical name -> must NOT collide.
+	body := `#EXTINF:-1 tvg-id="" group-title="Sports",Dup
+#EXTVLCOPT:http-user-agent=UA/9
+http://first
+#EXTINF:-1 tvg-id="" group-title="Sports",Dup
+http://second
+`
+	d := statusDoer{routes: map[string]struct {
+		status int
+		body   string
+	}{"p.m3u": {200, body}}}
+	p := newTestLiveTV([]string{"https://x/p.m3u"}, d)
+	chans, _ := p.Channels("Sports")
+	if len(chans) != 2 {
+		t.Fatalf("want 2 distinct channels, got %d", len(chans))
+	}
+	if chans[0].ID == chans[1].ID {
+		t.Fatalf("ids collided: %q", chans[0].ID)
+	}
+	st, err := p.Watch(chans[0].ID, "", "", "")
+	if err != nil || st.URL != "http://first" || st.UserAgent != "UA/9" {
+		t.Fatalf("watch[0] wrong: %v / %+v", err, st)
+	}
+	st2, _ := p.Watch(chans[1].ID, "", "", "")
+	if st2.URL != "http://second" {
+		t.Fatalf("watch[1] resolved wrong stream: %+v", st2)
+	}
+}
+
+func TestLiveTVLocalFileSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "local.m3u")
+	if err := os.WriteFile(path, []byte("#EXTINF:-1 group-title=\"Movies\",Loc\nhttp://loc\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// httpDoer would error on a local path; load() must use os.ReadFile.
+	d := statusDoer{routes: map[string]struct {
+		status int
+		body   string
+	}{}}
+	p := newTestLiveTV([]string{path}, d)
+	chans, err := p.Channels("Movies")
+	if err != nil || len(chans) != 1 || chans[0].Title != "Loc" {
+		t.Fatalf("local file source failed: %v / %+v", err, chans)
+	}
+}
+
+func TestLiveTVSkipsFailedSource(t *testing.T) {
+	ok := `#EXTINF:-1 group-title="Sports",A
+http://a
+`
+	d := statusDoer{routes: map[string]struct {
+		status int
+		body   string
+	}{"good.m3u": {200, ok}, "bad.m3u": {500, ""}}}
+	p := newTestLiveTV([]string{"https://x/bad.m3u", "https://x/good.m3u"}, d)
+	cats, err := p.Categories()
+	if err != nil {
+		t.Fatalf("one bad source must not fail the load: %v", err)
+	}
+	if len(cats) != 1 || cats[0].Title != "Sports" {
+		t.Fatalf("good source did not survive: %+v", cats)
+	}
+}

--- a/internal/provider/livetv_test.go
+++ b/internal/provider/livetv_test.go
@@ -138,3 +138,16 @@ http://a
 		t.Fatalf("good source did not survive: %+v", cats)
 	}
 }
+
+func TestRedactURL(t *testing.T) {
+	cases := map[string]string{
+		"http://h:8080/get.php?username=u&password=p&type=m3u_plus": "http://h:8080/get.php",
+		"https://user:pass@host/path?q=1":                           "https://host/path",
+		"https://iptv-org.github.io/iptv/index.category.m3u":        "https://iptv-org.github.io/iptv/index.category.m3u",
+	}
+	for in, want := range cases {
+		if got := redactURL(in); got != want {
+			t.Errorf("redactURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/provider/m3u.go
+++ b/internal/provider/m3u.go
@@ -1,0 +1,125 @@
+package provider
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Channel is one IPTV channel parsed from an M3U playlist.
+type Channel struct {
+	ID         string   // tvg-id if present, else slug(Name); uniqueness enforced by the provider
+	Name       string   // display name (text after the EXTINF comma)
+	Logo       string   // tvg-logo URL ("" if none)
+	Categories []string // group-title split on ";"; ["Uncategorized"] if empty/Undefined
+	URL        string   // stream URL
+	Referer    string   // from #EXTVLCOPT:http-referrer
+	UserAgent  string   // from #EXTVLCOPT:http-user-agent
+}
+
+var (
+	m3uAttrRe = regexp.MustCompile(`([a-zA-Z0-9-]+)="([^"]*)"`)
+	slugRe    = regexp.MustCompile(`[^a-z0-9]+`)
+)
+
+// ParseM3U turns raw M3U bytes into channels. It is tolerant of empty
+// attributes, commas inside quoted attributes and names, missing URL lines,
+// unknown # directives, blank lines, and CRLF/LF endings.
+func ParseM3U(data []byte) []Channel {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	var out []Channel
+	var cur *Channel
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "":
+			continue
+		case strings.HasPrefix(line, "#EXTINF:"):
+			cur = parseExtinf(line)
+		case strings.HasPrefix(line, "#EXTVLCOPT:"):
+			if cur != nil {
+				applyVlcOpt(cur, strings.TrimPrefix(line, "#EXTVLCOPT:"))
+			}
+		case strings.HasPrefix(line, "#"):
+			continue // unknown directive
+		default:
+			if cur == nil {
+				continue
+			}
+			cur.URL = line
+			out = append(out, *cur)
+			cur = nil
+		}
+	}
+	return out
+}
+
+func parseExtinf(line string) *Channel {
+	attrs := map[string]string{}
+	for _, m := range m3uAttrRe.FindAllStringSubmatch(line, -1) {
+		attrs[strings.ToLower(m[1])] = m[2]
+	}
+	c := &Channel{
+		Name:       extinfName(line),
+		Logo:       attrs["tvg-logo"],
+		Categories: splitCategories(attrs["group-title"]),
+	}
+	if id := attrs["tvg-id"]; id != "" {
+		c.ID = id
+	} else {
+		c.ID = slug(c.Name)
+	}
+	return c
+}
+
+// extinfName returns the text after the comma that follows the final closing
+// quote of the attribute block (so commas inside attributes don't truncate it).
+func extinfName(line string) string {
+	start := strings.LastIndex(line, `"`)
+	comma := -1
+	if start >= 0 {
+		if rel := strings.Index(line[start:], ","); rel >= 0 {
+			comma = start + rel
+		}
+	} else {
+		comma = strings.Index(line, ",")
+	}
+	if comma < 0 {
+		return ""
+	}
+	return strings.TrimSpace(line[comma+1:])
+}
+
+func splitCategories(g string) []string {
+	g = strings.TrimSpace(g)
+	if g == "" || strings.EqualFold(g, "Undefined") {
+		return []string{"Uncategorized"}
+	}
+	var cats []string
+	for _, p := range strings.Split(g, ";") {
+		if p = strings.TrimSpace(p); p != "" {
+			cats = append(cats, p)
+		}
+	}
+	if len(cats) == 0 {
+		return []string{"Uncategorized"}
+	}
+	return cats
+}
+
+func applyVlcOpt(c *Channel, opt string) {
+	key, val, ok := strings.Cut(opt, "=") // first '=' only
+	if !ok {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "http-user-agent":
+		c.UserAgent = val
+	case "http-referrer":
+		c.Referer = val
+	}
+}
+
+func slug(s string) string {
+	s = slugRe.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "-")
+	return strings.Trim(s, "-")
+}

--- a/internal/provider/m3u_test.go
+++ b/internal/provider/m3u_test.go
@@ -1,0 +1,101 @@
+package provider
+
+import "testing"
+
+func TestParseM3UBasic(t *testing.T) {
+	data := []byte(`#EXTM3U x-tvg-url="https://guide"
+#EXTINF:-1 tvg-id="ASpor.tr@SD" tvg-logo="https://i/logo.png" group-title="Sports",A Spor (1080p)
+https://cdn/aspor.m3u8
+`)
+	chs := ParseM3U(data)
+	if len(chs) != 1 {
+		t.Fatalf("want 1 channel, got %d", len(chs))
+	}
+	c := chs[0]
+	if c.ID != "ASpor.tr@SD" || c.Name != "A Spor (1080p)" || c.Logo != "https://i/logo.png" {
+		t.Fatalf("bad parse: %+v", c)
+	}
+	if len(c.Categories) != 1 || c.Categories[0] != "Sports" {
+		t.Fatalf("bad categories: %+v", c.Categories)
+	}
+	if c.URL != "https://cdn/aspor.m3u8" {
+		t.Fatalf("bad url: %q", c.URL)
+	}
+}
+
+func TestParseM3UMultiCategory(t *testing.T) {
+	data := []byte("#EXTINF:-1 group-title=\"News;Sports\",X\nhttp://u\n")
+	c := ParseM3U(data)[0]
+	if len(c.Categories) != 2 || c.Categories[0] != "News" || c.Categories[1] != "Sports" {
+		t.Fatalf("multi-category split wrong: %+v", c.Categories)
+	}
+}
+
+func TestParseM3UUndefinedAndEmptyCategory(t *testing.T) {
+	for _, gt := range []string{`group-title="Undefined"`, `group-title=""`, ``} {
+		data := []byte("#EXTINF:-1 " + gt + ",X\nhttp://u\n")
+		c := ParseM3U(data)[0]
+		if len(c.Categories) != 1 || c.Categories[0] != "Uncategorized" {
+			t.Fatalf("gt %q -> %+v, want [Uncategorized]", gt, c.Categories)
+		}
+	}
+}
+
+func TestParseM3UCommasInAttrAndName(t *testing.T) {
+	data := []byte(`#EXTINF:-1 group-title="A, B" tvg-logo="http://i/a,b.png",Name, With Comma
+http://u
+`)
+	c := ParseM3U(data)[0]
+	if c.Name != "Name, With Comma" {
+		t.Fatalf("name split wrong: %q", c.Name)
+	}
+	if len(c.Categories) != 1 || c.Categories[0] != "A, B" {
+		t.Fatalf("attr-comma split wrong: %+v", c.Categories)
+	}
+}
+
+func TestParseM3UEmptyTvgIDFallsBackToSlug(t *testing.T) {
+	data := []byte("#EXTINF:-1 tvg-id=\"\" group-title=\"Sports\",Hello World\nhttp://u\n")
+	c := ParseM3U(data)[0]
+	if c.ID != "hello-world" {
+		t.Fatalf("slug fallback wrong: %q", c.ID)
+	}
+}
+
+func TestParseM3UHeaders(t *testing.T) {
+	data := []byte(`#EXTINF:-1 group-title="Sports",X
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (X11) key=val
+#EXTVLCOPT:http-referrer=https://ref/
+http://u
+`)
+	c := ParseM3U(data)[0]
+	if c.UserAgent != "Mozilla/5.0 (X11) key=val" {
+		t.Fatalf("UA split-on-first-= wrong: %q", c.UserAgent)
+	}
+	if c.Referer != "https://ref/" {
+		t.Fatalf("referrer wrong: %q", c.Referer)
+	}
+}
+
+func TestParseM3USkipsBadLinesAndNoURL(t *testing.T) {
+	// First EXTINF has no URL (immediately followed by another EXTINF) -> dropped.
+	// Blank lines and unknown # directives are skipped.
+	data := []byte(`#EXTINF:-1 group-title="A",NoUrl
+
+#EXTGRP:ignored
+#EXTINF:-1 group-title="B",HasUrl
+http://u
+`)
+	chs := ParseM3U(data)
+	if len(chs) != 1 || chs[0].Name != "HasUrl" {
+		t.Fatalf("want only HasUrl, got %+v", chs)
+	}
+}
+
+func TestParseM3UCRLF(t *testing.T) {
+	data := []byte("#EXTINF:-1 group-title=\"A\",X\r\nhttp://u\r\n")
+	c := ParseM3U(data)
+	if len(c) != 1 || c[0].URL != "http://u" {
+		t.Fatalf("CRLF handling wrong: %+v", c)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -514,6 +514,11 @@ func (m *AppModel) setLiveRows(rows []liveRow) {
 		items[i] = listItem{result: r.result, desc: r.desc}
 	}
 	m.list.SetItems(items)
+	// Clear stale preview/poster carried over from the previous row set.
+	m.currentDetail = nil
+	m.currentPoster = ""
+	m.posterReady = false
+	m.drawnPosterKey = ""
 	if len(m.results) > 0 {
 		m.currentItem = &m.results[0]
 	} else {
@@ -605,10 +610,14 @@ func (m AppModel) View() string {
 		footer = footerStyle.Render("[P] Pause/Resume  [X] Cancel  [R] Retry  [BS] Remove  [C] Clear  [Shift+R] Refresh  [TAB] Browse")
 	} else {
 		dlHint := ""
-		if m.dlManager != nil && m.activeTab != tabLiveTV {
-			dlHint = "  [D] Download  "
+		tabRange := "[1-5]"
+		if m.dlManager != nil {
+			tabRange = "[1-6]"
+			if m.activeTab != tabLiveTV {
+				dlHint = "  [D] Download  "
+			}
 		}
-		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  [1-6] Categories  [TAB] Next Tab  [Q] Quit")
+		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  " + tabRange + " Categories  [TAB] Next Tab  [Q] Quit")
 	}
 
 	base := docStyle.Render(lipgloss.JoinVertical(lipgloss.Left,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -70,6 +70,8 @@ type AppModel struct {
 	isSearching      bool
 	selectedResult   *media.SearchResult
 	selectedProvider provider.Provider
+	selectedLineup   []media.SearchResult // full Live TV category lineup for surf; nil otherwise
+	selectedIndex    int                  // start index into selectedLineup
 
 	// Tab and download manager state
 	activeTab      tab
@@ -117,7 +119,7 @@ var (
 )
 
 // StartApp launches the TUI. If mgr is nil, download features are disabled.
-func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager, fallbacks ...provider.Provider) (*media.SearchResult, provider.Provider, error) {
+func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager, fallbacks ...provider.Provider) (*media.SearchResult, []media.SearchResult, int, provider.Provider, error) {
 	ti := textinput.New()
 	ti.Placeholder = "Search..."
 	ti.CharLimit = 156
@@ -158,13 +160,13 @@ func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager, f
 	p2 := tea.NewProgram(m, tea.WithAltScreen(), tea.WithOutput(out))
 	m2, err := p2.Run()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, nil, err
 	}
 	appModel := m2.(AppModel)
 	if appModel.selectedProvider == nil {
 		appModel.selectedProvider = p
 	}
-	return appModel.selectedResult, appModel.selectedProvider, nil
+	return appModel.selectedResult, appModel.selectedLineup, appModel.selectedIndex, appModel.selectedProvider, nil
 }
 
 func (m AppModel) Init() tea.Cmd {
@@ -306,9 +308,23 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.liveCategory = cat
 					return m, tea.Batch(fetchChannelsCmd(m.liveTVProvider, cat), m.list.StartSpinner())
 				}
-				// level 1: play the selected channel.
+				// level 1: play the selected channel, with the full category
+				// lineup so the play layer can surf past dead channels.
+				lineup := make([]media.SearchResult, len(m.liveMaster))
+				for idx, r := range m.liveMaster {
+					lineup[idx] = r.result
+				}
+				startIdx := 0
+				for idx := range lineup {
+					if lineup[idx].ID == m.currentItem.ID {
+						startIdx = idx
+						break
+					}
+				}
 				m.selectedResult = m.currentItem
 				m.selectedProvider = m.liveTVProvider
+				m.selectedLineup = lineup
+				m.selectedIndex = startIdx
 				return m, tea.Quit
 			}
 			if m.currentItem != nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -37,6 +37,7 @@ const (
 	tabSeries
 	tabCartoons
 	tabAnime
+	tabLiveTV
 	tabDownloads
 )
 
@@ -76,6 +77,12 @@ type AppModel struct {
 	dlManager      *dlmanager.Manager
 	toast          string // transient notification
 
+	// Live TV state
+	liveTVProvider *provider.LiveTV
+	liveLevel      int       // 0 = categories, 1 = channels
+	liveCategory   string    // current category at level 1
+	liveMaster     []liveRow // unfiltered rows for the current level
+
 	// Download dialog for TV show batch downloads
 	dlDialog downloadDialog
 
@@ -86,10 +93,14 @@ type AppModel struct {
 // item adapter for list.Model
 type listItem struct {
 	result media.SearchResult
+	desc   string // overrides Description() when non-empty (Live TV rows)
 }
 
 func (i listItem) Title() string { return i.result.Title }
 func (i listItem) Description() string {
+	if i.desc != "" {
+		return i.desc
+	}
 	desc := fmt.Sprintf("%s \u2022 %s", i.result.Type.String(), i.result.Year)
 	if i.result.Type == media.TV {
 		desc = fmt.Sprintf("%s \u2022 %d Seasons", desc, i.result.Seasons)
@@ -128,6 +139,7 @@ func StartApp(p provider.Provider, cfg *config.Config, mgr *dlmanager.Manager, f
 		provider:          p,
 		cartoonProvider:   provider.NewKimCartoon(provider.ResolveDomain("kimcartoon.com.co", "kimcartoon", cfg.DomainOverrides)),
 		animeProvider:     provider.NewAllAnime(cfg.AnimeDub),
+		liveTVProvider:    provider.NewLiveTV(cfg.LiveTV.Sources()),
 		fallbackProviders: fallbacks,
 		config:            cfg,
 		list:              l,
@@ -243,10 +255,11 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "4":
 			return m, m.switchTab(tabAnime)
 		case "5":
+			return m, m.switchTab(tabLiveTV)
+		case "6":
 			if m.dlManager != nil {
 				return m, m.switchTab(tabDownloads)
 			}
-			return m, nil
 		}
 
 		// Route to active tab.
@@ -342,6 +355,14 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentDetail = nil
 		}
 
+	case liveItemsFetchedMsg:
+		m.list.StopSpinner()
+		m.liveLevel = msg.level
+		m.liveMaster = msg.rows
+		m.list.Title = msg.title
+		m.setLiveRows(msg.rows)
+		return m, nil
+
 	case detailFetchedMsg:
 		m.err = nil
 		if m.currentItem != nil && m.currentItem.ID == msg.id {
@@ -428,6 +449,23 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+// setLiveRows populates the list + m.results from live rows, keeping them
+// index-aligned (selection reads m.results[m.list.Index()]).
+func (m *AppModel) setLiveRows(rows []liveRow) {
+	m.results = make([]media.SearchResult, len(rows))
+	items := make([]list.Item, len(rows))
+	for i, r := range rows {
+		m.results[i] = r.result
+		items[i] = listItem{result: r.result, desc: r.desc}
+	}
+	m.list.SetItems(items)
+	if len(m.results) > 0 {
+		m.currentItem = &m.results[0]
+	} else {
+		m.currentItem = nil
+	}
 }
 
 // queueCurrentDownload queues the currently selected item for download.
@@ -517,7 +555,7 @@ func (m AppModel) View() string {
 		if m.dlManager != nil {
 			dlHint = "  [D] Download  "
 		}
-		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  [1-4] Categories  [TAB] Next Tab  [Q] Quit")
+		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  [1-6] Categories  [TAB] Next Tab  [Q] Quit")
 	}
 
 	base := docStyle.Render(lipgloss.JoinVertical(lipgloss.Left,
@@ -554,13 +592,14 @@ func (m AppModel) renderTabBar() string {
 		{tabSeries, "2 Series"},
 		{tabCartoons, "3 Cartoons"},
 		{tabAnime, "4 Anime"},
+		{tabLiveTV, "5 Live TV"},
 	}
 
 	if m.dlManager != nil {
 		labels = append(labels, struct {
 			tab   tab
 			label string
-		}{tabDownloads, "5 Downloads"})
+		}{tabDownloads, "6 Downloads"})
 	}
 
 	rendered := make([]string, 0, len(labels)*2)
@@ -581,6 +620,8 @@ func (m AppModel) providerForActiveTab() provider.Provider {
 		return m.cartoonProvider
 	case tabAnime:
 		return m.animeProvider
+	case tabLiveTV:
+		return m.liveTVProvider
 	default:
 		return m.provider
 	}
@@ -605,9 +646,13 @@ func (m AppModel) nextTab() tab {
 	case tabCartoons:
 		return tabAnime
 	case tabAnime:
+		return tabLiveTV
+	case tabLiveTV:
 		if m.dlManager != nil {
 			return tabDownloads
 		}
+		return tabMovies
+	case tabDownloads:
 		return tabMovies
 	default:
 		return tabMovies
@@ -638,6 +683,11 @@ func (m *AppModel) switchTab(next tab) tea.Cmd {
 	m.results = nil
 	m.list.SetItems(nil)
 	m.list.Title = m.tabTitle(next)
+	if next == tabLiveTV {
+		m.liveLevel = 0
+		m.liveCategory = ""
+		return tea.Batch(fetchCategoriesCmd(m.liveTVProvider), m.list.StartSpinner(), tea.ClearScreen)
+	}
 	return tea.Batch(fetchTabCmd(m.providerForActiveTab(), next), m.list.StartSpinner(), tea.ClearScreen)
 }
 
@@ -649,6 +699,8 @@ func (m AppModel) tabTitle(t tab) string {
 		return "Cartoons"
 	case tabAnime:
 		return "Anime"
+	case tabLiveTV:
+		return "Live TV"
 	default:
 		return "Movies"
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -331,6 +331,10 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, tea.Batch(fetchTabCmd(m.providerForActiveTab(), m.activeTab), m.list.StartSpinner())
 				}
 			}
+			if m.activeTab == tabLiveTV {
+				m.toast = "Live channels can't be downloaded"
+				return m, nil
+			}
 			if m.dlManager != nil && m.currentItem != nil {
 				if m.currentItem.Type == media.TV {
 					outputDir, err := m.config.ExpandDownloadDir()
@@ -585,7 +589,7 @@ func (m AppModel) View() string {
 		footer = footerStyle.Render("[P] Pause/Resume  [X] Cancel  [R] Retry  [BS] Remove  [C] Clear  [Shift+R] Refresh  [TAB] Browse")
 	} else {
 		dlHint := ""
-		if m.dlManager != nil {
+		if m.dlManager != nil && m.activeTab != tabLiveTV {
 			dlHint = "  [D] Download  "
 		}
 		footer = footerStyle.Render("[ENTER] Play" + dlHint + "[S] Search  [1-6] Categories  [TAB] Next Tab  [Q] Quit")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -216,6 +216,19 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case tea.KeyEnter:
 				m.isSearching = false
 				m.searchInput.Blur()
+				if m.activeTab == tabLiveTV {
+					// Client-side filter of the current level; no network call.
+					// An empty query restores the full list (filterLiveRows returns
+					// the full master), so this is also the clear-filter path.
+					q := m.searchInput.Value()
+					if m.liveLevel == 1 && m.liveCategory != "" {
+						m.list.Title = m.liveCategory
+					} else {
+						m.list.Title = "Live TV"
+					}
+					m.setLiveRows(filterLiveRows(m.liveMaster, q))
+					return m, nil
+				}
 				m.list.Title = "Search: " + m.searchInput.Value()
 				m.results = nil // Clear current results to show loader
 				m.currentItem = nil
@@ -277,7 +290,27 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.searchInput.SetValue("")
 			m.drawnPosterKey = ""
 			return m, tea.ClearScreen
+		case "esc":
+			if m.activeTab == tabLiveTV && m.liveLevel == 1 {
+				m.liveCategory = ""
+				return m, tea.Batch(fetchCategoriesCmd(m.liveTVProvider), m.list.StartSpinner())
+			}
 		case "enter":
+			if m.activeTab == tabLiveTV {
+				if m.currentItem == nil {
+					return m, nil
+				}
+				if m.liveLevel == 0 {
+					// Drill into the selected category; do NOT quit.
+					cat := m.currentItem.ID
+					m.liveCategory = cat
+					return m, tea.Batch(fetchChannelsCmd(m.liveTVProvider, cat), m.list.StartSpinner())
+				}
+				// level 1: play the selected channel.
+				m.selectedResult = m.currentItem
+				m.selectedProvider = m.liveTVProvider
+				return m, tea.Quit
+			}
 			if m.currentItem != nil {
 				m.selectedResult = m.currentItem
 				m.selectedProvider = m.providerForActiveTab()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -84,6 +84,7 @@ type AppModel struct {
 	liveLevel      int       // 0 = categories, 1 = channels
 	liveCategory   string    // current category at level 1
 	liveMaster     []liveRow // unfiltered rows for the current level
+	liveReqGen     int       // bumped per Live TV fetch; stale responses are ignored
 
 	// Download dialog for TV show batch downloads
 	dlDialog downloadDialog
@@ -295,7 +296,8 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "esc":
 			if m.activeTab == tabLiveTV && m.liveLevel == 1 {
 				m.liveCategory = ""
-				return m, tea.Batch(fetchCategoriesCmd(m.liveTVProvider), m.list.StartSpinner())
+				m.liveReqGen++
+				return m, tea.Batch(fetchCategoriesCmd(m.liveTVProvider, m.liveReqGen), m.list.StartSpinner())
 			}
 		case "enter":
 			if m.activeTab == tabLiveTV {
@@ -306,7 +308,8 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// Drill into the selected category; do NOT quit.
 					cat := m.currentItem.ID
 					m.liveCategory = cat
-					return m, tea.Batch(fetchChannelsCmd(m.liveTVProvider, cat), m.list.StartSpinner())
+					m.liveReqGen++
+					return m, tea.Batch(fetchChannelsCmd(m.liveTVProvider, cat, m.liveReqGen), m.list.StartSpinner())
 				}
 				// level 1: play the selected channel, with the full category
 				// lineup so the play layer can surf past dead channels.
@@ -409,6 +412,11 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case liveItemsFetchedMsg:
+		// Ignore a response the user has moved past: a different tab is now
+		// active, or a newer Live TV request was issued after this one.
+		if m.activeTab != tabLiveTV || msg.gen != m.liveReqGen {
+			return m, nil
+		}
 		m.list.StopSpinner()
 		m.liveLevel = msg.level
 		m.liveMaster = msg.rows
@@ -748,7 +756,8 @@ func (m *AppModel) switchTab(next tab) tea.Cmd {
 	if next == tabLiveTV {
 		m.liveLevel = 0
 		m.liveCategory = ""
-		return tea.Batch(fetchCategoriesCmd(m.liveTVProvider), m.list.StartSpinner(), tea.ClearScreen)
+		m.liveReqGen++
+		return tea.Batch(fetchCategoriesCmd(m.liveTVProvider, m.liveReqGen), m.list.StartSpinner(), tea.ClearScreen)
 	}
 	return tea.Batch(fetchTabCmd(m.providerForActiveTab(), next), m.list.StartSpinner(), tea.ClearScreen)
 }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -224,6 +225,58 @@ func fetchPosterForItemCmd(item media.SearchResult, width, height int, lookup fu
 		rendered := poster.RenderTUI(url, width, height)
 		return posterFetchedMsg{id: item.ID, poster: rendered}
 	}
+}
+
+// liveRow is one displayable Live TV item plus its description override.
+type liveRow struct {
+	result media.SearchResult
+	desc   string
+}
+
+// fetchCategoriesCmd loads the Live TV category list.
+func fetchCategoriesCmd(p *provider.LiveTV) tea.Cmd {
+	return func() tea.Msg {
+		cats, err := p.Categories()
+		if err != nil {
+			return errMsg{err}
+		}
+		rows := make([]liveRow, len(cats))
+		for i, c := range cats {
+			rows[i] = liveRow{result: c, desc: fmt.Sprintf("%d channels", c.Episodes)}
+		}
+		return liveItemsFetchedMsg{rows: rows, level: 0, title: "Live TV"}
+	}
+}
+
+// fetchChannelsCmd loads the channels in a Live TV category.
+func fetchChannelsCmd(p *provider.LiveTV, category string) tea.Cmd {
+	return func() tea.Msg {
+		chans, err := p.Channels(category)
+		if err != nil {
+			return errMsg{err}
+		}
+		rows := make([]liveRow, len(chans))
+		for i, c := range chans {
+			rows[i] = liveRow{result: c, desc: category}
+		}
+		return liveItemsFetchedMsg{rows: rows, level: 1, title: category}
+	}
+}
+
+// filterLiveRows returns rows whose title contains q (case-insensitive); an
+// empty query returns the full slice.
+func filterLiveRows(master []liveRow, q string) []liveRow {
+	q = strings.ToLower(strings.TrimSpace(q))
+	if q == "" {
+		return master
+	}
+	var out []liveRow
+	for _, r := range master {
+		if strings.Contains(strings.ToLower(r.result.Title), q) {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // listenProgressCmd reads one progress update from the manager and returns it.

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -234,7 +234,7 @@ type liveRow struct {
 }
 
 // fetchCategoriesCmd loads the Live TV category list.
-func fetchCategoriesCmd(p *provider.LiveTV) tea.Cmd {
+func fetchCategoriesCmd(p *provider.LiveTV, gen int) tea.Cmd {
 	return func() tea.Msg {
 		cats, err := p.Categories()
 		if err != nil {
@@ -244,12 +244,12 @@ func fetchCategoriesCmd(p *provider.LiveTV) tea.Cmd {
 		for i, c := range cats {
 			rows[i] = liveRow{result: c, desc: fmt.Sprintf("%d channels", c.Episodes)}
 		}
-		return liveItemsFetchedMsg{rows: rows, level: 0, title: "Live TV"}
+		return liveItemsFetchedMsg{rows: rows, level: 0, title: "Live TV", gen: gen}
 	}
 }
 
 // fetchChannelsCmd loads the channels in a Live TV category.
-func fetchChannelsCmd(p *provider.LiveTV, category string) tea.Cmd {
+func fetchChannelsCmd(p *provider.LiveTV, category string, gen int) tea.Cmd {
 	return func() tea.Msg {
 		chans, err := p.Channels(category)
 		if err != nil {
@@ -259,7 +259,7 @@ func fetchChannelsCmd(p *provider.LiveTV, category string) tea.Cmd {
 		for i, c := range chans {
 			rows[i] = liveRow{result: c, desc: category}
 		}
-		return liveItemsFetchedMsg{rows: rows, level: 1, title: category}
+		return liveItemsFetchedMsg{rows: rows, level: 1, title: category, gen: gen}
 	}
 }
 

--- a/internal/tui/livetv_test.go
+++ b/internal/tui/livetv_test.go
@@ -1,0 +1,22 @@
+package tui
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+func TestFilterLiveRows(t *testing.T) {
+	master := []liveRow{
+		{result: media.SearchResult{Title: "A Spor"}},
+		{result: media.SearchResult{Title: "BBC News"}},
+		{result: media.SearchResult{Title: "Sport TV"}},
+	}
+	if got := filterLiveRows(master, ""); len(got) != 3 {
+		t.Fatalf("empty query keeps all, got %d", len(got))
+	}
+	got := filterLiveRows(master, "spor")
+	if len(got) != 2 {
+		t.Fatalf("want 2 matches for 'spor', got %d", len(got))
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -59,6 +59,7 @@ type liveItemsFetchedMsg struct {
 	rows  []liveRow
 	level int
 	title string
+	gen   int // request generation; stale/cross-tab responses are ignored
 }
 
 // posterFetchedMsg is sent when a poster image has been prepared.

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -53,6 +53,14 @@ type downloadProgressMsg dlmanager.ProgressUpdate
 // downloadListUpdatedMsg signals the downloads list should refresh from store.
 type downloadListUpdatedMsg struct{}
 
+// liveItemsFetchedMsg carries one level of the Live TV drill-down (categories or
+// channels) to the Update loop. level 0 = categories, level 1 = channels.
+type liveItemsFetchedMsg struct {
+	rows  []liveRow
+	level int
+	title string
+}
+
 // posterFetchedMsg is sent when a poster image has been prepared.
 // For char-art terminals, `poster` holds the rendered cell-art.
 // For inline terminals, `inline` is true and `b64`/`imgW`/`imgH` hold the image.

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -5,6 +5,7 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,10 @@ import (
 
 	"golang.org/x/term"
 )
+
+// ErrCancelled is returned when the user aborts a selection (fzf exit 130,
+// e.g. Esc or Ctrl-C), as distinct from a real selector/TTY failure.
+var ErrCancelled = errors.New("selection cancelled")
 
 // Select presents items to the user via fzf and returns the selected item's index.
 // Items are passed as plain text via stdin. No --preview or shell-evaluated strings.
@@ -52,7 +57,7 @@ func Select(prompt string, items []string) (int, error) {
 
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 130 {
-			return -1, fmt.Errorf("selection cancelled")
+			return -1, ErrCancelled
 		}
 		return -1, fmt.Errorf("fzf failed: %w", err)
 	}


### PR DESCRIPTION
## Live TV (IPTV)

Adds a **Live TV** tab that streams free public IPTV (the [iptv-org](https://github.com/iptv-org/iptv) playlists) plus any user-supplied M3U or Xtream-codes playlists, browsable by category and played through the existing player. lobster stays a player — it consumes existing public sources, it does not scrape anything.

### What you get
- **Live TV tab** (key `5`): category list → channel list → play. `Esc` goes back a level; the search box filters the current list client-side (no network round-trip).
- Built-in source: iptv-org `index.category.m3u` (~13k working channels, 30 categories), default-on and toggleable.
- Custom sources: extra M3U URLs/paths and Xtream-codes (`server`/`username`/`password`) via the `[live_tv]` config table.
- Per-channel `Referer` **and** `User-Agent` headers honored (≈900 channels need a custom UA), so header-gated streams play.
- Live channels can't be downloaded (endless streams) — guarded on both the CLI `--download` path and the TUI `d` key.

### Design notes
- Channels are surfaced as `media.Movie`, so they flow through the existing single-play path — **no** changes to the Seasons/Episodes/playlist machinery.
- Pure `ParseM3U` → `LiveTV` `StreamProvider` → config `Sources()` → TUI; each unit independently tested. Unique-ID collision handling, failed-source skip, and `sync.Once` lazy load.
- Xtream URLs honor an explicit `https://` scheme (TLS); default `http://` only when none given.
- **Network resilience:** some networks (certain phone hotspots/middleboxes) stall TLS 1.3 handshakes to GitHub Pages — the playlist fetch uses a short TLS-handshake timeout and retries capped at TLS 1.2, and surfaces the real error instead of hanging.

### Scope
Free-to-air / publicly-listed channels only (incl. ~437 free sports networks). Premium/pirated league streams are explicitly **out of scope**. EPG, DVR, and per-country browse are deferred.

### Testing
- Full suite green (`CGO_ENABLED=0 go test ./...`), `go vet` clean.
- Parser unit-tested for multi-value `group-title`, EXTVLCOPT headers, no-URL lines, CRLF, comma-in-attribute, ID collisions.
- Validated end-to-end against the live iptv-org source (30 categories, Sports = 437, real HLS URLs resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Live TV** tab with category/channel navigation, in-tab search filtering, and per-row descriptions.
  * Introduced **surf playback** for Live TV lineups with “back to channel list” flow.
  * Added support for **User-Agent** and **Referer** headers during playback.
* **Bug Fixes**
  * Prevented **downloading** of Live TV streams (clear error when attempted).
  * Improved Live TV playlist/source handling (URL-escaping, deterministic source ordering, fallback behavior).
* **Tests**
  * Added coverage for Live TV browsing, M3U parsing, surf decision/indexing, TUI filtering, and header argument generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->