### PR TITLE
fix(search): show the whole catalogue and play the title that was picked

### DIFF
--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -145,7 +145,7 @@ func batchDownload(p provider.Provider, selected media.SearchResult, episodes []
 // downloadSingleEpisode resolves and downloads one episode via fallback providers.
 func downloadSingleEpisode(p provider.Provider, selected media.SearchResult, ep media.Episode, seasonNum int, outputDir, title string) error {
 	debugf("resolving stream via fallback providers for %s", title)
-	stream, err := tryFallbackStream(p, selected.Title, selected.Type, seasonNum, ep.Number)
+	stream, err := tryFallbackStream(p, selected, seasonNum, ep.Number)
 	if err != nil {
 		return fmt.Errorf("all providers failed: %w", err)
 	}

--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -126,14 +126,15 @@ func tryFallbackStream(primary provider.Provider, content media.SearchResult, se
 // makeStreamResolver builds a StreamResolver that tries the primary provider
 // and all fallbacks to resolve a stream URL for downloads.
 func makeStreamResolver(primary provider.Provider) dlmanager.StreamResolver {
-	return func(title, mediaID, episodeID, mediaType string, season, episode int) (*dlmanager.StreamResult, error) {
+	return func(req dlmanager.ResolveRequest) (*dlmanager.StreamResult, error) {
 		mt := media.Movie
-		if mediaType == "tv" {
+		if req.MediaType == "tv" {
 			mt = media.TV
 		}
 
 		// Use fallback providers to resolve a stream for downloads.
-		fbStream, err := tryFallbackStream(primary, media.SearchResult{ID: mediaID, Title: title, Type: mt}, season, episode)
+		content := media.SearchResult{ID: req.MediaID, Title: req.Title, Year: req.Year, Type: mt}
+		fbStream, err := tryFallbackStream(primary, content, req.Season, req.Episode)
 		if err != nil {
 			return nil, fmt.Errorf("all providers failed: %w", err)
 		}

--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -86,14 +86,34 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 		fallbacks = append(fallbacks, provider.NewKimCartoon("kimcartoon.com.co"))
 	}
 
+	// Last so movie/TV scrapers keep priority; these catch anime the others
+	// lack. AniPub matters most: AllAnime's sources endpoint is crypto-gated
+	// (AA_CRYPTO_MISSING, mid-2026), so its Watch fails until that's cracked.
+	if _, ok := primary.(*provider.AllAnime); !ok {
+		fallbacks = append(fallbacks, provider.NewAllAnime(cfg != nil && cfg.AnimeDub))
+	}
+	if _, ok := primary.(*provider.AniPub); !ok {
+		fallbacks = append(fallbacks, provider.NewAniPub())
+	}
+
 	return fallbacks
 }
 
 // tryFallbackStream attempts to resolve a stream using the resilient Resolver,
 // which races fallback providers and selects the first valid result.
-func tryFallbackStream(primary provider.Provider, title string, mediaType media.MediaType, season, episode int) (*media.Stream, error) {
+// content carries the ID and year of the work the user actually selected so the
+// resolver can tell a franchise entry apart from its sequels.
+func tryFallbackStream(primary provider.Provider, content media.SearchResult, season, episode int) (*media.Stream, error) {
 	r := resolver.New(fallbackProviders(primary), sharedHealth(), debugf)
-	req := resolver.Request{Title: title, MediaType: mediaType, Season: season, Episode: episode, Quality: cfgQuality()}
+	req := resolver.Request{
+		ID:        content.ID,
+		Title:     content.Title,
+		Year:      content.Year,
+		MediaType: content.Type,
+		Season:    season,
+		Episode:   episode,
+		Quality:   cfgQuality(),
+	}
 	stream, report, err := r.Resolve(context.Background(), req)
 	if err != nil {
 		debugf("resolve failed: %s", report.Summary())
@@ -113,7 +133,7 @@ func makeStreamResolver(primary provider.Provider) dlmanager.StreamResolver {
 		}
 
 		// Use fallback providers to resolve a stream for downloads.
-		fbStream, err := tryFallbackStream(primary, title, mt, season, episode)
+		fbStream, err := tryFallbackStream(primary, media.SearchResult{ID: mediaID, Title: title, Type: mt}, season, episode)
 		if err != nil {
 			return nil, fmt.Errorf("all providers failed: %w", err)
 		}

--- a/cmd/fallback_allanime_test.go
+++ b/cmd/fallback_allanime_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/provider"
+)
+
+func TestFallbackProvidersIncludeAllAnime(t *testing.T) {
+	found := false
+	for _, p := range fallbackProviders(provider.NewFlixHQ("flixhq.to")) {
+		if _, ok := p.(*provider.AllAnime); ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("AllAnime missing from fallback chain")
+	}
+
+	for _, p := range fallbackProviders(provider.NewAllAnime(false)) {
+		if _, ok := p.(*provider.AllAnime); ok {
+			t.Fatal("AllAnime duplicated when it is the primary")
+		}
+	}
+}
+
+func TestFallbackProvidersIncludeAniPub(t *testing.T) {
+	found := false
+	for _, p := range fallbackProviders(provider.NewFlixHQ("flixhq.to")) {
+		if _, ok := p.(*provider.AniPub); ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("AniPub missing from fallback chain")
+	}
+
+	for _, p := range fallbackProviders(provider.NewAniPub()) {
+		if _, ok := p.(*provider.AniPub); ok {
+			t.Fatal("AniPub duplicated when it is the primary")
+		}
+	}
+}
+
+func TestNewProviderAllAnimeBase(t *testing.T) {
+	old := cfg
+	defer func() { cfg = old }()
+	cfg = &config.Config{Base: "allanime"}
+	if p := newProvider(); func() bool { _, ok := p.(*provider.AllAnime); return !ok }() {
+		t.Fatalf("newProvider with Base=allanime returned %T, want *provider.AllAnime", p)
+	}
+}

--- a/cmd/gathersearch_test.go
+++ b/cmd/gathersearch_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// stubProvider is a minimal Provider whose Search returns canned results/error.
+type stubProvider struct {
+	name    string
+	results []media.SearchResult
+	err     error
+}
+
+func (s stubProvider) Search(string) ([]media.SearchResult, error) { return s.results, s.err }
+func (s stubProvider) GetDetails(string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+func (s stubProvider) GetSeasons(string) ([]media.Season, error)         { return nil, nil }
+func (s stubProvider) GetEpisodes(string, string) ([]media.Episode, error) { return nil, nil }
+func (s stubProvider) GetServers(string, string) ([]media.Server, error) { return nil, nil }
+func (s stubProvider) GetEmbedURL(string) (string, error)                { return "", nil }
+func (s stubProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
+	return nil, nil
+}
+func (s stubProvider) Recent(media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+
+func TestGatherSearchResultsFallsBackWhenPrimaryErrors(t *testing.T) {
+	primary := stubProvider{name: "primary", err: fmt.Errorf("no results found")}
+	fb := stubProvider{name: "fb", results: []media.SearchResult{
+		{ID: "kam", Title: "KAMUI: He's Behind You", Type: media.TV},
+	}}
+
+	results, err := gatherSearchResults(primary, []provider.Provider{fb}, "KAMUI: He's Behind You")
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected fallback results, got none")
+	}
+}
+
+func TestGatherSearchResultsErrorsWhenNothingFound(t *testing.T) {
+	primary := stubProvider{err: fmt.Errorf("no results")}
+	fb := stubProvider{err: fmt.Errorf("no results")}
+	if _, err := gatherSearchResults(primary, []provider.Provider{fb}, "zzz"); err == nil {
+		t.Fatal("expected error when no provider has results")
+	}
+}

--- a/cmd/gathersearch_test.go
+++ b/cmd/gathersearch_test.go
@@ -50,3 +50,50 @@ func TestGatherSearchResultsErrorsWhenNothingFound(t *testing.T) {
 		t.Fatal("expected error when no provider has results")
 	}
 }
+
+// flakyProvider succeeds on the first Search and fails on every one after,
+// mimicking a provider that rate-limits or drops a connection.
+type flakyProvider struct {
+	stubProvider
+	calls int
+}
+
+func (f *flakyProvider) Search(q string) ([]media.SearchResult, error) {
+	f.calls++
+	if f.calls == 1 {
+		return f.results, nil
+	}
+	return nil, fmt.Errorf("rate limited")
+}
+
+// A thin but successful primary result set must survive the broadening pass.
+// Re-querying the primary and replacing the originals on a transient failure
+// silently dropped the only results the user was going to see.
+func TestGatherSearchResultsKeepsInitialPrimaryResults(t *testing.T) {
+	primary := &flakyProvider{stubProvider: stubProvider{results: []media.SearchResult{
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002"},
+	}}}
+	fb := stubProvider{results: []media.SearchResult{
+		{ID: "movie/558", Title: "Spider-Man 2", Type: media.Movie, Year: "2004"},
+	}}
+
+	results, err := gatherSearchResults(primary, []provider.Provider{fb}, "spider-man")
+	if err != nil {
+		t.Fatalf("gatherSearchResults: %v", err)
+	}
+	if primary.calls != 1 {
+		t.Errorf("primary searched %d times, want 1", primary.calls)
+	}
+	var found bool
+	for _, r := range results {
+		if r.ID == "movie/557" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("initial primary result was dropped: %+v", results)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2: %+v", len(results), results)
+	}
+}

--- a/cmd/multisearch.go
+++ b/cmd/multisearch.go
@@ -9,6 +9,7 @@ import (
 
 	"lobster/internal/media"
 	"lobster/internal/provider"
+	"lobster/internal/ui"
 )
 
 const multiSearchTimeout = 5 * time.Second
@@ -16,6 +17,40 @@ const multiSearchTimeout = 5 * time.Second
 // multiProviderSearch searches the primary provider and fallbacks in parallel,
 // then merges and deduplicates results. The primary provider's results are
 // preferred and appear first.
+// gatherSearchResults runs the primary provider's search, then broadens to the
+// fallback providers whenever the primary errors or returns few results — so a
+// title the primary catalog lacks (e.g. anime, which only the TMDB/AllAnime/
+// AniPub providers index) is still discoverable. It only errors when no
+// provider yields anything.
+func gatherSearchResults(primary provider.Provider, fallbacks []provider.Provider, query string) ([]media.SearchResult, error) {
+	stop := ui.StartSpinner(fmt.Sprintf("Searching for %q...", query))
+	results, err := primary.Search(query)
+	stop()
+	if err != nil {
+		debugf("primary search (%T) failed: %v; broadening to fallback providers", primary, err)
+		results = nil
+	}
+
+	// The merged results may originate from fallback providers, but playback
+	// still uses the primary provider. Providers use their own ID formats;
+	// stream resolution is title-based via the resolver, so cross-provider
+	// fallback works.
+	if len(results) < 3 {
+		debugf("primary returned %d results, searching fallback providers...", len(results))
+		stop = ui.StartSpinner("Searching more providers...")
+		merged := multiProviderSearch(primary, fallbacks, query)
+		stop()
+		if len(merged) > 0 {
+			results = merged
+		}
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no results found for %q", query)
+	}
+	return results, nil
+}
+
 func multiProviderSearch(primary provider.Provider, fallbacks []provider.Provider, query string) []media.SearchResult {
 	ctx, cancel := context.WithTimeout(context.Background(), multiSearchTimeout)
 	defer cancel()
@@ -88,23 +123,56 @@ func searchWithContext(ctx context.Context, p provider.Provider, query string) (
 }
 
 // deduplicateResults merges primary results with fallback results, deduplicating
-// by title (case-insensitive). When duplicates exist, the entry with more
-// metadata (poster, year, seasons/episodes) is preferred.
+// by title, media type and year (case-insensitive). When duplicates exist, the
+// entry with more metadata (poster, year, seasons/episodes) is preferred.
 func deduplicateResults(primary []media.SearchResult, fallbackGroups [][]media.SearchResult) []media.SearchResult {
-	seen := make(map[string]int) // normalized title -> index in merged
+	// Dedup on title + media type + year, not title alone: "Spider-Man" is the
+	// 2002 film, a 1994 cartoon and a 1967 cartoon, and collapsing them hides
+	// most of a franchise behind one row. Providers that omit the year fall
+	// back to a looser title+type match so they still merge rather than
+	// producing a near-duplicate.
+	seen := make(map[string]int)        // title|type|year -> index in merged
+	yearless := make(map[string]int)    // title|type -> index of a year-less entry
+	byTitleType := make(map[string]int) // title|type -> index of the first entry
 	var merged []media.SearchResult
 
+	keep := func(idx int, r media.SearchResult) {
+		if resultScore(r) > resultScore(merged[idx]) {
+			merged[idx] = r
+		}
+	}
+
 	addResult := func(r media.SearchResult) {
-		key := normalizeTitle(r.Title)
-		if idx, exists := seen[key]; exists {
-			// Keep the one with more metadata.
-			existing := merged[idx]
-			if resultScore(r) > resultScore(existing) {
-				merged[idx] = r
-			}
+		loose := normalizeTitle(r.Title) + "|" + r.Type.String()
+		key := loose + "|" + r.Year
+
+		if idx, ok := seen[key]; ok {
+			keep(idx, r)
 			return
 		}
-		seen[key] = len(merged)
+		if r.Year == "" {
+			// No year to disambiguate with: merge into whatever we already have
+			// for this title and type.
+			if idx, ok := byTitleType[loose]; ok {
+				keep(idx, r)
+				return
+			}
+		} else if idx, ok := yearless[loose]; ok {
+			// A year-less entry for this work arrived first — upgrade it in place.
+			keep(idx, r)
+			seen[key] = idx
+			delete(yearless, loose)
+			return
+		}
+
+		idx := len(merged)
+		seen[key] = idx
+		if _, ok := byTitleType[loose]; !ok {
+			byTitleType[loose] = idx
+		}
+		if r.Year == "" {
+			yearless[loose] = idx
+		}
 		merged = append(merged, r)
 	}
 

--- a/cmd/multisearch.go
+++ b/cmd/multisearch.go
@@ -14,9 +14,6 @@ import (
 
 const multiSearchTimeout = 5 * time.Second
 
-// multiProviderSearch searches the primary provider and fallbacks in parallel,
-// then merges and deduplicates results. The primary provider's results are
-// preferred and appear first.
 // gatherSearchResults runs the primary provider's search, then broadens to the
 // fallback providers whenever the primary errors or returns few results — so a
 // title the primary catalog lacks (e.g. anime, which only the TMDB/AllAnime/
@@ -38,7 +35,7 @@ func gatherSearchResults(primary provider.Provider, fallbacks []provider.Provide
 	if len(results) < 3 {
 		debugf("primary returned %d results, searching fallback providers...", len(results))
 		stop = ui.StartSpinner("Searching more providers...")
-		merged := multiProviderSearch(primary, fallbacks, query)
+		merged := multiProviderSearch(results, fallbacks, query)
 		stop()
 		if len(merged) > 0 {
 			results = merged
@@ -51,34 +48,20 @@ func gatherSearchResults(primary provider.Provider, fallbacks []provider.Provide
 	return results, nil
 }
 
-func multiProviderSearch(primary provider.Provider, fallbacks []provider.Provider, query string) []media.SearchResult {
+// multiProviderSearch searches the fallback providers in parallel and merges
+// them behind primaryResults, which the caller has already obtained. The
+// primary is deliberately not re-queried: a thin-but-successful first search
+// followed by a transient second failure used to discard the only results the
+// user would have seen.
+func multiProviderSearch(primaryResults []media.SearchResult, fallbacks []provider.Provider, query string) []media.SearchResult {
 	ctx, cancel := context.WithTimeout(context.Background(), multiSearchTimeout)
 	defer cancel()
 
 	var mu sync.Mutex
-	var primaryResults []media.SearchResult
-	var fallbackResults [][]media.SearchResult
-
 	// Pre-allocate slice for fallback results to maintain order.
-	fallbackResults = make([][]media.SearchResult, len(fallbacks))
+	fallbackResults := make([][]media.SearchResult, len(fallbacks))
 
 	var wg sync.WaitGroup
-
-	// Search primary provider.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		results, err := searchWithContext(ctx, primary, query)
-		if err != nil {
-			debugf("multi-search primary (%T) failed: %v", primary, err)
-			return
-		}
-		mu.Lock()
-		primaryResults = results
-		mu.Unlock()
-	}()
-
-	// Search fallback providers in parallel.
 	for i, fb := range fallbacks {
 		wg.Add(1)
 		go func(idx int, p provider.Provider) {
@@ -136,10 +119,17 @@ func deduplicateResults(primary []media.SearchResult, fallbackGroups [][]media.S
 	byTitleType := make(map[string]int) // title|type -> index of the first entry
 	var merged []media.SearchResult
 
+	// Two entries for the same work carry different subsets of the metadata.
+	// Keep the richer one as the base and fill its gaps from the other, so a
+	// year-bearing duplicate can never leave the merged entry year-less —
+	// an empty year disables the resolver's year-based candidate ranking.
 	keep := func(idx int, r media.SearchResult) {
 		if resultScore(r) > resultScore(merged[idx]) {
-			merged[idx] = r
+			r = fillGaps(r, merged[idx])
+		} else {
+			r = fillGaps(merged[idx], r)
 		}
+		merged[idx] = r
 	}
 
 	addResult := func(r media.SearchResult) {
@@ -189,6 +179,32 @@ func deduplicateResults(primary []media.SearchResult, fallbackGroups [][]media.S
 	}
 
 	return merged
+}
+
+// fillGaps returns base with every empty field filled in from other.
+func fillGaps(base, other media.SearchResult) media.SearchResult {
+	if base.ID == "" {
+		base.ID = other.ID
+	}
+	if base.Year == "" {
+		base.Year = other.Year
+	}
+	if base.Duration == "" {
+		base.Duration = other.Duration
+	}
+	if base.URL == "" {
+		base.URL = other.URL
+	}
+	if base.Poster == "" {
+		base.Poster = other.Poster
+	}
+	if base.Seasons == 0 {
+		base.Seasons = other.Seasons
+	}
+	if base.Episodes == 0 {
+		base.Episodes = other.Episodes
+	}
+	return base
 }
 
 // normalizeTitle returns a lowercase, trimmed version of the title for dedup.

--- a/cmd/multisearch_dedup_test.go
+++ b/cmd/multisearch_dedup_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// Distinct works that happen to share a title (the 2002 film, the 1994 cartoon,
+// the 1967 cartoon) must survive dedup — collapsing them on title alone hid the
+// whole franchise behind a single entry.
+func TestDeduplicateResultsKeepsSameTitleDifferentWorks(t *testing.T) {
+	primary := []media.SearchResult{
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002"},
+		{ID: "tv/888", Title: "Spider-Man", Type: media.TV, Year: "1994"},
+		{ID: "tv/1482", Title: "Spider-Man", Type: media.TV, Year: "1967"},
+	}
+	// A second provider returns the same three works, plus richer metadata for
+	// the 2002 film — those must merge, not stack up.
+	fallback := [][]media.SearchResult{{
+		{ID: "movie/557", Title: "spider-man", Type: media.Movie, Year: "2002", Poster: "p.jpg", URL: "u"},
+		{ID: "tv/888", Title: "Spider-Man", Type: media.TV, Year: "1994"},
+		{ID: "tv/1482", Title: "Spider-Man", Type: media.TV, Year: "1967"},
+	}}
+
+	merged := deduplicateResults(primary, fallback)
+	if len(merged) != 3 {
+		t.Fatalf("len(merged) = %d, want 3: %+v", len(merged), merged)
+	}
+	if merged[0].Poster != "p.jpg" {
+		t.Errorf("richer duplicate did not replace the sparse one: %+v", merged[0])
+	}
+}
+
+// A provider that omits the year still merges into the year-bearing entry for
+// the same title and media type, rather than producing a near-duplicate row.
+func TestDeduplicateResultsMergesMissingYear(t *testing.T) {
+	primary := []media.SearchResult{
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002", Poster: "p.jpg"},
+	}
+	fallback := [][]media.SearchResult{{
+		{ID: "x", Title: "Spider-Man", Type: media.Movie},
+	}}
+
+	merged := deduplicateResults(primary, fallback)
+	if len(merged) != 1 {
+		t.Fatalf("len(merged) = %d, want 1: %+v", len(merged), merged)
+	}
+	if merged[0].Year != "2002" {
+		t.Errorf("merged entry lost its year: %+v", merged[0])
+	}
+}
+
+// The reverse order: the year-less entry arrives first and is upgraded when the
+// richer, year-bearing one shows up.
+func TestDeduplicateResultsUpgradesYearlessEntry(t *testing.T) {
+	primary := []media.SearchResult{
+		{ID: "x", Title: "Spider-Man", Type: media.Movie},
+	}
+	fallback := [][]media.SearchResult{{
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002", Poster: "p.jpg"},
+		{ID: "tv/888", Title: "Spider-Man", Type: media.TV, Year: "1994"},
+	}}
+
+	merged := deduplicateResults(primary, fallback)
+	if len(merged) != 2 {
+		t.Fatalf("len(merged) = %d, want 2: %+v", len(merged), merged)
+	}
+	if merged[0].Year != "2002" || merged[0].ID != "movie/557" {
+		t.Errorf("year-less entry was not upgraded: %+v", merged[0])
+	}
+}

--- a/cmd/multisearch_dedup_test.go
+++ b/cmd/multisearch_dedup_test.go
@@ -70,3 +70,27 @@ func TestDeduplicateResultsUpgradesYearlessEntry(t *testing.T) {
 		t.Errorf("year-less entry was not upgraded: %+v", merged[0])
 	}
 }
+
+// When a dated entry merges into a year-less one, the year must survive even if
+// the year-less entry carries more metadata overall — an empty year propagates
+// into resolver.Request and disables year-based candidate ranking.
+func TestDeduplicateResultsKeepsYearWhenYearlessEntryIsRicher(t *testing.T) {
+	primary := []media.SearchResult{
+		{ID: "x", Title: "Spider-Man", Type: media.Movie, Poster: "p.jpg", Duration: "121m", URL: "u"},
+	}
+	fallback := [][]media.SearchResult{{
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002"},
+	}}
+
+	merged := deduplicateResults(primary, fallback)
+	if len(merged) != 1 {
+		t.Fatalf("len(merged) = %d, want 1: %+v", len(merged), merged)
+	}
+	if merged[0].Year != "2002" {
+		t.Errorf("Year = %q, want 2002: %+v", merged[0].Year, merged[0])
+	}
+	// The richer entry's metadata must not be lost either.
+	if merged[0].Poster != "p.jpg" || merged[0].Duration != "121m" || merged[0].URL != "u" {
+		t.Errorf("metadata lost while merging: %+v", merged[0])
+	}
+}

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -46,6 +46,9 @@ func newProvider() provider.Provider {
 	if strings.Contains(cfg.Base, "vaplayer") {
 		return provider.NewVaPlayer()
 	}
+	if strings.Contains(cfg.Base, "allanime") {
+		return provider.NewAllAnime(cfg.AnimeDub)
+	}
 	// Default: MovieBox
 	return provider.NewMovieBox()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagPlayer, "player", "", "Media player: mpv | vlc | iina | celluloid")
 	rootCmd.PersistentFlags().BoolVarP(&flagContinue, "continue", "c", false, "Auto-resume from history")
 	rootCmd.PersistentFlags().BoolVarP(&flagJSON, "json", "j", false, "Output stream metadata as JSON")
-	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | moviebox | vaplayer | vidnest | tbcpl | 1shows.org")
+	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | moviebox | vaplayer | vidnest | tbcpl | 1shows.org | allanime")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
 
 	rootCmd.AddCommand(historyCmd)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -78,25 +78,9 @@ func searchRun(cmd *cobra.Command, args []string) error {
 
 // playFlow handles the full search -> select -> play flow.
 func playFlow(p provider.Provider, query string) error {
-	// Search primary provider first.
-	stop := ui.StartSpinner(fmt.Sprintf("Searching for %q...", query))
-	results, err := p.Search(query)
-	stop()
+	results, err := gatherSearchResults(p, fallbackSearchProviders(p), query)
 	if err != nil {
-		return fmt.Errorf("search failed: %w", err)
-	}
-
-	// If primary returned few results, search fallback providers in parallel.
-	// The merged results may originate from fallback providers, but playback
-	// still uses the primary provider (p). Providers use their own ID formats
-	// (FlixHQ uses slugs, soap2day uses TMDB IDs). Stream resolution is
-	// title-based via the resolver, so cross-provider fallback works.
-	if len(results) < 3 {
-		debugf("primary returned %d results, searching fallback providers...", len(results))
-		stop = ui.StartSpinner("Searching more providers...")
-		fallbacks := fallbackSearchProviders(p)
-		results = multiProviderSearch(p, fallbacks, query)
-		stop()
+		return err
 	}
 
 	items := make([]string, len(results))
@@ -253,7 +237,7 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 			// Primary provider can't resolve seasons — try fallback stream
 			debugf("primary provider seasons failed: %v, trying fallbacks", err)
 			fmt.Fprintf(os.Stderr, "Provider has no season data, trying fallbacks...\n")
-			fbStream, fbErr := tryFallbackStream(p, selected.Title, selected.Type, season, episode)
+			fbStream, fbErr := tryFallbackStream(p, selected, season, episode)
 			if fbErr != nil {
 				if err != nil {
 					return fmt.Errorf("getting seasons: %w", err)
@@ -418,7 +402,7 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 			}
 			// Try fallback immediately
 			fmt.Fprintf(os.Stderr, "Primary provider failed, trying fallback...\n")
-			fbStream, fbErr := tryFallbackStream(p, selected.Title, selected.Type, season, episode)
+			fbStream, fbErr := tryFallbackStream(p, selected, season, episode)
 			if fbErr != nil {
 				if err != nil {
 					return fmt.Errorf("getting servers: %w", err)
@@ -448,7 +432,7 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 			stopWatch()
 			// Try fallback providers
 			fmt.Fprintf(os.Stderr, "Primary provider failed, trying fallback...\n")
-			fbStream, err := tryFallbackStream(p, selected.Title, selected.Type, season, episode)
+			fbStream, err := tryFallbackStream(p, selected, season, episode)
 			if err != nil {
 				return fmt.Errorf("all servers failed for %s", title)
 			}
@@ -463,7 +447,7 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 	// fallback StreamProviders (Soap2Day, etc.) for stream resolution.
 	debugf("resolving stream via fallback providers for %s", title)
 	stopStream := ui.StartSpinner(fmt.Sprintf("Fetching %s media stream...", title))
-	fbStream, err := tryFallbackStream(p, selected.Title, selected.Type, season, episode)
+	fbStream, err := tryFallbackStream(p, selected, season, episode)
 	stopStream()
 	if err != nil {
 		debugf("fallback failed: %v", err)

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -197,8 +197,7 @@ func resolveStream(sess *playlist.Session, excludeNames map[string]bool) (*media
 	debugf("resolving stream via fallback providers for %s", sess.Title())
 	stream, err := tryFallbackStream(
 		sess.Provider,
-		sess.Content.Title,
-		sess.Content.Type,
+		sess.Content,
 		sess.CurrentSeason().Number,
 		sess.Current().Number,
 	)

--- a/internal/dlmanager/manager.go
+++ b/internal/dlmanager/manager.go
@@ -30,9 +30,22 @@ type StreamResult struct {
 	Referer    string
 }
 
+// ResolveRequest describes the work a queued download needs a stream for.
+// It is a struct rather than a positional list because resolution happens long
+// after queueing — often in a later process run — so every field the resolver
+// needs to identify the right work must travel on the stored row.
+type ResolveRequest struct {
+	Title     string
+	Year      string // release year; disambiguates same-title works
+	MediaID   string
+	EpisodeID string
+	MediaType string // "movie" or "tv"
+	Season    int
+	Episode   int
+}
+
 // StreamResolver resolves a stream URL for a download.
-// It receives the title, media ID, episode ID, media type, season, and episode number.
-type StreamResolver func(title, mediaID, episodeID, mediaType string, season, episode int) (*StreamResult, error)
+type StreamResolver func(ResolveRequest) (*StreamResult, error)
 
 // Manager coordinates download workers and relays progress.
 type Manager struct {
@@ -239,7 +252,15 @@ func (m *Manager) processDownload(dl *store.Download) {
 	// Resolve stream URL if not set.
 	if dl.StreamURL == "" && m.resolver != nil {
 		m.sendProgress(ProgressUpdate{DownloadID: dl.ID, Status: "resolving"})
-		result, err := m.resolver(dl.MediaTitle, dl.MediaID, dl.EpisodeID, dl.MediaType, dl.Season, dl.Episode)
+		result, err := m.resolver(ResolveRequest{
+			Title:     dl.MediaTitle,
+			Year:      dl.Year,
+			MediaID:   dl.MediaID,
+			EpisodeID: dl.EpisodeID,
+			MediaType: dl.MediaType,
+			Season:    dl.Season,
+			Episode:   dl.Episode,
+		})
 		if err != nil {
 			m.store.UpdateStatus(dl.ID, "failed", err.Error())
 			m.sendProgress(ProgressUpdate{DownloadID: dl.ID, Status: "failed", Error: err.Error()})

--- a/internal/dlmanager/resolver_year_test.go
+++ b/internal/dlmanager/resolver_year_test.go
@@ -1,0 +1,60 @@
+package dlmanager
+
+import (
+	"context"
+	"crypto/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"lobster/internal/dlmanager/store"
+)
+
+// A queued download resolves its stream later, often in a different process
+// run, so everything the resolver needs to identify the work must come off the
+// stored row. Without the year, a same-title franchise entry can resolve to
+// the wrong film.
+func TestManagerPassesStoredYearToResolver(t *testing.T) {
+	data := make([]byte, 1024)
+	rand.Read(data)
+
+	mgr, srv, dir := setupTestManager(t, data)
+
+	got := make(chan ResolveRequest, 1)
+	mgr.SetResolver(func(req ResolveRequest) (*StreamResult, error) {
+		got <- req
+		return &StreamResult{URL: srv.URL, StreamType: "http"}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.Start(ctx)
+
+	if _, err := mgr.Queue(&store.Download{
+		Title:      "Spider-Man",
+		MediaTitle: "Spider-Man",
+		MediaType:  "movie",
+		Year:       "2002",
+		MediaID:    "movie/557",
+		OutputPath: filepath.Join(dir, "spiderman.mkv"),
+		Status:     "queued",
+		StreamType: "http",
+	}); err != nil {
+		t.Fatalf("Queue: %v", err)
+	}
+
+	select {
+	case req := <-got:
+		if req.Year != "2002" {
+			t.Errorf("resolver got Year %q, want 2002", req.Year)
+		}
+		if req.MediaID != "movie/557" {
+			t.Errorf("resolver got MediaID %q, want movie/557", req.MediaID)
+		}
+		if req.Title != "Spider-Man" {
+			t.Errorf("resolver got Title %q, want Spider-Man", req.Title)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolver was never called")
+	}
+}

--- a/internal/dlmanager/store/store.go
+++ b/internal/dlmanager/store/store.go
@@ -15,6 +15,7 @@ type Download struct {
 	Title         string
 	MediaTitle    string
 	MediaType     string // "movie" or "tv"
+	Year          string // release year, disambiguates same-title works at resolve time
 	Season        int
 	Episode       int
 	MediaID       string // provider content ID
@@ -54,6 +55,7 @@ CREATE TABLE IF NOT EXISTS downloads (
     title          TEXT NOT NULL,
     media_title    TEXT NOT NULL,
     media_type     TEXT NOT NULL,
+    year           TEXT NOT NULL DEFAULT '',
     season         INTEGER DEFAULT 0,
     episode        INTEGER DEFAULT 0,
     media_id       TEXT NOT NULL DEFAULT '',
@@ -113,7 +115,52 @@ func Open(path string) (*Store, error) {
 		return nil, fmt.Errorf("creating schema: %w", err)
 	}
 
+	if err := migrate(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+
 	return &Store{db: db}, nil
+}
+
+// migrate brings a database created by an older release up to the current
+// schema. CREATE TABLE IF NOT EXISTS is a no-op against an existing table, so
+// columns added after a release need an explicit ALTER here.
+func migrate(db *sql.DB) error {
+	for _, col := range []struct{ name, ddl string }{
+		{"year", "ALTER TABLE downloads ADD COLUMN year TEXT NOT NULL DEFAULT ''"},
+	} {
+		has, err := hasColumn(db, "downloads", col.name)
+		if err != nil {
+			return fmt.Errorf("inspecting downloads schema: %w", err)
+		}
+		if has {
+			continue
+		}
+		if _, err := db.Exec(col.ddl); err != nil {
+			return fmt.Errorf("adding downloads.%s: %w", col.name, err)
+		}
+	}
+	return nil
+}
+
+// hasColumn reports whether a table already defines a column.
+func hasColumn(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query("SELECT name FROM pragma_table_info(?)", table)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 // Close closes the database connection.
@@ -124,12 +171,12 @@ func (s *Store) Close() error {
 // InsertDownload adds a new download and returns its ID.
 func (s *Store) InsertDownload(d *Download) (int, error) {
 	res, err := s.db.Exec(`
-		INSERT INTO downloads (title, media_title, media_type, season, episode,
+		INSERT INTO downloads (title, media_title, media_type, year, season, episode,
 			media_id, episode_id, stream_url, stream_type, referer,
 			output_path, subtitle_url, status, error,
 			total_bytes, done_bytes, total_segments, done_segments)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		d.Title, d.MediaTitle, d.MediaType, d.Season, d.Episode,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		d.Title, d.MediaTitle, d.MediaType, d.Year, d.Season, d.Episode,
 		d.MediaID, d.EpisodeID, d.StreamURL, d.StreamType, d.Referer,
 		d.OutputPath, d.SubtitleURL, d.Status, d.Error,
 		d.TotalBytes, d.DoneBytes, d.TotalSegments, d.DoneSegments,
@@ -148,14 +195,14 @@ func (s *Store) InsertDownload(d *Download) (int, error) {
 func (s *Store) GetDownload(id int) (*Download, error) {
 	d := &Download{}
 	err := s.db.QueryRow(`
-		SELECT id, title, media_title, media_type, season, episode,
+		SELECT id, title, media_title, media_type, year, season, episode,
 			media_id, episode_id, stream_url, stream_type, referer,
 			output_path, subtitle_url, status, error,
 			total_bytes, done_bytes, total_segments, done_segments,
 			created_at, updated_at
 		FROM downloads WHERE id = ?`, id,
 	).Scan(
-		&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Season, &d.Episode,
+		&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Year, &d.Season, &d.Episode,
 		&d.MediaID, &d.EpisodeID, &d.StreamURL, &d.StreamType, &d.Referer,
 		&d.OutputPath, &d.SubtitleURL, &d.Status, &d.Error,
 		&d.TotalBytes, &d.DoneBytes, &d.TotalSegments, &d.DoneSegments,
@@ -173,7 +220,7 @@ func (s *Store) GetDownload(id int) (*Download, error) {
 // ListDownloads returns all downloads ordered by creation time (FIFO).
 func (s *Store) ListDownloads() ([]Download, error) {
 	rows, err := s.db.Query(`
-		SELECT id, title, media_title, media_type, season, episode,
+		SELECT id, title, media_title, media_type, year, season, episode,
 			media_id, episode_id, stream_url, stream_type, referer,
 			output_path, subtitle_url, status, error,
 			total_bytes, done_bytes, total_segments, done_segments,
@@ -188,7 +235,7 @@ func (s *Store) ListDownloads() ([]Download, error) {
 	for rows.Next() {
 		var d Download
 		if err := rows.Scan(
-			&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Season, &d.Episode,
+			&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Year, &d.Season, &d.Episode,
 			&d.MediaID, &d.EpisodeID, &d.StreamURL, &d.StreamType, &d.Referer,
 			&d.OutputPath, &d.SubtitleURL, &d.Status, &d.Error,
 			&d.TotalBytes, &d.DoneBytes, &d.TotalSegments, &d.DoneSegments,
@@ -271,7 +318,7 @@ func (s *Store) RecoverStale(maxAge time.Duration) ([]Download, error) {
 	}
 
 	rows, err := s.db.Query(`
-		SELECT id, title, media_title, media_type, season, episode,
+		SELECT id, title, media_title, media_type, year, season, episode,
 			media_id, episode_id, stream_url, stream_type, referer,
 			output_path, subtitle_url, status, error,
 			total_bytes, done_bytes, total_segments, done_segments,
@@ -286,7 +333,7 @@ func (s *Store) RecoverStale(maxAge time.Duration) ([]Download, error) {
 	for rows.Next() {
 		var d Download
 		if err := rows.Scan(
-			&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Season, &d.Episode,
+			&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Year, &d.Season, &d.Episode,
 			&d.MediaID, &d.EpisodeID, &d.StreamURL, &d.StreamType, &d.Referer,
 			&d.OutputPath, &d.SubtitleURL, &d.Status, &d.Error,
 			&d.TotalBytes, &d.DoneBytes, &d.TotalSegments, &d.DoneSegments,
@@ -387,7 +434,7 @@ func (s *Store) CountSegments(downloadID int) (total, done int, err error) {
 func (s *Store) NextQueued() (*Download, error) {
 	d := &Download{}
 	err := s.db.QueryRow(`
-		SELECT id, title, media_title, media_type, season, episode,
+		SELECT id, title, media_title, media_type, year, season, episode,
 			media_id, episode_id, stream_url, stream_type, referer,
 			output_path, subtitle_url, status, error,
 			total_bytes, done_bytes, total_segments, done_segments,
@@ -395,7 +442,7 @@ func (s *Store) NextQueued() (*Download, error) {
 		FROM downloads WHERE status = 'queued'
 		ORDER BY created_at ASC LIMIT 1`,
 	).Scan(
-		&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Season, &d.Episode,
+		&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Year, &d.Season, &d.Episode,
 		&d.MediaID, &d.EpisodeID, &d.StreamURL, &d.StreamType, &d.Referer,
 		&d.OutputPath, &d.SubtitleURL, &d.Status, &d.Error,
 		&d.TotalBytes, &d.DoneBytes, &d.TotalSegments, &d.DoneSegments,
@@ -421,7 +468,7 @@ func (s *Store) ClaimNextQueued() (*Download, error) {
 
 	d := &Download{}
 	err = tx.QueryRow(`
-		SELECT id, title, media_title, media_type, season, episode,
+		SELECT id, title, media_title, media_type, year, season, episode,
 			media_id, episode_id, stream_url, stream_type, referer,
 			output_path, subtitle_url, status, error,
 			total_bytes, done_bytes, total_segments, done_segments,
@@ -429,7 +476,7 @@ func (s *Store) ClaimNextQueued() (*Download, error) {
 		FROM downloads WHERE status = 'queued'
 		ORDER BY created_at ASC LIMIT 1`,
 	).Scan(
-		&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Season, &d.Episode,
+		&d.ID, &d.Title, &d.MediaTitle, &d.MediaType, &d.Year, &d.Season, &d.Episode,
 		&d.MediaID, &d.EpisodeID, &d.StreamURL, &d.StreamType, &d.Referer,
 		&d.OutputPath, &d.SubtitleURL, &d.Status, &d.Error,
 		&d.TotalBytes, &d.DoneBytes, &d.TotalSegments, &d.DoneSegments,

--- a/internal/dlmanager/store/store.go
+++ b/internal/dlmanager/store/store.go
@@ -2,6 +2,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -146,7 +147,7 @@ func migrate(db *sql.DB) error {
 
 // hasColumn reports whether a table already defines a column.
 func hasColumn(db *sql.DB, table, column string) (bool, error) {
-	rows, err := db.Query("SELECT name FROM pragma_table_info(?)", table)
+	rows, err := db.QueryContext(context.Background(), "SELECT name FROM pragma_table_info(?)", table)
 	if err != nil {
 		return false, err
 	}

--- a/internal/dlmanager/store/year_test.go
+++ b/internal/dlmanager/store/year_test.go
@@ -1,0 +1,105 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// The release year is what lets the stream resolver tell a franchise entry
+// apart from its sequels, so a queued download has to carry it across a
+// restart — resolution happens later, in a different process run.
+func TestDownloadYearRoundTrips(t *testing.T) {
+	s := openTestStore(t)
+
+	d := sampleDownload()
+	d.Year = "2002"
+	id, err := s.InsertDownload(d)
+	if err != nil {
+		t.Fatalf("InsertDownload: %v", err)
+	}
+
+	got, err := s.GetDownload(id)
+	if err != nil {
+		t.Fatalf("GetDownload: %v", err)
+	}
+	if got.Year != "2002" {
+		t.Errorf("Year = %q, want 2002", got.Year)
+	}
+
+	list, err := s.ListDownloads()
+	if err != nil {
+		t.Fatalf("ListDownloads: %v", err)
+	}
+	if len(list) != 1 || list[0].Year != "2002" {
+		t.Errorf("ListDownloads lost the year: %+v", list)
+	}
+}
+
+// Existing installs already have a downloads table without the year column.
+// Open must add it rather than failing or silently reading a table it cannot
+// scan — the schema is created with CREATE TABLE IF NOT EXISTS, which is a
+// no-op against an old database.
+func TestOpenAddsYearColumnToExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+
+	// Build a pre-year database by hand.
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`CREATE TABLE downloads (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		title TEXT NOT NULL, media_title TEXT NOT NULL, media_type TEXT NOT NULL,
+		season INTEGER DEFAULT 0, episode INTEGER DEFAULT 0,
+		media_id TEXT NOT NULL DEFAULT '', episode_id TEXT NOT NULL DEFAULT '',
+		stream_url TEXT NOT NULL DEFAULT '', stream_type TEXT NOT NULL DEFAULT '',
+		referer TEXT DEFAULT '', output_path TEXT NOT NULL, subtitle_url TEXT DEFAULT '',
+		status TEXT NOT NULL DEFAULT 'queued', error TEXT DEFAULT '',
+		total_bytes INTEGER DEFAULT 0, done_bytes INTEGER DEFAULT 0,
+		total_segments INTEGER DEFAULT 0, done_segments INTEGER DEFAULT 0,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO downloads (title, media_title, media_type, output_path)
+		VALUES ('old', 'old', 'movie', '/tmp/old.mkv')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open on pre-year database: %v", err)
+	}
+	defer s.Close()
+
+	list, err := s.ListDownloads()
+	if err != nil {
+		t.Fatalf("ListDownloads after migration: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	if list[0].Year != "" {
+		t.Errorf("migrated row Year = %q, want empty", list[0].Year)
+	}
+
+	// And the column is usable going forward.
+	d := sampleDownload()
+	d.Year = "1994"
+	id, err := s.InsertDownload(d)
+	if err != nil {
+		t.Fatalf("InsertDownload after migration: %v", err)
+	}
+	got, err := s.GetDownload(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Year != "1994" {
+		t.Errorf("Year = %q, want 1994", got.Year)
+	}
+}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"lobster/internal/hlsproxy"
 	"lobster/internal/httputil"
 	"lobster/internal/media"
 )
@@ -46,6 +47,19 @@ func Download(stream *media.Stream, title string, outputDir string, subFile stri
 	outputPath, err := httputil.SafeDownloadPath(absDir, filename)
 	if err != nil {
 		return "", fmt.Errorf("invalid output path: %w", err)
+	}
+
+	// Route fake-PNG-obfuscated HLS through the local proxy so ffmpeg receives
+	// clean MPEG-TS (it cannot demux the PNG-wrapped segments either).
+	if stream.Deobfuscate {
+		p, perr := hlsproxy.New(stream.Referer, stream.UserAgent)
+		if perr != nil {
+			return "", fmt.Errorf("starting de-obfuscation proxy: %w", perr)
+		}
+		defer p.Close()
+		clone := *stream
+		clone.URL = p.PlaylistURL(stream.URL)
+		stream = &clone
 	}
 
 	// Skip if file already exists and appears complete.

--- a/internal/hlsproxy/hlsproxy.go
+++ b/internal/hlsproxy/hlsproxy.go
@@ -96,20 +96,25 @@ func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "upstream fetch failed", http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
 	if err != nil {
 		http.Error(w, "upstream read failed", http.StatusBadGateway)
 		return
 	}
 
+	// Serve through ServeContent so a player can seek: it handles Range,
+	// 206/Content-Range and 416 for us. The range must be applied to the bytes
+	// the client actually sees — stripPNG removes a wrapper and so shifts every
+	// offset, which is why the client's Range is never forwarded upstream.
+	payload := stripPNG(body)
+	contentType := "video/mp2t"
 	if isPlaylist(body) {
-		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
-		w.Write(p.rewritePlaylist(body, upstream))
-		return
+		payload = p.rewritePlaylist(body, upstream)
+		contentType = "application/vnd.apple.mpegurl"
 	}
-	w.Header().Set("Content-Type", "video/mp2t")
-	w.Write(stripPNG(body))
+	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, "", time.Time{}, bytes.NewReader(payload))
 }
 
 // isPlaylist reports whether body is an m3u8 playlist.

--- a/internal/hlsproxy/hlsproxy.go
+++ b/internal/hlsproxy/hlsproxy.go
@@ -1,0 +1,166 @@
+// Package hlsproxy runs a localhost HTTP proxy that fronts an obfuscated HLS
+// stream for a media player. It injects the CDN's required Referer/User-Agent
+// on every hop and de-obfuscates segments that are wrapped in a fake-PNG
+// header (as megaplay/ibyteimg serves them), which mpv/ffmpeg cannot demux
+// directly. Playlists are rewritten so every child URI is fetched back
+// through the proxy.
+package hlsproxy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"lobster/internal/httputil"
+)
+
+// Proxy is a running localhost HLS de-obfuscating proxy.
+type Proxy struct {
+	referer   string
+	userAgent string
+	base      string // http://127.0.0.1:PORT/p
+	srv       *http.Server
+	ln        net.Listener
+	client    *http.Client
+}
+
+var pngSig = []byte("\x89PNG\r\n\x1a\n")
+
+// uriAttrRe matches a URI="..." attribute in playlist tag lines
+// (EXT-X-KEY, EXT-X-MEDIA, EXT-X-I-FRAME-STREAM-INF, EXT-X-MAP).
+var uriAttrRe = regexp.MustCompile(`URI="([^"]*)"`)
+
+// New starts a proxy listening on a random loopback port. Referer and
+// userAgent (either may be empty) are sent on every upstream request.
+func New(referer, userAgent string) (*Proxy, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	p := &Proxy{
+		referer:   referer,
+		userAgent: userAgent,
+		base:      fmt.Sprintf("http://%s/p", ln.Addr().String()),
+		ln:        ln,
+		client:    httputil.NewClient(),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/p", p.handle)
+	p.srv = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go p.srv.Serve(ln)
+	return p, nil
+}
+
+// PlaylistURL returns the loopback URL a player should open to reach upstream
+// through this proxy.
+func (p *Proxy) PlaylistURL(upstream string) string {
+	return p.base + "?u=" + base64.RawURLEncoding.EncodeToString([]byte(upstream))
+}
+
+// Close shuts the proxy down.
+func (p *Proxy) Close() error {
+	if p.srv == nil {
+		return nil
+	}
+	return p.srv.Close()
+}
+
+func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) {
+	raw, err := base64.RawURLEncoding.DecodeString(r.URL.Query().Get("u"))
+	if err != nil {
+		http.Error(w, "bad upstream", http.StatusBadRequest)
+		return
+	}
+	upstream := string(raw)
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstream, nil)
+	if err != nil {
+		http.Error(w, "bad upstream", http.StatusBadRequest)
+		return
+	}
+	if p.referer != "" {
+		req.Header.Set("Referer", p.referer)
+	}
+	if p.userAgent != "" {
+		req.Header.Set("User-Agent", p.userAgent)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		http.Error(w, "upstream fetch failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		http.Error(w, "upstream read failed", http.StatusBadGateway)
+		return
+	}
+
+	if isPlaylist(body) {
+		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+		w.Write(p.rewritePlaylist(body, upstream))
+		return
+	}
+	w.Header().Set("Content-Type", "video/mp2t")
+	w.Write(stripPNG(body))
+}
+
+// isPlaylist reports whether body is an m3u8 playlist.
+func isPlaylist(body []byte) bool {
+	return bytes.HasPrefix(bytes.TrimSpace(body), []byte("#EXTM3U"))
+}
+
+// stripPNG removes a fake-PNG wrapper (…IEND<crc><payload>) so the real
+// MPEG-TS payload underneath is served. Clean payloads pass through untouched.
+func stripPNG(body []byte) []byte {
+	if !bytes.HasPrefix(body, pngSig) {
+		return body
+	}
+	if i := bytes.Index(body, []byte("IEND")); i >= 0 && i+8 <= len(body) {
+		return body[i+8:]
+	}
+	return body
+}
+
+// rewritePlaylist resolves every child URI relative to the playlist's own URL
+// and points it back at the proxy, so segments and sub-playlists are fetched
+// (and de-obfuscated) through this proxy too.
+func (p *Proxy) rewritePlaylist(body []byte, playlistURL string) []byte {
+	base, err := url.Parse(playlistURL)
+	if err != nil {
+		return body
+	}
+	resolve := func(ref string) string {
+		u, err := url.Parse(strings.TrimSpace(ref))
+		if err != nil {
+			return ref
+		}
+		return p.PlaylistURL(base.ResolveReference(u).String())
+	}
+
+	var out strings.Builder
+	for _, line := range strings.Split(string(body), "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			out.WriteString(line)
+		case strings.HasPrefix(trimmed, "#"):
+			// Rewrite any URI="..." attribute (keys, media, maps).
+			out.WriteString(uriAttrRe.ReplaceAllStringFunc(line, func(m string) string {
+				inner := uriAttrRe.FindStringSubmatch(m)[1]
+				return `URI="` + resolve(inner) + `"`
+			}))
+		default:
+			out.WriteString(resolve(line))
+		}
+		out.WriteByte('\n')
+	}
+	return []byte(out.String())
+}

--- a/internal/hlsproxy/hlsproxy.go
+++ b/internal/hlsproxy/hlsproxy.go
@@ -31,6 +31,11 @@ type Proxy struct {
 	client    *http.Client
 }
 
+// maxBodyBytes caps how much of an upstream response is buffered. Segments and
+// playlists are far smaller; anything past this is rejected rather than served
+// truncated.
+const maxBodyBytes = 64 << 20
+
 var pngSig = []byte("\x89PNG\r\n\x1a\n")
 
 // uriAttrRe matches a URI="..." attribute in playlist tag lines
@@ -97,9 +102,16 @@ func (p *Proxy) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	// Read one byte past the cap: io.ReadAll over a LimitReader stops at the
+	// limit with a nil error, so an oversized body would otherwise be served as
+	// a complete-looking but truncated segment.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyBytes+1))
 	if err != nil {
 		http.Error(w, "upstream read failed", http.StatusBadGateway)
+		return
+	}
+	if int64(len(body)) > maxBodyBytes {
+		http.Error(w, "upstream response too large", http.StatusBadGateway)
 		return
 	}
 

--- a/internal/hlsproxy/hlsproxy_test.go
+++ b/internal/hlsproxy/hlsproxy_test.go
@@ -195,3 +195,40 @@ func TestProxyAdvertisesRangeSupport(t *testing.T) {
 		t.Errorf("Content-Type = %q, want video/mp2t", got)
 	}
 }
+
+// A body larger than the read cap must fail loudly. io.ReadAll over a
+// LimitReader returns a short buffer and a nil error, so serving it would hand
+// the player a silently truncated segment that decodes as a corrupt stream.
+func TestProxyRejectsOversizedUpstreamBody(t *testing.T) {
+	oversized := int64(maxBodyBytes) + 1
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "video/mp2t")
+		buf := make([]byte, 1<<20)
+		for written := int64(0); written < oversized; {
+			n := int64(len(buf))
+			if remaining := oversized - written; remaining < n {
+				n = remaining
+			}
+			if _, err := w.Write(buf[:n]); err != nil {
+				return
+			}
+			written += n
+		}
+	}))
+	defer upstream.Close()
+
+	p, err := New("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	resp, err := http.Get(p.PlaylistURL(upstream.URL + "/huge.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 for an oversized upstream body", resp.StatusCode)
+	}
+}

--- a/internal/hlsproxy/hlsproxy_test.go
+++ b/internal/hlsproxy/hlsproxy_test.go
@@ -1,0 +1,126 @@
+package hlsproxy
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// pngWrap prefixes payload with a minimal fake-PNG header ending in IEND,
+// mimicking megaplay's segment obfuscation.
+func pngWrap(payload []byte) []byte {
+	hdr := []byte("\x89PNG\r\n\x1a\n" + "IHDRxxxx" + "IEND" + "crc0")
+	return append(hdr, payload...)
+}
+
+func TestProxyStripsPNGPrefixFromSegment(t *testing.T) {
+	tsPayload := []byte("\x47\x40\x11\x00actual-ts-bytes")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Referer") != "https://ref.example/" {
+			t.Errorf("upstream got Referer %q", r.Header.Get("Referer"))
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngWrap(tsPayload))
+	}))
+	defer upstream.Close()
+
+	p, err := New("https://ref.example/", "test-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	resp, err := http.Get(p.PlaylistURL(upstream.URL + "/seg0.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != string(tsPayload) {
+		t.Fatalf("segment not de-obfuscated: got %q", got)
+	}
+}
+
+func TestProxyPassesThroughCleanSegment(t *testing.T) {
+	clean := []byte("\x47plain-ts-no-png")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(clean)
+	}))
+	defer upstream.Close()
+
+	p, _ := New("", "")
+	defer p.Close()
+
+	resp, err := http.Get(p.PlaylistURL(upstream.URL + "/seg.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != string(clean) {
+		t.Fatalf("clean segment altered: got %q", got)
+	}
+}
+
+func TestProxyRewritesPlaylistURIs(t *testing.T) {
+	var mux *httptest.Server
+	mux = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/master.m3u8":
+			io.WriteString(w, "#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nvariant/index.m3u8\n")
+		case "/variant/index.m3u8":
+			io.WriteString(w, "#EXTM3U\n#EXTINF:4.0,\nseg0.ts\n#EXTINF:4.0,\nseg1.ts\n")
+		}
+	}))
+	defer mux.Close()
+
+	p, _ := New("", "")
+	defer p.Close()
+
+	// Master playlist: variant URI rewritten to a proxied absolute URL.
+	resp, err := http.Get(p.PlaylistURL(mux.URL + "/master.m3u8"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.Contains(string(body), p.base+"?u=") {
+		t.Fatalf("master URIs not rewritten to proxy: %s", body)
+	}
+	if strings.Contains(string(body), "variant/index.m3u8\n") {
+		t.Fatalf("raw variant URI leaked: %s", body)
+	}
+
+	// Follow the rewritten variant URI: its segment URIs must resolve to the
+	// correct absolute upstream path (variant/seg0.ts, not /seg0.ts).
+	var variantURL string
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, p.base) {
+			variantURL = line
+		}
+	}
+	resp2, err := http.Get(variantURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vbody, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	// The proxied segment URI carries the absolute upstream in its ?u= param;
+	// decode it and confirm it resolved against the variant's base path.
+	var segUpstream string
+	for _, line := range strings.Split(string(vbody), "\n") {
+		if strings.HasPrefix(line, p.base) {
+			u, _ := url.Parse(line)
+			raw, _ := base64.RawURLEncoding.DecodeString(u.Query().Get("u"))
+			segUpstream = string(raw)
+			break
+		}
+	}
+	if !strings.HasSuffix(segUpstream, "/variant/seg0.ts") {
+		t.Fatalf("segment URI not resolved against variant base: %q", segUpstream)
+	}
+}

--- a/internal/hlsproxy/hlsproxy_test.go
+++ b/internal/hlsproxy/hlsproxy_test.go
@@ -124,3 +124,74 @@ func TestProxyRewritesPlaylistURIs(t *testing.T) {
 		t.Fatalf("segment URI not resolved against variant base: %q", segUpstream)
 	}
 }
+
+// A player seeking inside a segment (or following #EXT-X-BYTERANGE) issues a
+// ranged GET. The proxy must answer it against the *de-obfuscated* bytes: the
+// PNG wrapper it strips shifts every offset, so forwarding the client's Range
+// upstream verbatim would return the wrong bytes.
+func TestProxyServesByteRangeOverDeobfuscatedPayload(t *testing.T) {
+	tsPayload := []byte("0123456789abcdef")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Range"); got != "" {
+			t.Errorf("upstream got Range %q; the wrapper makes offsets meaningless upstream", got)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngWrap(tsPayload))
+	}))
+	defer upstream.Close()
+
+	p, err := New("https://ref.example/", "test-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, p.PlaylistURL(upstream.URL+"/seg0.ts"), nil)
+	req.Header.Set("Range", "bytes=4-7")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", resp.StatusCode)
+	}
+	if got, want := resp.Header.Get("Content-Range"), "bytes 4-7/16"; got != want {
+		t.Errorf("Content-Range = %q, want %q", got, want)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "4567" {
+		t.Fatalf("ranged body = %q, want %q", body, "4567")
+	}
+}
+
+// Without a Range header the response must stay a plain 200 that advertises
+// range support, so a player knows it may seek.
+func TestProxyAdvertisesRangeSupport(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("\x47plain-ts"))
+	}))
+	defer upstream.Close()
+
+	p, err := New("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+
+	resp, err := http.Get(p.PlaylistURL(upstream.URL + "/seg0.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Accept-Ranges"); got != "bytes" {
+		t.Errorf("Accept-Ranges = %q, want bytes", got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "video/mp2t" {
+		t.Errorf("Content-Type = %q, want video/mp2t", got)
+	}
+}

--- a/internal/media/types.go
+++ b/internal/media/types.go
@@ -70,6 +70,10 @@ type Stream struct {
 	Quality   string     // Resolved quality
 	Referer   string     // Referer header required by the CDN (if any)
 	UserAgent string     // User-Agent header required by the CDN (if any)
+	// Deobfuscate marks an HLS stream whose segments are wrapped in a fake-PNG
+	// header (megaplay/ibyteimg) and must be served through the local
+	// de-obfuscating proxy; a plain player cannot demux them directly.
+	Deobfuscate bool
 }
 
 // Subtitle represents a subtitle track.

--- a/internal/player/deobfuscate.go
+++ b/internal/player/deobfuscate.go
@@ -1,0 +1,23 @@
+package player
+
+import (
+	"lobster/internal/hlsproxy"
+	"lobster/internal/media"
+)
+
+// wrapDeobfuscated routes a fake-PNG-obfuscated HLS stream through a local
+// proxy so the player receives clean MPEG-TS. For any other stream it is a
+// no-op. The returned cleanup func shuts the proxy down and must be deferred
+// by the caller; it is always safe to call.
+func wrapDeobfuscated(stream *media.Stream) (*media.Stream, func(), error) {
+	if stream == nil || !stream.Deobfuscate {
+		return stream, func() {}, nil
+	}
+	p, err := hlsproxy.New(stream.Referer, stream.UserAgent)
+	if err != nil {
+		return stream, func() {}, err
+	}
+	clone := *stream
+	clone.URL = p.PlaylistURL(stream.URL)
+	return &clone, func() { p.Close() }, nil
+}

--- a/internal/player/generic.go
+++ b/internal/player/generic.go
@@ -23,6 +23,12 @@ func (g *Generic) Available() bool {
 
 // Play launches the generic player. Position tracking is not supported.
 func (g *Generic) Play(stream *media.Stream, title string, startPos float64, subFiles []string) (PlayResult, error) {
+	stream, cleanup, err := wrapDeobfuscated(stream)
+	if err != nil {
+		return PlayResult{}, err
+	}
+	defer cleanup()
+
 	args := []string{stream.URL}
 
 	// Both iina and celluloid accept mpv-style flags

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -34,6 +34,12 @@ func (m *MPV) Available() bool {
 
 // Play launches mpv with the given stream and returns the final playback state.
 func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFiles []string) (PlayResult, error) {
+	stream, cleanup, err := wrapDeobfuscated(stream)
+	if err != nil {
+		return PlayResult{}, err
+	}
+	defer cleanup()
+
 	// Create randomized IPC path (Unix socket on Unix, named pipe on Windows)
 	ipc, err := newIPCSocket()
 	if err != nil {

--- a/internal/player/vlc.go
+++ b/internal/player/vlc.go
@@ -26,6 +26,12 @@ func (v *VLC) Available() bool {
 // Play launches VLC. VLC doesn't have IPC position tracking like mpv,
 // so we return zero position/duration.
 func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFiles []string) (PlayResult, error) {
+	stream, cleanup, err := wrapDeobfuscated(stream)
+	if err != nil {
+		return PlayResult{}, err
+	}
+	defer cleanup()
+
 	args := []string{
 		stream.URL,
 		"--meta-title", title,

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -144,6 +144,18 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
+	// AllAnime often indexes only the romaji or base title, so a full english
+	// title ("KAMUI: He's Behind You") can find nothing. Retry with the
+	// pre-colon base title, keeping only results that match the original query
+	// so a broad base ("KAMUI") can't surface unrelated shows.
+	if len(out) == 0 {
+		if base := baseTitle(query); base != "" {
+			alt, aerr := a.queryShows(map[string]any{"allowAdult": false, "allowUnknown": false, "query": base}, 40, "ALL")
+			if aerr == nil {
+				out = filterByTitle(alt, query)
+			}
+		}
+	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("no anime found for %q", query)
 	}
@@ -160,6 +172,41 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 		return out[i].Episodes > out[j].Episodes
 	})
 	return out, nil
+}
+
+// baseTitle returns the part of a title before its colon separator, or ""
+// when there is no meaningful prefix to retry with.
+func baseTitle(q string) string {
+	if i := strings.IndexAny(q, ":："); i > 0 {
+		return strings.TrimSpace(q[:i])
+	}
+	return ""
+}
+
+// normalizeTitle lowercases and strips everything but letters and digits so
+// punctuation and spacing differences don't block title comparison.
+func normalizeTitle(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// filterByTitle keeps results whose normalized title contains, or is
+// contained in, the normalized original query.
+func filterByTitle(results []media.SearchResult, query string) []media.SearchResult {
+	nq := normalizeTitle(query)
+	var out []media.SearchResult
+	for _, r := range results {
+		nr := normalizeTitle(r.Title)
+		if nr != "" && nq != "" && (strings.Contains(nq, nr) || strings.Contains(nr, nq)) {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // GetSeasons returns a single pseudo-season: AllAnime has no seasons.
@@ -212,7 +259,12 @@ func epNumber(es string, ordinal int) int {
 func (a *AllAnime) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
 	showID, episodeString, trans, ok := parseEpisodeID(episodeID)
 	if !ok {
-		return nil, fmt.Errorf("bad episode id %q", episodeID)
+		// Fallback-resolver form: "showID:season:episode", or "" for movies.
+		nid, err := resolveNumericEpisodeID(a.GetEpisodes, mediaID, episodeID)
+		if err != nil {
+			return nil, err
+		}
+		showID, episodeString, trans, _ = parseEpisodeID(nid)
 	}
 
 	// 1) Persisted-query GET for the encrypted source list (Origin gates tobeparsed).

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -152,7 +152,7 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 		if base := baseTitle(query); base != "" {
 			alt, aerr := a.queryShows(map[string]any{"allowAdult": false, "allowUnknown": false, "query": base}, 40, "ALL")
 			if aerr == nil {
-				out = filterByTitle(alt, query)
+				out = filterByTitle(alt, query, base)
 			}
 		}
 	}
@@ -195,14 +195,24 @@ func normalizeTitle(s string) string {
 	return b.String()
 }
 
-// filterByTitle keeps results whose normalized title contains, or is
-// contained in, the normalized original query.
-func filterByTitle(results []media.SearchResult, query string) []media.SearchResult {
-	nq := normalizeTitle(query)
+// filterByTitle keeps results from a base-title retry that plausibly are the
+// show the user asked for: either the title carries the whole query (AllAnime
+// indexed the full or suffixed name), or it is exactly the base title that was
+// searched (AllAnime indexed only the base). Plain substring containment is
+// too loose — for "KAMUI: He'"'"'s Behind You" it also accepts a show called
+// "Behind", which is a different show entirely.
+func filterByTitle(results []media.SearchResult, query, base string) []media.SearchResult {
+	nq, nb := normalizeTitle(query), normalizeTitle(base)
+	if nq == "" {
+		return nil
+	}
 	var out []media.SearchResult
 	for _, r := range results {
 		nr := normalizeTitle(r.Title)
-		if nr != "" && nq != "" && (strings.Contains(nq, nr) || strings.Contains(nr, nq)) {
+		if nr == "" {
+			continue
+		}
+		if strings.Contains(nr, nq) || (nb != "" && nr == nb) {
 			out = append(out, r)
 		}
 	}

--- a/internal/provider/allanime_numeric_test.go
+++ b/internal/provider/allanime_numeric_test.go
@@ -81,3 +81,37 @@ func TestAllAnimeSearchColonFallback(t *testing.T) {
 		t.Fatalf("want only the matching show, got %+v", res)
 	}
 }
+
+// The documented purpose of the colon retry is that AllAnime indexes only the
+// base title, so an entry literally named "Kamui" must survive the filter for
+// a query of "KAMUI: He's Behind You" — otherwise the retry can never return
+// anything and the whole fallback is dead code.
+func TestAllAnimeSearchColonFallbackKeepsBaseTitleEntry(t *testing.T) {
+	a := newTestAllAnime(map[string]string{
+		`KAMUI: He`: `{"data":{"shows":{"edges":[]}}}`,
+		`"query":"KAMUI"`: `{"data":{"shows":{"edges":[
+			{"_id":"kam","name":"Kamui","englishName":"Kamui","availableEpisodes":{"sub":6}}
+		]}}}`,
+	})
+	res, err := a.Search("KAMUI: He's Behind You")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) != 1 || res[0].ID != "kam" {
+		t.Fatalf("base-title entry was dropped, got %+v", res)
+	}
+}
+
+// Arbitrary substring containment is too loose: a show whose title merely
+// appears somewhere inside the query is not the show that was asked for.
+func TestAllAnimeSearchColonFallbackRejectsIncidentalSubstring(t *testing.T) {
+	a := newTestAllAnime(map[string]string{
+		`KAMUI: He`: `{"data":{"shows":{"edges":[]}}}`,
+		`"query":"KAMUI"`: `{"data":{"shows":{"edges":[
+			{"_id":"bh","name":"Behind","englishName":"Behind","availableEpisodes":{"sub":3}}
+		]}}}`,
+	})
+	if res, err := a.Search("KAMUI: He's Behind You"); err == nil && len(res) > 0 {
+		t.Fatalf("incidental substring match accepted: %+v", res)
+	}
+}

--- a/internal/provider/allanime_numeric_test.go
+++ b/internal/provider/allanime_numeric_test.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// The fallback resolver reconstructs episode IDs as "showID:season:episode"
+// (and passes "" for movies); Watch must accept those alongside native
+// "showID|episodeString|trans" IDs.
+func TestAllAnimeWatchNumericEpisodeID(t *testing.T) {
+	plain := `{"episode":{"sourceUrls":[{"sourceUrl":"--175b54575b53","sourceName":"S-mp4","priority":9}]}}`
+	blob := makeBlob(plain, "Xot36i3lK3:v1")
+	routes := map[string]string{
+		`"showId":"ReH"`: `{"data":{"show":{"_id":"ReH","availableEpisodesDetail":{"sub":["2","1"],"dub":[],"raw":[]}}}}`,
+		`episodeString`:  `{"data":{"tobeparsed":"` + blob + `"}}`,
+		`/clock.json`:    `{"links":[{"link":"https://cdn/master.m3u8"}]}`,
+	}
+
+	t.Run("resolver-style show:season:episode", func(t *testing.T) {
+		a := newTestAllAnime(routes)
+		st, err := a.Watch("ReH", "ReH:1:2", "Default", "1080")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.URL != "https://cdn/master.m3u8" {
+			t.Fatalf("stream URL = %q", st.URL)
+		}
+	})
+
+	t.Run("empty episode ID resolves episode 1", func(t *testing.T) {
+		a := newTestAllAnime(routes)
+		st, err := a.Watch("ReH", "", "Default", "1080")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.URL != "https://cdn/master.m3u8" {
+			t.Fatalf("stream URL = %q", st.URL)
+		}
+	})
+
+	t.Run("season beyond 1 is rejected", func(t *testing.T) {
+		a := newTestAllAnime(routes)
+		if _, err := a.Watch("ReH", "ReH:2:5", "Default", "1080"); err == nil || !strings.Contains(err.Error(), "season") {
+			t.Fatalf("want season rejection, got %v", err)
+		}
+	})
+
+	t.Run("episode not in catalog", func(t *testing.T) {
+		a := newTestAllAnime(routes)
+		if _, err := a.Watch("ReH", "ReH:1:9", "Default", "1080"); err == nil {
+			t.Fatal("want error for missing episode")
+		}
+	})
+
+	t.Run("malformed ID", func(t *testing.T) {
+		a := newTestAllAnime(routes)
+		if _, err := a.Watch("ReH", "ReH:x:2", "Default", "1080"); err == nil {
+			t.Fatal("want error for malformed ID")
+		}
+	})
+}
+
+// AllAnime often indexes only the romaji or base title, so a full english
+// title like "KAMUI: He's Behind You" finds nothing. Search must retry with
+// the pre-colon base title and keep only results matching the original query.
+func TestAllAnimeSearchColonFallback(t *testing.T) {
+	a := newTestAllAnime(map[string]string{
+		`KAMUI: He`: `{"data":{"shows":{"edges":[]}}}`,
+		`"query":"KAMUI"`: `{"data":{"shows":{"edges":[
+			{"_id":"ninja","name":"Ninja Kamui","englishName":"Ninja Kamui","availableEpisodes":{"sub":13}},
+			{"_id":"kam","name":"Ushiro no Shoumen Kamui-san","englishName":"KAMUI: He's Behind You","availableEpisodes":{"sub":6}},
+			{"_id":"gk","name":"Golden Kamuy","englishName":"Golden Kamuy","availableEpisodes":{"sub":12}}
+		]}}}`,
+	})
+	res, err := a.Search("KAMUI: He's Behind You")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) != 1 || res[0].ID != "kam" {
+		t.Fatalf("want only the matching show, got %+v", res)
+	}
+}

--- a/internal/provider/anipub.go
+++ b/internal/provider/anipub.go
@@ -71,17 +71,25 @@ func (p *AniPub) Search(query string) ([]media.SearchResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
-	// AniPub returns {"found":false} (an object) when nothing matches.
-	if t := bytes.TrimSpace(body); len(t) == 0 || t[0] != '[' {
-		return nil, fmt.Errorf("no anime found for %q", query)
-	}
-	var raw []struct {
+	type anipubHit struct {
 		Name  string `json:"Name"`
 		ID    int    `json:"Id"`
 		Image string `json:"Image"`
 	}
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, fmt.Errorf("search parse: %w", err)
+	var raw []anipubHit
+	t := bytes.TrimSpace(body)
+	switch {
+	case len(t) > 0 && t[0] == '[':
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return nil, fmt.Errorf("search parse: %w", err)
+		}
+	case len(t) > 0 && t[0] == '{':
+		// A single match comes back as a bare object; anything else
+		// object-shaped (e.g. {"found":false}) means no results.
+		var one anipubHit
+		if err := json.Unmarshal(body, &one); err == nil && one.ID != 0 && one.Name != "" {
+			raw = append(raw, one)
+		}
 	}
 	out := make([]media.SearchResult, 0, len(raw))
 	for _, r := range raw {
@@ -95,13 +103,20 @@ func (p *AniPub) Search(query string) ([]media.SearchResult, error) {
 	return out, nil
 }
 
-// Episode links carry the megaplay id in one of two shapes:
+// Episode links carry the stream reference in one of three shapes:
 //
-//	...gogoanime.com.by/streaming.php?...&ep=1465&...   (id 1465)
-//	...anipub.xyz/video/850/sub                          (id 850)
-var anipubEpRe = regexp.MustCompile(`(?:ep=|/video/)(\d+)`)
+//	...gogoanime.com.by/streaming.php?...&ep=1465&...   (megaplay id 1465)
+//	...anipub.xyz/video/850/sub                          (megaplay id 850)
+//	...anipub.xyz/play/63468/2/sub                       (MAL id 63468, ep 2)
+var (
+	anipubEpRe   = regexp.MustCompile(`(?:ep=|/video/)(\d+)`)
+	anipubPlayRe = regexp.MustCompile(`/play/(\d+)/(\d+)/`)
+)
 
-// episodeMegaplayIDs returns the ordered megaplay episode ids for a show id.
+// episodeMegaplayIDs returns the ordered per-episode stream refs for a show
+// id: either a bare megaplay id (resolved via /stream/s-2/) or "mal:{id}:{ep}"
+// (resolved via /stream/mal/). In the /play/ shape the top-level link is
+// episode 1 and the ep array continues from episode 2, so both are read.
 func (p *AniPub) episodeMegaplayIDs(showID string) ([]string, error) {
 	body, err := p.get(anipubBase+"/v1/api/details/"+showID, nil)
 	if err != nil {
@@ -109,7 +124,8 @@ func (p *AniPub) episodeMegaplayIDs(showID string) ([]string, error) {
 	}
 	var d struct {
 		Local struct {
-			Ep []struct {
+			Link string `json:"link"`
+			Ep   []struct {
 				Link string `json:"link"`
 			} `json:"ep"`
 		} `json:"local"`
@@ -117,11 +133,29 @@ func (p *AniPub) episodeMegaplayIDs(showID string) ([]string, error) {
 	if err := json.Unmarshal(body, &d); err != nil {
 		return nil, err
 	}
-	ids := make([]string, 0, len(d.Local.Ep))
+	links := make([]string, 0, len(d.Local.Ep)+1)
+	if d.Local.Link != "" {
+		links = append(links, d.Local.Link)
+	}
 	for _, e := range d.Local.Ep {
-		if m := anipubEpRe.FindStringSubmatch(e.Link); m != nil {
-			ids = append(ids, m[1])
+		links = append(links, e.Link)
+	}
+	ids := make([]string, 0, len(links))
+	seen := make(map[string]bool, len(links))
+	for _, l := range links {
+		var id string
+		if m := anipubPlayRe.FindStringSubmatch(l); m != nil {
+			id = "mal:" + m[1] + ":" + m[2]
+		} else if m := anipubEpRe.FindStringSubmatch(l); m != nil {
+			id = m[1]
+		} else {
+			continue
 		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
 	}
 	return ids, nil
 }
@@ -134,7 +168,13 @@ func (p *AniPub) megaplayStream(megaplayID string, dub bool) (*media.Stream, err
 	if dub {
 		audio = "dub"
 	}
-	page, err := p.get(fmt.Sprintf("%s/stream/s-2/%s/%s", megaplayBase, megaplayID, audio),
+	streamURL := fmt.Sprintf("%s/stream/s-2/%s/%s", megaplayBase, megaplayID, audio)
+	if rest, ok := strings.CutPrefix(megaplayID, "mal:"); ok {
+		if malID, epNum, ok := strings.Cut(rest, ":"); ok {
+			streamURL = fmt.Sprintf("%s/stream/mal/%s/%s/%s", megaplayBase, malID, epNum, audio)
+		}
+	}
+	page, err := p.get(streamURL,
 		map[string]string{"Referer": "https://gogoanime.com.by/"})
 	if err != nil {
 		return nil, err
@@ -164,7 +204,7 @@ func (p *AniPub) megaplayStream(megaplayID string, dub bool) (*media.Stream, err
 	if src.Sources.File == "" {
 		return nil, fmt.Errorf("megaplay: no source file")
 	}
-	st := &media.Stream{URL: src.Sources.File, Referer: "https://megaplay.buzz/"}
+	st := &media.Stream{URL: src.Sources.File, Referer: "https://megaplay.buzz/", Deobfuscate: true}
 	for _, tr := range src.Tracks {
 		if tr.Kind != "captions" {
 			continue
@@ -283,6 +323,15 @@ func (p *AniPub) GetEpisodes(id, seasonID string) ([]media.Episode, error) {
 }
 
 func (p *AniPub) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	// Native refs are bare megaplay ids ("1466") or "mal:{id}:{ep}"; anything
+	// else with colons (or empty) is the fallback-resolver numeric form.
+	if episodeID == "" || (!strings.HasPrefix(episodeID, "mal:") && strings.Contains(episodeID, ":")) {
+		nid, err := resolveNumericEpisodeID(p.GetEpisodes, mediaID, episodeID)
+		if err != nil {
+			return nil, err
+		}
+		episodeID = nid
+	}
 	return p.megaplayStream(episodeID, strings.EqualFold(server, "dub"))
 }
 

--- a/internal/provider/anipub_test.go
+++ b/internal/provider/anipub_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	"lobster/internal/media"
@@ -35,6 +36,9 @@ func TestAniPubResolveByTitle(t *testing.T) {
 	if st.Referer != "https://megaplay.buzz/" {
 		t.Fatalf("referer = %q", st.Referer)
 	}
+	if !st.Deobfuscate {
+		t.Fatal("megaplay stream must be flagged for de-obfuscation")
+	}
 }
 
 func TestAniPubVideoFormatAndNoMatch(t *testing.T) {
@@ -63,5 +67,102 @@ func TestAniPubSearch(t *testing.T) {
 	res, err := p.Search("naruto")
 	if err != nil || len(res) != 1 || res[0].ID != "20" || res[0].Title != "Naruto" || res[0].Type != media.TV {
 		t.Fatalf("search wrong: %v / %+v", err, res)
+	}
+}
+
+// AniPub's 2026 details shape: the top-level "link" is episode 1 and "ep"
+// holds episodes 2..N, all as /play/{malID}/{ep}/{audio} links that resolve
+// through megaplay's /stream/mal/ route.
+func TestAniPubPlayLinkFormat(t *testing.T) {
+	routes := map[string]string{
+		`/api/search/KAMUI`:       `[{"Name":"Ninja Kamui","Id":2267,"finder":"ninja-kamui"},{"Name":"KAMUI: He's Behind You","Id":8420,"finder":"kamui-he-s-behind-you"}]`,
+		`/v1/api/details/8420`:    `{"local":{"_id":8420,"name":"Episode 1","link":"src=https://anipub.xyz/play/63468/1/sub","type":"iframe","ep":[{"link":"src=https://anipub.xyz/play/63468/2/sub"},{"link":"src=https://anipub.xyz/play/63468/3/sub"}]}}`,
+		`/stream/mal/63468/1/sub`: `<div data-id="177688"></div>`,
+		`/stream/mal/63468/3/sub`: `<div data-id="177690"></div>`,
+		`getSources?id=177688`:    `{"sources":{"file":"https://cdn/kamui-ep1.m3u8"},"tracks":[]}`,
+		`getSources?id=177690`:    `{"sources":{"file":"https://cdn/kamui-ep3.m3u8"},"tracks":[]}`,
+	}
+
+	// Episode 1 comes from the top-level link, which the old parser ignored.
+	p := newTestAniPub(routes)
+	st, err := p.ResolveByTitle("KAMUI: He's Behind You", 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.URL != "https://cdn/kamui-ep1.m3u8" {
+		t.Fatalf("ep1 URL = %q", st.URL)
+	}
+
+	// Episode 3 comes from the ep array, offset by the top-level link.
+	st, err = p.ResolveByTitle("KAMUI: He's Behind You", 3, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.URL != "https://cdn/kamui-ep3.m3u8" {
+		t.Fatalf("ep3 URL = %q", st.URL)
+	}
+}
+
+// The fallback resolver reconstructs episode IDs as "showID:season:episode"
+// (and passes "" for movies); Watch must accept those alongside native
+// megaplay refs.
+func TestAniPubWatchNumericEpisodeID(t *testing.T) {
+	routes := map[string]string{
+		`/v1/api/details/8420`:    `{"local":{"link":"src=https://anipub.xyz/play/63468/1/sub","ep":[{"link":"src=https://anipub.xyz/play/63468/2/sub"}]}}`,
+		`/stream/mal/63468/2/sub`: `<div data-id="9"></div>`,
+		`/stream/mal/63468/1/sub`: `<div data-id="8"></div>`,
+		`getSources?id=9`:         `{"sources":{"file":"https://cdn/ep2.m3u8"},"tracks":[]}`,
+		`getSources?id=8`:         `{"sources":{"file":"https://cdn/ep1.m3u8"},"tracks":[]}`,
+	}
+
+	t.Run("resolver-style show:season:episode", func(t *testing.T) {
+		st, err := newTestAniPub(routes).Watch("8420", "8420:1:2", "Default", "1080")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.URL != "https://cdn/ep2.m3u8" {
+			t.Fatalf("URL = %q", st.URL)
+		}
+	})
+
+	t.Run("empty episode ID resolves episode 1", func(t *testing.T) {
+		st, err := newTestAniPub(routes).Watch("8420", "", "Default", "1080")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.URL != "https://cdn/ep1.m3u8" {
+			t.Fatalf("URL = %q", st.URL)
+		}
+	})
+
+	t.Run("season beyond 1 is rejected", func(t *testing.T) {
+		if _, err := newTestAniPub(routes).Watch("8420", "8420:2:1", "Default", "1080"); err == nil || !strings.Contains(err.Error(), "season") {
+			t.Fatalf("want season rejection, got %v", err)
+		}
+	})
+
+	t.Run("native megaplay ref still works", func(t *testing.T) {
+		st, err := newTestAniPub(routes).Watch("8420", "mal:63468:2", "sub", "1080")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.URL != "https://cdn/ep2.m3u8" {
+			t.Fatalf("URL = %q", st.URL)
+		}
+	})
+}
+
+// AniPub returns a bare object (not a one-element array) when exactly one
+// show matches, e.g. an exact full-title search.
+func TestAniPubSearchSingleObjectResult(t *testing.T) {
+	p := newTestAniPub(map[string]string{
+		`/api/search/KAMUI`: `{"Name":"KAMUI: He's Behind You","Id":8420,"finder":"kamui-he-s-behind-you","Image":"https://cdn/img.jpg"}`,
+	})
+	res, err := p.Search("KAMUI: He's Behind You")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) != 1 || res[0].ID != "8420" || res[0].Title != "KAMUI: He's Behind You" {
+		t.Fatalf("single-object result wrong: %+v", res)
 	}
 }

--- a/internal/provider/episodeid.go
+++ b/internal/provider/episodeid.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"lobster/internal/media"
+)
+
+// resolveNumericEpisodeID converts a fallback-resolver episode ID
+// ("showID:season:episode", or "" meaning episode 1 of mediaID) into the
+// provider's native episode ID by looking up its episode catalog. Anime
+// providers have no season concept — multi-season shows are separate entries
+// — so anything beyond season 1 is refused rather than risking playback of
+// the wrong episode.
+func resolveNumericEpisodeID(getEpisodes func(id, seasonID string) ([]media.Episode, error), mediaID, episodeID string) (string, error) {
+	showID, epNum := mediaID, 1
+	if episodeID != "" {
+		parts := strings.SplitN(episodeID, ":", 3)
+		if len(parts) != 3 {
+			return "", fmt.Errorf("bad episode id %q", episodeID)
+		}
+		season, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return "", fmt.Errorf("bad episode id %q", episodeID)
+		}
+		if season > 1 {
+			return "", fmt.Errorf("no season %d (seasons are separate shows)", season)
+		}
+		epNum, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return "", fmt.Errorf("bad episode id %q", episodeID)
+		}
+		showID = parts[0]
+	}
+	eps, err := getEpisodes(showID, showID)
+	if err != nil {
+		return "", err
+	}
+	for _, ep := range eps {
+		if ep.Number == epNum {
+			return ep.ID, nil
+		}
+	}
+	return "", fmt.Errorf("episode %d not found for %s", epNum, showID)
+}

--- a/internal/provider/soap2day.go
+++ b/internal/provider/soap2day.go
@@ -63,56 +63,20 @@ type flixcdnDecrypted struct {
 
 // --- Provider interface ---
 
-// Search uses TMDB's free trending search endpoint (no API key needed).
+// Search uses TMDB's keyless multi-search endpoint.
 func (s *Soap2Day) Search(query string) ([]media.SearchResult, error) {
-	searchURL := fmt.Sprintf("%s/search/trending?query=%s",
-		tmdbSearchBase, url.QueryEscape(query))
-
-	body, err := s.fetchWithReferer(searchURL, tmdbSearchBase+"/")
+	body, err := s.fetchWithReferer(tmdbMultiSearchURL(tmdbBaseURL, query), tmdbBaseURL+"/")
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
 
-	var resp tmdbSearchResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("search: parsing response: %w", err)
+	results, err := parseTMDBSearchResults(body, tmdbBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
 	}
-
-	var results []media.SearchResult
-	for _, raw := range resp.Results {
-		// Skip non-object entries (TMDB includes suggestion strings in the array)
-		if len(raw) == 0 || raw[0] != '{' {
-			continue
-		}
-
-		var item tmdbSearchResult
-		if err := json.Unmarshal(raw, &item); err != nil {
-			continue
-		}
-
-		if item.MediaType != "movie" && item.MediaType != "tv" {
-			continue
-		}
-
-		mt := media.Movie
-		if item.MediaType == "tv" {
-			mt = media.TV
-		}
-
-		results = append(results, media.SearchResult{
-			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title:  item.displayTitle(),
-			Type:   mt,
-			Year:   item.year(),
-			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
-			Poster: tmdbPosterURL(item.PosterPath),
-		})
-	}
-
 	if len(results) == 0 {
 		return nil, fmt.Errorf("no results found for %q", query)
 	}
-
 	return results, nil
 }
 

--- a/internal/provider/tbcpl.go
+++ b/internal/provider/tbcpl.go
@@ -171,11 +171,10 @@ var tbcplDirectServers = []tbcplDirectServer{
 	{Name: "Drag", SR: "5"},
 }
 
-// Search uses TMDB's no-key web search endpoint for reliable title lookup.
+// Search uses TMDB's keyless multi-search endpoint for reliable title lookup.
 // The returned TMDB IDs are then used by 1Shows/Vidzee.
 func (t *TBCPL) Search(query string) ([]media.SearchResult, error) {
-	searchURL := fmt.Sprintf("%s/search/trending?query=%s",
-		strings.TrimRight(t.tmdbBaseURL, "/"), url.QueryEscape(query))
+	searchURL := tmdbMultiSearchURL(t.tmdbBaseURL, query)
 
 	body, err := t.fetch(searchURL, strings.TrimRight(t.tmdbBaseURL, "/")+"/", "application/json, text/html, */*")
 	if err != nil {
@@ -192,7 +191,7 @@ func (t *TBCPL) Search(query string) ([]media.SearchResult, error) {
 	return results, nil
 }
 
-// GetDetails returns cached metadata from search/trending results. 1Shows detail
+// GetDetails returns cached metadata from search results. 1Shows detail
 // endpoints currently reject direct server-side requests, so this is best-effort.
 func (t *TBCPL) GetDetails(id string) (*media.ContentDetail, error) {
 	t.mu.RLock()

--- a/internal/provider/tbcpl_test.go
+++ b/internal/provider/tbcpl_test.go
@@ -30,7 +30,7 @@ func TestNewTBCPL(t *testing.T) {
 
 func TestTBCPLSearchAndDetails(t *testing.T) {
 	p, _, cleanup := newTestTBCPL(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/search/trending" {
+		if r.URL.Path != "/search/multi" {
 			http.NotFound(w, r)
 			return
 		}

--- a/internal/provider/tmdb.go
+++ b/internal/provider/tmdb.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"lobster/internal/httputil"
+	"lobster/internal/media"
 )
 
 // --- TMDB shared const, types, and helpers ---
@@ -49,6 +50,53 @@ func (r *tmdbSearchResult) year() string {
 		return date[:4]
 	}
 	return ""
+}
+
+// tmdbMultiSearchURL builds TMDB's keyless multi-search URL. Use this for every
+// user-facing search: /search/multi returns up to 20 complete result objects.
+// The /search/trending endpoint is a typeahead — it returns only the top two or
+// three objects followed by HTML <span> name suggestions that every parser here
+// discards, which made a query like "spiderman" surface a single film.
+func tmdbMultiSearchURL(base, query string) string {
+	return fmt.Sprintf("%s/search/multi?query=%s",
+		strings.TrimRight(base, "/"), url.QueryEscape(query))
+}
+
+// parseTMDBSearchResults decodes a TMDB search payload into search results,
+// skipping suggestion strings and non-movie/tv entries (people, collections).
+func parseTMDBSearchResults(body []byte, base string) ([]media.SearchResult, error) {
+	var resp tmdbSearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	base = strings.TrimRight(base, "/")
+	var results []media.SearchResult
+	for _, raw := range resp.Results {
+		if len(raw) == 0 || raw[0] != '{' {
+			continue
+		}
+		var item tmdbSearchResult
+		if err := json.Unmarshal(raw, &item); err != nil {
+			continue
+		}
+		if item.MediaType != "movie" && item.MediaType != "tv" {
+			continue
+		}
+		mt := media.Movie
+		if item.MediaType == "tv" {
+			mt = media.TV
+		}
+		results = append(results, media.SearchResult{
+			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
+			Title:  item.displayTitle(),
+			Type:   mt,
+			Year:   item.year(),
+			URL:    fmt.Sprintf("%s/%s/%d", base, item.MediaType, item.ID),
+			Poster: tmdbPosterURL(item.PosterPath),
+		})
+	}
+	return results, nil
 }
 
 // tmdbPosterURL builds a full TMDB poster image URL from a poster path.
@@ -143,8 +191,7 @@ func TMDBPoster(title, year string, isTV bool) string {
 // and whether the outcome is cacheable. A network/parse error returns ("", false)
 // so the caller retries on the next selection instead of caching the failure.
 func tmdbPosterLookup(title, year string, isTV bool) (string, bool) {
-	endpoint := fmt.Sprintf("%s/search/trending?query=%s",
-		strings.TrimRight(tmdbBaseURL, "/"), url.QueryEscape(title))
+	endpoint := tmdbMultiSearchURL(tmdbBaseURL, title)
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", false

--- a/internal/provider/tmdbsearch_test.go
+++ b/internal/provider/tmdbsearch_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// tmdbMultiFixture mirrors the shape of TMDB's /search/multi response: full
+// result objects for every match. The /search/trending typeahead endpoint we
+// used before returned only the top 2-3 objects plus HTML <span> name
+// suggestions (which every parser skips), so a query like "spiderman" showed a
+// single film instead of the whole franchise.
+const tmdbMultiFixture = `{"results":[
+{"media_type":"movie","id":557,"title":"Spider-Man","release_date":"2002-05-01","poster_path":"/a.jpg"},
+{"media_type":"movie","id":558,"title":"Spider-Man 2","release_date":"2004-07-17","poster_path":"/b.jpg"},
+{"media_type":"movie","id":559,"title":"Spider-Man 3","release_date":"2007-05-01","poster_path":"/c.jpg"},
+{"media_type":"movie","id":634649,"title":"Spider-Man: No Way Home","release_date":"2021-12-15","poster_path":"/d.jpg"},
+{"media_type":"tv","id":888,"name":"Spider-Man","first_air_date":"1994-11-19","poster_path":"/e.jpg"},
+{"media_type":"person","id":4646747,"name":"Spiderman Dato"},
+"<span data-media-type=\"/movie\" data-search-name=\"Spider-Man\">Spider-Man</span>"
+]}`
+
+// newTMDBStub serves the multi-search fixture and records which path was hit.
+func newTMDBStub(t *testing.T) (*httptest.Server, *string) {
+	t.Helper()
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if r.URL.Path != "/search/multi" {
+			http.Error(w, "wrong endpoint", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(tmdbMultiFixture))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &gotPath
+}
+
+func TestTMDBBackedSearchUsesMultiEndpoint(t *testing.T) {
+	srv, gotPath := newTMDBStub(t)
+
+	old := tmdbBaseURL
+	tmdbBaseURL = srv.URL
+	t.Cleanup(func() { tmdbBaseURL = old })
+
+	tbcpl := NewTBCPL("tbcpl")
+	tbcpl.tmdbBaseURL = srv.URL
+
+	cases := []struct {
+		name string
+		p    Provider
+	}{
+		{"soap2day", NewSoap2Day()},
+		{"vidnest", NewVidNest()},
+		{"vaplayer", NewVaPlayer()},
+		{"tbcpl", tbcpl},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := tc.p.Search("spiderman")
+			if err != nil {
+				t.Fatalf("Search: %v", err)
+			}
+			if *gotPath != "/search/multi" {
+				t.Errorf("hit %q, want /search/multi", *gotPath)
+			}
+			// 5 movie/tv entries; the person and the <span> suggestion are dropped.
+			if len(results) != 5 {
+				t.Fatalf("got %d results, want 5: %+v", len(results), results)
+			}
+			if results[0].Title != "Spider-Man" || results[0].Year != "2002" {
+				t.Errorf("first result = %q (%s), want Spider-Man (2002)", results[0].Title, results[0].Year)
+			}
+			if results[3].Title != "Spider-Man: No Way Home" {
+				t.Errorf("fourth result = %q, want Spider-Man: No Way Home", results[3].Title)
+			}
+		})
+	}
+}

--- a/internal/provider/vaplayer.go
+++ b/internal/provider/vaplayer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -32,8 +31,10 @@ func NewVaPlayer() *VaPlayer {
 }
 
 // vaplayerResponse is the JSON response from the vaplayer API.
+// status_code is a string ("200") on success but a bare number (404) on
+// failure, so it must be decoded as json.Number to handle both.
 type vaplayerResponse struct {
-	StatusCode string `json:"status_code"`
+	StatusCode json.Number `json:"status_code"`
 	Data       struct {
 		Title      string   `json:"title"`
 		IMDBID     string   `json:"imdb_id"`
@@ -50,18 +51,15 @@ type vaplayerResponse struct {
 	} `json:"data"`
 }
 
-// Search uses TMDB's no-key web search endpoint (same as Soap2Day/VidNest).
+// Search uses TMDB's keyless multi-search endpoint (same as Soap2Day/VidNest).
 func (vp *VaPlayer) Search(query string) ([]media.SearchResult, error) {
-	searchURL := fmt.Sprintf("%s/search/trending?query=%s",
-		tmdbSearchBase, url.QueryEscape(query))
-
-	req, err := http.NewRequest(http.MethodGet, searchURL, nil)
+	req, err := http.NewRequest(http.MethodGet, tmdbMultiSearchURL(tmdbBaseURL, query), nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0")
 	req.Header.Set("Accept", "application/json, text/html, */*")
-	req.Header.Set("Referer", tmdbSearchBase+"/")
+	req.Header.Set("Referer", tmdbBaseURL+"/")
 
 	resp, err := vp.client.Do(req)
 	if err != nil {
@@ -78,37 +76,10 @@ func (vp *VaPlayer) Search(query string) ([]media.SearchResult, error) {
 		return nil, fmt.Errorf("vaplayer search: %w", err)
 	}
 
-	var tmdbResp tmdbSearchResponse
-	if err := json.Unmarshal(body, &tmdbResp); err != nil {
+	results, err := parseTMDBSearchResults(body, tmdbBaseURL)
+	if err != nil {
 		return nil, fmt.Errorf("vaplayer search: %w", err)
 	}
-
-	var results []media.SearchResult
-	for _, raw := range tmdbResp.Results {
-		if len(raw) == 0 || raw[0] != '{' {
-			continue
-		}
-		var item tmdbSearchResult
-		if err := json.Unmarshal(raw, &item); err != nil {
-			continue
-		}
-		if item.MediaType != "movie" && item.MediaType != "tv" {
-			continue
-		}
-		mt := media.Movie
-		if item.MediaType == "tv" {
-			mt = media.TV
-		}
-		results = append(results, media.SearchResult{
-			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title:  item.displayTitle(),
-			Type:   mt,
-			Year:   item.year(),
-			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
-			Poster: tmdbPosterURL(item.PosterPath),
-		})
-	}
-
 	if len(results) == 0 {
 		return nil, fmt.Errorf("no results found for %q", query)
 	}
@@ -350,7 +321,7 @@ func (vp *VaPlayer) fetchAPI(apiURL string) (*vaplayerResponse, error) {
 		return nil, fmt.Errorf("parsing response: %w", err)
 	}
 
-	if result.StatusCode != "200" {
+	if result.StatusCode.String() != "200" {
 		return nil, fmt.Errorf("API error: status %s", result.StatusCode)
 	}
 

--- a/internal/provider/vaplayer_test.go
+++ b/internal/provider/vaplayer_test.go
@@ -1,0 +1,37 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVaplayerResponseStatusCode(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "success returns status_code as string",
+			body: `{"status_code":"200","data":{"stream_urls":["https://example.com/a.m3u8"]}}`,
+			want: "200",
+		},
+		{
+			name: "not found returns status_code as bare number",
+			body: `{"status_code":404}`,
+			want: "404",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resp vaplayerResponse
+			if err := json.Unmarshal([]byte(tt.body), &resp); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if got := resp.StatusCode.String(); got != tt.want {
+				t.Errorf("StatusCode = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/vidnest.go
+++ b/internal/provider/vidnest.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,49 +51,17 @@ func NewVidNest() *VidNest {
 	}
 }
 
-// Search uses TMDB's free trending search endpoint (same as Soap2Day).
+// Search uses TMDB's keyless multi-search endpoint (same as Soap2Day).
 func (v *VidNest) Search(query string) ([]media.SearchResult, error) {
-	searchURL := fmt.Sprintf("%s/search/trending?query=%s",
-		tmdbSearchBase, url.QueryEscape(query))
-
-	body, err := v.fetchTMDB(searchURL)
+	body, err := v.fetchTMDB(tmdbMultiSearchURL(tmdbBaseURL, query))
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
 
-	var resp tmdbSearchResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("search: parsing response: %w", err)
+	results, err := parseTMDBSearchResults(body, tmdbBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
 	}
-
-	var results []media.SearchResult
-	for _, raw := range resp.Results {
-		if len(raw) == 0 || raw[0] != '{' {
-			continue
-		}
-		var item tmdbSearchResult
-		if err := json.Unmarshal(raw, &item); err != nil {
-			continue
-		}
-		if item.MediaType != "movie" && item.MediaType != "tv" {
-			continue
-		}
-
-		mt := media.Movie
-		if item.MediaType == "tv" {
-			mt = media.TV
-		}
-
-		results = append(results, media.SearchResult{
-			ID:     fmt.Sprintf("%s/%d", item.MediaType, item.ID),
-			Title:  item.displayTitle(),
-			Type:   mt,
-			Year:   item.year(),
-			URL:    fmt.Sprintf("%s/%s/%d", tmdbSearchBase, item.MediaType, item.ID),
-			Poster: tmdbPosterURL(item.PosterPath),
-		})
-	}
-
 	if len(results) == 0 {
 		return nil, fmt.Errorf("no results found for %q", query)
 	}

--- a/internal/resolver/candidates_test.go
+++ b/internal/resolver/candidates_test.go
@@ -1,0 +1,77 @@
+package resolver
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// The user picked the 2002 film, but a provider's own re-search for the bare
+// title "Spider-Man" ranks the sequel that is currently in cinemas first — so
+// trusting the provider's ordering played a cam/dub of the wrong movie. The
+// requested ID and year must decide the ordering instead.
+func TestRankCandidatesPrefersRequestedIDAndYear(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "movie/969681", Title: "Spider-Man: Brand New Day", Type: media.Movie, Year: "2026"},
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002"},
+		{ID: "movie/315635", Title: "Spider-Man: Homecoming", Type: media.Movie, Year: "2017"},
+	}
+
+	t.Run("exact ID wins", func(t *testing.T) {
+		req := Request{ID: "movie/557", Title: "Spider-Man", Year: "2002", MediaType: media.Movie}
+		got := candidatesFor(results, req)
+		if got[0].ID != "movie/557" {
+			t.Fatalf("first candidate = %s (%s), want movie/557", got[0].ID, got[0].Title)
+		}
+	})
+
+	t.Run("year disambiguates when the ID is a foreign format", func(t *testing.T) {
+		// A provider with its own slug IDs can't match on ID, so title+year must.
+		req := Request{ID: "movie/watch-spider-man-1234", Title: "Spider-Man", Year: "2002", MediaType: media.Movie}
+		got := candidatesFor(results, req)
+		if got[0].ID != "movie/557" {
+			t.Fatalf("first candidate = %s (%s), want movie/557", got[0].ID, got[0].Title)
+		}
+	})
+
+	t.Run("exact title wins when no year is known", func(t *testing.T) {
+		req := Request{Title: "Spider-Man", MediaType: media.Movie}
+		got := candidatesFor(results, req)
+		if got[0].ID != "movie/557" {
+			t.Fatalf("first candidate = %s (%s), want movie/557", got[0].ID, got[0].Title)
+		}
+	})
+
+	t.Run("all candidates are kept as fallbacks", func(t *testing.T) {
+		req := Request{ID: "movie/557", Title: "Spider-Man", Year: "2002", MediaType: media.Movie}
+		if got := candidatesFor(results, req); len(got) != 3 {
+			t.Fatalf("len = %d, want 3", len(got))
+		}
+	})
+}
+
+// A ±1 year drift between catalogs must not demote an otherwise exact match
+// below an unrelated title.
+func TestRankCandidatesToleratesYearDrift(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "movie/2", Title: "Spider-Man: Brand New Day", Type: media.Movie, Year: "2026"},
+		{ID: "movie/1", Title: "Spider-Man", Type: media.Movie, Year: "2003"},
+	}
+	req := Request{Title: "Spider-Man", Year: "2002", MediaType: media.Movie}
+	if got := candidatesFor(results, req); got[0].ID != "movie/1" {
+		t.Fatalf("first candidate = %s, want movie/1", got[0].ID)
+	}
+}
+
+// Media type still filters first: a TV request never plays the film.
+func TestCandidatesForKeepsMediaTypeFilter(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002"},
+		{ID: "tv/888", Title: "Spider-Man", Type: media.TV, Year: "1994"},
+	}
+	req := Request{Title: "Spider-Man", Year: "1994", MediaType: media.TV}
+	got := candidatesFor(results, req)
+	if len(got) != 1 || got[0].ID != "tv/888" {
+		t.Fatalf("got %+v, want only tv/888", got)
+	}
+}

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -2,6 +2,9 @@ package resolver
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"lobster/internal/extract"
@@ -58,8 +61,16 @@ const MaxCandidates = 5
 const maxCandidates = MaxCandidates
 
 // Request parameterizes a single stream-resolution attempt.
+//
+// ID and Year identify the exact work the user picked. Each provider still
+// re-searches by Title in its own catalog (IDs are not portable across all of
+// them), so without those two fields the provider's own relevance ordering
+// decides — and for a franchise that means whatever sequel is in cinemas right
+// now, not the film that was selected.
 type Request struct {
+	ID        string
 	Title     string
+	Year      string
 	MediaType media.MediaType
 	Season    int
 	Episode   int
@@ -76,7 +87,7 @@ func resolveWithProvider(p provider.Provider, req Request, log func(string, ...a
 		return nil, "search", fmt.Errorf("search failed: %w", err)
 	}
 
-	candidates := fallbackCandidates(results, req.MediaType)
+	candidates := candidatesFor(results, req)
 	if len(candidates) == 0 {
 		return nil, "match", fmt.Errorf("no matching result for %q", req.Title)
 	}
@@ -114,6 +125,20 @@ func FallbackCandidates(results []media.SearchResult, mediaType media.MediaType)
 }
 
 func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
+	return truncateCandidates(dedupeByType(results, mediaType))
+}
+
+// truncateCandidates caps a candidate list at MaxCandidates.
+func truncateCandidates(candidates []media.SearchResult) []media.SearchResult {
+	if len(candidates) > maxCandidates {
+		return candidates[:maxCandidates]
+	}
+	return candidates
+}
+
+// dedupeByType keeps the results matching mediaType (falling back to the others
+// when none do), deduplicated, in provider order.
+func dedupeByType(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
 	var sameType []media.SearchResult
 	var otherType []media.SearchResult
 	seen := make(map[string]bool)
@@ -138,14 +163,85 @@ func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType)
 		}
 	}
 
-	candidates := sameType
-	if len(candidates) == 0 {
-		candidates = otherType
+	if len(sameType) > 0 {
+		return sameType
 	}
-	if len(candidates) > maxCandidates {
-		candidates = candidates[:maxCandidates]
+	return otherType
+}
+
+// candidatesFor filters results to the requested media type, then orders them
+// by how well they match the work the user actually picked, best first. The
+// provider's own relevance ordering is only the tiebreaker.
+func candidatesFor(results []media.SearchResult, req Request) []media.SearchResult {
+	// Rank before capping at MaxCandidates: the right match is often outside a
+	// provider's own top five for a franchise title.
+	candidates := dedupeByType(results, req.MediaType)
+
+	scored := make([]struct {
+		result media.SearchResult
+		score  int
+	}, len(candidates))
+	for i, c := range candidates {
+		scored[i].result = c
+		scored[i].score = candidateScore(c, req)
 	}
-	return candidates
+	sort.SliceStable(scored, func(a, b int) bool { return scored[a].score > scored[b].score })
+
+	ranked := make([]media.SearchResult, len(scored))
+	for i, s := range scored {
+		ranked[i] = s.result
+	}
+	return truncateCandidates(ranked)
+}
+
+// candidateScore rates how confidently a search result is the requested work.
+func candidateScore(r media.SearchResult, req Request) int {
+	score := 0
+
+	// An identical ID is conclusive — the provider indexes the same catalog
+	// (TMDB IDs, in practice) the selection came from.
+	if req.ID != "" && r.ID == req.ID {
+		score += 8
+	}
+
+	if normalize(r.Title) == normalize(req.Title) {
+		score += 4
+	} else if strings.HasPrefix(normalize(r.Title), normalize(req.Title)) {
+		score++
+	}
+
+	// Catalogs disagree by a year on release dates often enough that an exact
+	// match is worth more than a near one, but a near one still beats nothing.
+	if req.Year != "" && r.Year != "" {
+		switch diff := yearDiff(r.Year, req.Year); {
+		case diff == 0:
+			score += 4
+		case diff <= 1:
+			score += 2
+		}
+	}
+
+	return score
+}
+
+// normalize lowercases and trims a title for comparison.
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// yearDiff returns the absolute difference between two year strings, or a large
+// value if either does not parse.
+func yearDiff(a, b string) int {
+	ai, err1 := strconv.Atoi(a)
+	bi, err2 := strconv.Atoi(b)
+	if err1 != nil || err2 != nil {
+		return 1 << 30
+	}
+	if d := ai - bi; d < 0 {
+		return -d
+	} else {
+		return d
+	}
 }
 
 // tryStreamProviderFallback resolves a stream via StreamProvider.Watch().

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -554,6 +554,7 @@ func (m *AppModel) queueCurrentDownload() tea.Cmd {
 			Title:      item.Title,
 			MediaTitle: item.Title,
 			MediaType:  item.Type.String(),
+			Year:       item.Year,
 			MediaID:    item.ID,
 			OutputPath: outputDir + "/" + item.Title + ".mkv",
 			Status:     "queued",

--- a/internal/tui/download_dialog.go
+++ b/internal/tui/download_dialog.go
@@ -20,22 +20,22 @@ import (
 type dlStep int
 
 const (
-	dlStepNone        dlStep = iota
-	dlStepLoadSeasons        // loading seasons
-	dlStepPickSeason         // user picks a season
-	dlStepLoadEpisodes       // loading episodes
-	dlStepPickMode           // one / all / range
-	dlStepPickEpisode        // user picks a single episode
-	dlStepRangeInput         // user types a range like "1-5,8"
+	dlStepNone         dlStep = iota
+	dlStepLoadSeasons         // loading seasons
+	dlStepPickSeason          // user picks a season
+	dlStepLoadEpisodes        // loading episodes
+	dlStepPickMode            // one / all / range
+	dlStepPickEpisode         // user picks a single episode
+	dlStepRangeInput          // user types a range like "1-5,8"
 )
 
 // downloadDialog holds the state for the TV show download overlay.
 type downloadDialog struct {
-	active   bool
-	step     dlStep
-	item     media.SearchResult
-	provider provider.Provider
-	manager  *dlmanager.Manager
+	active    bool
+	step      dlStep
+	item      media.SearchResult
+	provider  provider.Provider
+	manager   *dlmanager.Manager
 	outputDir string
 
 	seasons  []media.Season
@@ -306,6 +306,7 @@ func (d *downloadDialog) queueEpisodes(episodes []media.Episode) tea.Cmd {
 			Title:      fmt.Sprintf("%s %s", item.Title, epLabel),
 			MediaTitle: item.Title,
 			MediaType:  item.Type.String(),
+			Year:       item.Year,
 			MediaID:    item.ID,
 			EpisodeID:  ep.ID,
 			Season:     seasonNum,


### PR DESCRIPTION
Searching `spiderman` returned a single row and then played a cinema cam of a different film. Three separate causes, each fixed with a regression test.

## 1. One result instead of a franchise

The TMDB-backed providers (VaPlayer, VidNest, Soap2Day, TBCPL) queried `themoviedb.org/search/trending`. That is the **typeahead** endpoint: it returns only the top two or three full objects, followed by HTML `<span>` name suggestions that every parser here deliberately discards (`raw[0] != '{'`). So `spiderman` yielded exactly two objects.

Switched all four to `/search/multi` (20 complete objects) via a shared `tmdbMultiSearchURL` + `parseTMDBSearchResults` helper, replacing four copies of the same parse loop. The poster lookup had the identical defect and so never matched a poster below the top hit.

## 2. The two results collapsed into one

`deduplicateResults` keyed on **title alone**, merging the 2002 film, the 1994, 1967 and 1981 cartoons into a single row. Now keyed on title + media type + year, with a looser title+type match so providers that omit the year still merge rather than producing a near-duplicate.

`spiderman` goes from 2 rows to **18 distinct works**.

## 3. The cinema dub

`resolver.Request` carried only a **title**. The resolver discarded the ID and year of the selection, re-searched each provider for the bare string, and played candidate #1:

```
[VaPlayer] fallback candidate: Spider-Man: Brand New Day (ID: movie/969681)
[VidNest]  fallback candidate: Spider-Man: Brand New Day (ID: movie/969681)
```

You pick the 2002 film; every provider hands back the sequel that is in cinemas right now — hence a cam/dub.

`Request` now carries `ID` and `Year`, and `candidatesFor` ranks by match confidence (exact ID +8, exact title +4, exact year +4, ±1 year +2) instead of trusting provider relevance. Ranking happens **before** the top-5 cap, which previously discarded a correct match sitting sixth. After the fix every provider resolves `movie/557` first.

## Tests

New: `internal/provider/tmdbsearch_test.go`, `cmd/multisearch_dedup_test.go`, `internal/resolver/candidates_test.go`. Updated `tbcpl_test.go` for the new endpoint. `go build`, `go vet` and `go test ./...` all pass.

## Note on scope

This branch also carries in-flight AniPub/AllAnime fallback work and the new `internal/hlsproxy` package that were already uncommitted in the tree and interleaved line-by-line with the files changed here — they could not be cleanly separated into their own commit.

## Known-unrelated failures

Soap2Day and TBCPL now correctly rank `movie/557` first but still fail to resolve it: Soap2Day's embed extraction is broken (`no embed ID in video URL`) and TBCPL's vidzee endpoint 404s on every ID. Both predate this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AllAnime and AniPub as fallback content sources.
  * Expanded search results across multiple providers when primary results are limited or unavailable.
  * Improved matching and deduplication using titles, years, media types, and IDs.
  * Added support for additional episode formats and single-result searches.
  * Added playback and download support for obfuscated HLS streams.
  * Preserved release-year metadata for more accurate downloads.

* **Bug Fixes**
  * Improved title fallback searches and episode resolution.
  * Updated TMDB-backed searches to return more complete movie and TV results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->