### PR TITLE
security: parse interpreter invocations instead of matching whole lines

### DIFF
--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -94,6 +94,14 @@ def targets(segment):
                 continue                   # unrelated flag
             if nxt.startswith((">", "<", "2>", "&")):
                 continue                   # redirection
+            # A bare word straight after a flag, with more tokens to come, is
+            # that flag's operand rather than the program: `python3 -W ignore
+            # ./payload.txt`. Enumerating every value-taking flag across five
+            # interpreters is a losing game, so key off the shape instead. A
+            # program argument is path-like, or it is the final token.
+            if (j - 2 >= 0 and rest[j - 2].startswith("-")
+                    and "/" not in nxt and "." not in nxt and j < len(rest)):
+                continue
             # Shell and JSON punctuation clinging to a token is not part of the
             # path. Stripping it also means `"type": "node",` yields nothing,
             # rather than reporting ',' as a target.

--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -59,6 +59,21 @@ VERSION_SUFFIX = re.compile(r"[0-9]+(?:\.[0-9]+)*$")
 # these would flag `python3 -m pip install pkg.whl`.
 MODULE_FLAGS = {"-m", "--module"}
 
+# Shell grouping and command-substitution punctuation clings to the front of the
+# interpreter name: `(node ./x)` and `$(node ./x)` tokenize as "(node"/"$(node".
+GROUPING = "(){}`$"
+
+# Punctuation that clings to a path in shell, JSON and prose. A markdown
+# sentence ends `...statusline-command.sh`). — strip that and the target is an
+# ordinary .sh; leave it and the extension reads as empty, i.e. suspicious.
+TRIM = ",;:()[]{}`\"'."
+
+# Words that precede a command without being one. Skipping them keeps
+# `sudo node ./payload` in command position; stopping at anything else is what
+# keeps prose out.
+COMMAND_WRAPPERS = {"sudo", "env", "exec", "nohup", "time", "command",
+                    "then", "do", "else"}
+
 # Shell command separators. Splitting on these is what stops a trailing
 # "; node build.js" from laundering the whole line.
 SEPARATORS = re.compile(r"&&|\|\||[;|&\n]")
@@ -97,7 +112,7 @@ def tokenize(segment):
 
 def is_interpreter(token):
     """True if token names an interpreter, including a versioned build."""
-    base = os.path.basename(token)
+    base = os.path.basename(token.lstrip(GROUPING))
     if base in INTERPRETERS:
         return True
     stem = VERSION_SUFFIX.sub("", base)
@@ -105,9 +120,28 @@ def is_interpreter(token):
 
 
 def embeds_command(text):
-    """True if a quoted run is itself a shell command rather than a path."""
-    parts = text.split()
-    return len(parts) > 1 and any(is_interpreter(t) for t in parts)
+    """True if a quoted run is itself a shell command rather than a path.
+
+    The interpreter has to stand in *command position* — the first real word of
+    the run or of one of its separator-delimited segments. Merely containing the
+    word is what made `"description": "Use node to run the helper"` recurse, and
+    `targets()` then reported `to` as node's target: a false positive that fails
+    the CI gate on ordinary package metadata.
+    """
+    for segment in SEPARATORS.split(text):
+        words = segment.split()
+        if len(words) < 2:
+            continue                    # a lone word is a path, not a command
+        for word in words:
+            # `VAR=1 node ./x` and `sudo node ./x` still run node.
+            if "=" in word and not word.startswith("-"):
+                continue
+            if os.path.basename(word.strip(GROUPING)) in COMMAND_WRAPPERS:
+                continue
+            if is_interpreter(word):
+                return True
+            break                       # first real word is not an interpreter
+    return False
 
 
 def targets(segment, depth=0):
@@ -147,14 +181,14 @@ def targets(segment, depth=0):
                 return
             if nxt in PRELOAD_FLAGS:
                 if j < len(toks):          # classify the preloaded file too...
-                    yield toks[j][0].strip(",;:()[]{}")
+                    yield toks[j][0].strip(TRIM)
                     j += 1
                 continue                   # ...then keep looking for the program
             if not nxt_quoted and nxt.startswith("-"):
                 # --require=./payload.txt binds the operand with '='.
                 flag, _, value = nxt.partition("=")
                 if value and flag in PRELOAD_FLAGS:
-                    yield value.strip(",;:()[]{}")
+                    yield value.strip(TRIM)
                 continue                   # unrelated flag
             if nxt.startswith((">", "<", "2>", "&")):
                 continue                   # redirection or comparison operator
@@ -169,7 +203,7 @@ def targets(segment, depth=0):
             # Shell and JSON punctuation clinging to a token is not part of the
             # path. Stripping it also means `"type": "node",` yields nothing,
             # rather than reporting ',' as a target.
-            nxt = nxt.strip(",;:()[]{}")
+            nxt = nxt.strip(TRIM)
             if not nxt:
                 continue
             yield nxt
@@ -178,7 +212,7 @@ def targets(segment, depth=0):
 
 
 def suspicious(target, path):
-    base = os.path.basename(target).strip(",;:()[]{}")
+    base = os.path.basename(target).strip(TRIM)
     if "." not in base:
         # Extensionless targets are the obvious evasion ("node payload"), but in
         # prose "use node to build" is harmless — so only flag them inside

--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Detect auto-execution loaders and payloads disguised as data files.
+
+The repo previously carried a VS Code task that ran on folder open and executed
+a JavaScript payload named fa-solid-400.woff2. This scans for that shape:
+
+  1. a committed .vscode directory (anywhere in the tree)
+  2. a task configured to run on folder open
+  3. task.allowAutomaticTasks:true, which suppresses the run prompt
+  4. an interpreter invoked against something that is not a known script
+  5. a .woff2 without the wOF2 magic bytes
+
+Check 4 parses each interpreter invocation separately rather than matching whole
+lines. A line-based matcher is trivially bypassed by appending an innocuous
+second command ("node payload.txt; node build.js"), and misses extensionless and
+quoted targets.
+"""
+
+import os
+import re
+import sys
+
+SKIP_DIRS = {".git", "node_modules", ".github", "vendor"}
+
+# Extensions that legitimately follow an interpreter.
+SCRIPT_EXT = {
+    "js", "mjs", "cjs", "jsx", "ts", "tsx", "py", "sh", "bash", "zsh",
+    "rb", "pl", "lua", "ps1", "bat", "cmd",
+}
+
+INTERPRETERS = {
+    "node", "python", "python3", "deno", "bun", "ruby", "perl",
+    "sh", "bash", "zsh",
+}
+
+# Flags whose argument is inline code, not a file to execute.
+INLINE_FLAGS = {"-c", "-e", "--eval", "--exec", "-p", "--print"}
+
+# Shell command separators. Splitting on these is what stops a trailing
+# "; node build.js" from laundering the whole line.
+SEPARATORS = re.compile(r"&&|\|\||[;|&\n]")
+
+# Files where an extensionless interpreter target ("node payload") is
+# suspicious. Prose may say "run node to start" and mean nothing by it.
+CONFIG_SUFFIX = (".json", ".yaml", ".yml", ".toml", ".sh", ".bash", ".cfg",
+                 ".conf", ".ini", ".mk")
+CONFIG_NAMES = {"Makefile", "Dockerfile", "makefile", "justfile", "Taskfile"}
+
+MAX_BYTES = 2 << 20
+
+
+def is_config(path):
+    return path.endswith(CONFIG_SUFFIX) or os.path.basename(path) in CONFIG_NAMES
+
+
+def targets(segment):
+    """Yield the file target of each interpreter invocation in one segment."""
+    # Quotes are delimiters, not grouping: the loader hid its command inside a
+    # JSON string, so treating a quoted run as one atom would hide it.
+    tokens = segment.replace('"', " ").replace("'", " ").split()
+    for i, tok in enumerate(tokens):
+        if os.path.basename(tok) not in INTERPRETERS:
+            continue
+        for nxt in tokens[i + 1:]:
+            if nxt in INLINE_FLAGS:
+                break                      # inline code, no file target
+            if nxt.startswith(("-",)):
+                continue                   # unrelated flag
+            if nxt.startswith((">", "<", "2>", "&")):
+                continue                   # redirection
+            # Shell and JSON punctuation clinging to a token is not part of the
+            # path. Stripping it also means `"type": "node",` yields nothing,
+            # rather than reporting ',' as a target.
+            nxt = nxt.strip(",;:()[]{}")
+            if not nxt:
+                continue
+            yield nxt
+            break
+
+
+def suspicious(target, path):
+    base = os.path.basename(target).strip(",;:()[]{}")
+    if "." not in base:
+        # Extensionless targets are the obvious evasion ("node payload"), but in
+        # prose "use node to build" is harmless — so only flag them inside
+        # config, where an interpreter invocation is always literal. Build-system
+        # variables are not literal targets either.
+        if target.startswith("$") or "{{" in target or "%" in target:
+            return False
+        return is_config(path)
+    return base.rsplit(".", 1)[1].lower() not in SCRIPT_EXT
+
+
+def walk():
+    for root, dirs, files in os.walk("."):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for name in files:
+            yield os.path.join(root, name)
+
+
+def main():
+    errors = []
+
+    for root, dirs, _ in os.walk("."):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS or d == ".vscode"]
+        for d in list(dirs):
+            if d == ".vscode":
+                errors.append(f"{os.path.join(root, d)} is committed; "
+                              f".vscode is gitignored (auto-run task vector)")
+                dirs.remove(d)
+
+    for path in walk():
+        if path.lower().endswith(".woff2"):
+            with open(path, "rb") as fh:
+                if fh.read(4) != b"wOF2":
+                    errors.append(f"{path} lacks the wOF2 magic bytes — not a real font")
+            continue
+        try:
+            if os.path.getsize(path) > MAX_BYTES:
+                continue
+            with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+
+        for lineno, line in enumerate(text.splitlines(), 1):
+            where = f"{path}:{lineno}"
+            if "folderOpen" in line:
+                errors.append(f"{where}: runs on folder open")
+            if re.search(r'"task\.allowAutomaticTasks"\s*:\s*true', line):
+                errors.append(f"{where}: task.allowAutomaticTasks:true suppresses the run prompt")
+            for segment in SEPARATORS.split(line):
+                for target in targets(segment):
+                    if suspicious(target, path):
+                        errors.append(f"{where}: interpreter invoked on non-script target {target!r}")
+
+    for e in errors:
+        print(f"::error::{e}")
+    if errors:
+        return 1
+    print("Clean — no auto-execution loader, prompt suppression, or disguised payload.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -64,43 +64,86 @@ def is_config(path):
     return path.endswith(CONFIG_SUFFIX) or os.path.basename(path) in CONFIG_NAMES
 
 
-def targets(segment):
+# A quoted run is either a path that happens to contain spaces, or a whole
+# shell command embedded in config (which is how the loader hid itself inside
+# tasks.json). Tokenizing has to keep both possible, so quotes are preserved
+# here and resolved by context below.
+TOKEN_RE = re.compile(r"""\"([^"]*)\"|'([^']*)'|(\S+)""")
+
+
+def tokenize(segment):
+    """Yield (text, was_quoted) for each token, keeping quoted runs intact."""
+    for m in TOKEN_RE.finditer(segment):
+        dq, sq, bare = m.groups()
+        if dq is not None:
+            yield dq, True
+        elif sq is not None:
+            yield sq, True
+        else:
+            yield bare, False
+
+
+def embeds_command(text):
+    """True if a quoted run is itself a shell command rather than a path."""
+    parts = text.split()
+    return len(parts) > 1 and any(os.path.basename(t) in INTERPRETERS for t in parts)
+
+
+def targets(segment, depth=0):
     """Yield the file target of each interpreter invocation in one segment."""
-    # Quotes are delimiters, not grouping: the loader hid its command inside a
-    # JSON string, so treating a quoted run as one atom would hide it.
-    tokens = segment.replace('"', " ").replace("'", " ").split()
-    for i, tok in enumerate(tokens):
-        if os.path.basename(tok) not in INTERPRETERS:
+    toks = list(tokenize(segment))
+    i = 0
+    while i < len(toks):
+        text, quoted = toks[i]
+
+        # A quoted run holding a command is config-embedded shell: recurse so
+        # the loader's `node ./x.woff2` inside a JSON string is still seen.
+        if quoted and depth < 3 and embeds_command(text):
+            for sub in SEPARATORS.split(text):
+                yield from targets(sub, depth + 1)
+            i += 1
             continue
-        rest = tokens[i + 1:]
-        j = 0
-        while j < len(rest):
-            nxt = rest[j]
+
+        if os.path.basename(text) not in INTERPRETERS:
+            i += 1
+            continue
+
+        # `"node": "…"` is a JSON key naming a runtime, not an invocation.
+        if i + 1 < len(toks) and toks[i + 1][0] == ":":
+            i += 1
+            continue
+
+        j = i + 1
+        while j < len(toks):
+            nxt, nxt_quoted = toks[j]
             j += 1
-            if nxt in INLINE_FLAGS:
-                break                      # inline code, no file target
-            if nxt in MODULE_FLAGS:
-                break                      # module name, then its own argv
+            if nxt in INLINE_FLAGS or nxt in MODULE_FLAGS:
+                # The argument is inline code or a module name, not a file.
+                # Stop the whole segment: separators are already split out, so
+                # everything after this belongs to the inline argument. Scanning
+                # on would re-read `node -e "... node ./x.woff2 ..."` as a
+                # second invocation and report a false positive.
+                return
             if nxt in PRELOAD_FLAGS:
-                if j < len(rest):          # classify the preloaded file too...
-                    yield rest[j].strip(",;:()[]{}")
+                if j < len(toks):          # classify the preloaded file too...
+                    yield toks[j][0].strip(",;:()[]{}")
                     j += 1
                 continue                   # ...then keep looking for the program
-            if nxt.startswith("-"):
+            if not nxt_quoted and nxt.startswith("-"):
                 # --require=./payload.txt binds the operand with '='.
                 flag, _, value = nxt.partition("=")
                 if value and flag in PRELOAD_FLAGS:
                     yield value.strip(",;:()[]{}")
                 continue                   # unrelated flag
             if nxt.startswith((">", "<", "2>", "&")):
-                continue                   # redirection
+                continue                   # redirection or comparison operator
             # A bare word straight after a flag, with more tokens to come, is
             # that flag's operand rather than the program: `python3 -W ignore
             # ./payload.txt`. Enumerating every value-taking flag across five
             # interpreters is a losing game, so key off the shape instead. A
             # program argument is path-like, or it is the final token.
-            if (j - 2 >= 0 and rest[j - 2].startswith("-")
-                    and "/" not in nxt and "." not in nxt and j < len(rest)):
+            if (not nxt_quoted and j - 2 >= 0 and toks[j - 2][0].startswith("-")
+                    and "/" not in nxt and "." not in nxt and j < len(toks)):
                 continue
             # Shell and JSON punctuation clinging to a token is not part of the
             # path. Stripping it also means `"type": "node",` yields nothing,
@@ -110,6 +153,7 @@ def targets(segment):
                 continue
             yield nxt
             break
+        i = max(j, i + 1)
 
 
 def suspicious(target, path):

--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -40,7 +40,19 @@ INLINE_FLAGS = {"-c", "-e", "--eval", "--exec", "-p", "--print"}
 # argument afterwards. `node --require ./preload.js ./payload.txt` executes
 # both, so both have to be classified — skipping the flag and stopping at
 # ./preload.js let ./payload.txt through unexamined.
-PRELOAD_FLAGS = {"-r", "--require", "--import", "--loader", "--experimental-loader"}
+PRELOAD_FLAGS = {"-r", "--require", "--import", "--loader", "--experimental-loader",
+                 # Shells source these before the program argument, so the same
+                 # rule applies: the operand is path-shaped, which means the
+                 # "bare word after a flag" heuristic below cannot recognize it
+                 # and the scan would stop at an innocuous ./preload.sh without
+                 # ever reaching the payload behind it.
+                 "--rcfile", "--init-file"}
+
+# Interpreters are routinely installed under versioned names (python3.12,
+# node20). Matching only the bare name lets those walk straight past, so strip a
+# trailing version before the lookup. The stem must differ from the basename,
+# which is what keeps "nodemon" from resolving to "node".
+VERSION_SUFFIX = re.compile(r"[0-9]+(?:\.[0-9]+)*$")
 
 # Flags that consume the next token as a module name; anything after that is
 # argv for the module, not something the interpreter executes. Scanning past
@@ -83,10 +95,19 @@ def tokenize(segment):
             yield bare, False
 
 
+def is_interpreter(token):
+    """True if token names an interpreter, including a versioned build."""
+    base = os.path.basename(token)
+    if base in INTERPRETERS:
+        return True
+    stem = VERSION_SUFFIX.sub("", base)
+    return stem != base and stem in INTERPRETERS
+
+
 def embeds_command(text):
     """True if a quoted run is itself a shell command rather than a path."""
     parts = text.split()
-    return len(parts) > 1 and any(os.path.basename(t) in INTERPRETERS for t in parts)
+    return len(parts) > 1 and any(is_interpreter(t) for t in parts)
 
 
 def targets(segment, depth=0):
@@ -104,7 +125,7 @@ def targets(segment, depth=0):
             i += 1
             continue
 
-        if os.path.basename(text) not in INTERPRETERS:
+        if not is_interpreter(text):
             i += 1
             continue
 

--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -111,9 +111,16 @@ def main():
 
     for path in walk():
         if path.lower().endswith(".woff2"):
-            with open(path, "rb") as fh:
-                if fh.read(4) != b"wOF2":
-                    errors.append(f"{path} lacks the wOF2 magic bytes — not a real font")
+            # A dangling symlink or an unreadable path must not abort the whole
+            # scan with a traceback — the text branch below already tolerates
+            # this. An unreadable file holds no payload anything can execute.
+            try:
+                with open(path, "rb") as fh:
+                    magic = fh.read(4)
+            except OSError:
+                continue
+            if magic != b"wOF2":
+                errors.append(f"{path} lacks the wOF2 magic bytes — not a real font")
             continue
         try:
             if os.path.getsize(path) > MAX_BYTES:

--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -36,6 +36,17 @@ INTERPRETERS = {
 # Flags whose argument is inline code, not a file to execute.
 INLINE_FLAGS = {"-c", "-e", "--eval", "--exec", "-p", "--print"}
 
+# Flags that consume the next token AND execute it, then still run a program
+# argument afterwards. `node --require ./preload.js ./payload.txt` executes
+# both, so both have to be classified — skipping the flag and stopping at
+# ./preload.js let ./payload.txt through unexamined.
+PRELOAD_FLAGS = {"-r", "--require", "--import", "--loader", "--experimental-loader"}
+
+# Flags that consume the next token as a module name; anything after that is
+# argv for the module, not something the interpreter executes. Scanning past
+# these would flag `python3 -m pip install pkg.whl`.
+MODULE_FLAGS = {"-m", "--module"}
+
 # Shell command separators. Splitting on these is what stops a trailing
 # "; node build.js" from laundering the whole line.
 SEPARATORS = re.compile(r"&&|\|\||[;|&\n]")
@@ -61,10 +72,25 @@ def targets(segment):
     for i, tok in enumerate(tokens):
         if os.path.basename(tok) not in INTERPRETERS:
             continue
-        for nxt in tokens[i + 1:]:
+        rest = tokens[i + 1:]
+        j = 0
+        while j < len(rest):
+            nxt = rest[j]
+            j += 1
             if nxt in INLINE_FLAGS:
                 break                      # inline code, no file target
-            if nxt.startswith(("-",)):
+            if nxt in MODULE_FLAGS:
+                break                      # module name, then its own argv
+            if nxt in PRELOAD_FLAGS:
+                if j < len(rest):          # classify the preloaded file too...
+                    yield rest[j].strip(",;:()[]{}")
+                    j += 1
+                continue                   # ...then keep looking for the program
+            if nxt.startswith("-"):
+                # --require=./payload.txt binds the operand with '='.
+                flag, _, value = nxt.partition("=")
+                if value and flag in PRELOAD_FLAGS:
+                    yield value.strip(",;:()[]{}")
                 continue                   # unrelated flag
             if nxt.startswith((">", "<", "2>", "&")):
                 continue                   # redirection

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -49,6 +49,11 @@ MUST_FLAG = [
     # scan stopped at the innocuous .sh and never reached the payload.
     ("path-valued flag shields the target", "run.txt",
      "bash --rcfile ./preload.sh ./payload.woff2"),
+    # Shell grouping and command substitution keep punctuation glued to the
+    # interpreter name, which hid it from the lookup.
+    ("shell grouping", "Makefile", "(node ./payload.woff2)"),
+    ("command substitution", "Makefile", "$(node ./payload.woff2)"),
+    ("grouped and quoted in config", "tasks.json", '"command": "(node ./payload.woff2)"'),
     ("folderOpen", "tasks.json", '"runOn": "folderOpen"'),
     ("prompt suppression", "settings.json", '"task.allowAutomaticTasks": true,'),
 ]
@@ -76,6 +81,16 @@ MUST_NOT_FLAG = [
     ("versioned python, real script", "Makefile", "python3.12 tool.py"),
     ("path-valued flag, real script", "run.txt", "bash --rcfile ./preload.sh ./app.sh"),
     ("word merely starting with an interpreter name", "Makefile", "nodemon watch.js"),
+    # Prose inside a config string is still prose. The interpreter has to sit in
+    # command position, or ordinary metadata fails the CI gate.
+    ("quoted prose in a config file", "package.json",
+     '  "description": "Use node to run the helper",'),
+    ("quoted prose naming a shell", "tasks.json", '  "detail": "runs bash for you",'),
+    # Markdown prose wraps commands in backticks and ends sentences with a
+    # period; neither is part of the path.
+    ("backticked command in prose", "notes.md",
+     "**Note:** a hardcoded path (`bash /home/u/.claude/statusline-command.sh`)."),
+    ("parenthesized command in prose", "notes.md", "(bash ./setup.sh) runs first."),
 ]
 
 

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -30,6 +30,12 @@ MUST_FLAG = [
     ("short preload flag", "tasks.json", "node -r ./preload.js ./payload.txt"),
     ("preload operand is itself the payload", "tasks.json", "node --require ./evil.woff2 ./app.js"),
     ("preload bound with equals", "tasks.json", "node --require=./payload.txt ./app.js"),
+    # A flag operand must not be mistaken for the program argument, including
+    # outside config files where an extensionless target is not suspicious.
+    ("flag operand shields the target", "run.txt", "python3 -W ignore ./payload.txt"),
+    ("flag operand, shell form", "run.txt", "bash -o pipefail ./payload.woff2"),
+    # The bare-word rule must not swallow a genuinely bare final target.
+    ("bare final target still flagged", "tasks.json", "node payload"),
     ("folderOpen", "tasks.json", '"runOn": "folderOpen"'),
     ("prompt suppression", "settings.json", '"task.allowAutomaticTasks": true,'),
 ]
@@ -49,6 +55,7 @@ MUST_NOT_FLAG = [
     ("chained legit commands", "Makefile", "node build.js && bash deploy.sh"),
     ("legit preload", "Makefile", "node --require ./preload.js ./app.js"),
     ("python module with file argv", "Makefile", "python3 -m pip install pkg.whl"),
+    ("flag operand then real script", "run.txt", "python3 -W ignore ./app.py"),
 ]
 
 

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Self-test for detect-loaders.py. Run from the repo root: python3 this_file."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DETECTOR = os.path.join(HERE, "detect-loaders.py")
+
+# The real loader, as it appeared in .vscode/tasks.json.
+REAL_LOADER = (
+    '"command": "(command -v node >/dev/null 2>&1 && node ./public/fonts/fa-solid-400.woff2)'
+    ' || (where node >nul 2>&1 && node ./public/fonts/fa-solid-400.woff2) || echo \'\'",'
+)
+
+MUST_FLAG = [
+    ("real loader command", "tasks.json", REAL_LOADER),
+    # Bypasses of the previous line-based matcher.
+    ("laundered by a second command", "tasks.json", "node payload.txt; node build.js"),
+    ("extensionless target", "tasks.json", "node ./payload"),
+    ("quoted target with a space", "tasks.json", 'node "payload file.txt"'),
+    ("chained with &&", "tasks.json", "true && node ./evil.woff2"),
+    ("piped", "tasks.json", "cat x | node ./evil.dat"),
+    ("python payload", "run.yaml", "python3 ./payload.txt"),
+    ("folderOpen", "tasks.json", '"runOn": "folderOpen"'),
+    ("prompt suppression", "settings.json", '"task.allowAutomaticTasks": true,'),
+]
+
+MUST_NOT_FLAG = [
+    ("plain node script", "Makefile", "node build.js"),
+    ("bash script", "Makefile", "bash install.sh"),
+    ("python script", "Makefile", "python3 tool.py"),
+    ("version flag", "Makefile", "node --version"),
+    ("inline eval", "Makefile", 'node -e "console.log(1)"'),
+    ("inline sh -c", "Makefile", 'sh -c "echo hi"'),
+    ("availability probe", "Makefile", "command -v node >/dev/null 2>&1"),
+    ("prose mentioning node", "README.md", "You can use node to run the helper"),
+    # A launch/package config naming node as a *type* is not an invocation.
+    ("node as a JSON value", "launch.json", '      "type": "node",'),
+    ("node as a package engine", "package.json", '  "engines": { "node": ">=18" },'),
+    ("chained legit commands", "Makefile", "node build.js && bash deploy.sh"),
+]
+
+
+def run(tmp):
+    return subprocess.run([sys.executable, DETECTOR], cwd=tmp,
+                          capture_output=True, text=True)
+
+
+def case(name, filename, content):
+    tmp = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(tmp, filename), "w") as fh:
+            fh.write(content + "\n")
+        r = run(tmp)
+        return r.returncode != 0, r.stdout.strip()
+    finally:
+        shutil.rmtree(tmp)
+
+
+def main():
+    failures = 0
+
+    for name, fn, content in MUST_FLAG:
+        flagged, out = case(name, fn, content)
+        print(f"  {'PASS' if flagged else 'FAIL'}  must flag: {name}")
+        if not flagged:
+            failures += 1
+
+    for name, fn, content in MUST_NOT_FLAG:
+        flagged, out = case(name, fn, content)
+        print(f"  {'PASS' if not flagged else 'FAIL'}  must not flag: {name}")
+        if flagged:
+            print(f"        false positive: {out}")
+            failures += 1
+
+    # A committed .vscode directory is itself an error.
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, ".vscode"))
+        open(os.path.join(tmp, ".vscode", "tasks.json"), "w").write("{}\n")
+        flagged = run(tmp).returncode != 0
+        print(f"  {'PASS' if flagged else 'FAIL'}  must flag: committed .vscode")
+        failures += 0 if flagged else 1
+    finally:
+        shutil.rmtree(tmp)
+
+    # Nested .vscode too.
+    tmp = tempfile.mkdtemp()
+    try:
+        os.makedirs(os.path.join(tmp, "packages", "app", ".vscode"))
+        open(os.path.join(tmp, "packages", "app", ".vscode", "tasks.json"), "w").write("{}\n")
+        flagged = run(tmp).returncode != 0
+        print(f"  {'PASS' if flagged else 'FAIL'}  must flag: nested .vscode")
+        failures += 0 if flagged else 1
+    finally:
+        shutil.rmtree(tmp)
+
+    # Fonts: genuine passes, spaced filename survives, corrupt is flagged.
+    for label, name, data, want in [
+        ("genuine font", "real.woff2", b"wOF2rest", False),
+        ("genuine font, spaced name", "brand font.woff2", b"wOF2rest", False),
+        ("disguised font", "fa-solid-400.woff2", b"    global['!']='8-**';", True),
+        ("disguised font, spaced name", "bad font.woff2", b"notafont", True),
+    ]:
+        tmp = tempfile.mkdtemp()
+        try:
+            open(os.path.join(tmp, name), "wb").write(data)
+            flagged = run(tmp).returncode != 0
+            ok = flagged == want
+            print(f"  {'PASS' if ok else 'FAIL'}  {'must flag' if want else 'must not flag'}: {label}")
+            failures += 0 if ok else 1
+        finally:
+            shutil.rmtree(tmp)
+
+    print(f"\n{'ALL PASS' if failures == 0 else str(failures) + ' FAILURE(S)'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -39,6 +39,16 @@ MUST_FLAG = [
     ("quoted spaced target, non-config", "run.txt", 'node "payload file.woff2"'),
     # The bare-word rule must not swallow a genuinely bare final target.
     ("bare final target still flagged", "tasks.json", "node payload"),
+    # Interpreter binaries are routinely versioned on disk; matching only the
+    # bare name lets `python3.12` walk straight past.
+    ("versioned python", "Makefile", "python3.12 ./payload.woff2"),
+    ("versioned python, quoted in config", "tasks.json",
+     '"command": "python3.12 ./payload.woff2"'),
+    ("versioned node", "Makefile", "node20 ./payload.woff2"),
+    # A path-valued flag operand looks exactly like a program argument, so the
+    # scan stopped at the innocuous .sh and never reached the payload.
+    ("path-valued flag shields the target", "run.txt",
+     "bash --rcfile ./preload.sh ./payload.woff2"),
     ("folderOpen", "tasks.json", '"runOn": "folderOpen"'),
     ("prompt suppression", "settings.json", '"task.allowAutomaticTasks": true,'),
 ]
@@ -62,6 +72,10 @@ MUST_NOT_FLAG = [
     # Inline code is an argument, not a command to re-parse.
     ("inline code mentioning a command", "Makefile", 'node -e "console.log(\'node ./payload.woff2\')"'),
     ("inline sh -c mentioning a command", "Makefile", 'sh -c "echo node ./payload.woff2"'),
+    # Versioned names must not turn every version-ish word into an interpreter.
+    ("versioned python, real script", "Makefile", "python3.12 tool.py"),
+    ("path-valued flag, real script", "run.txt", "bash --rcfile ./preload.sh ./app.sh"),
+    ("word merely starting with an interpreter name", "Makefile", "nodemon watch.js"),
 ]
 
 

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -34,6 +34,9 @@ MUST_FLAG = [
     # outside config files where an extensionless target is not suspicious.
     ("flag operand shields the target", "run.txt", "python3 -W ignore ./payload.txt"),
     ("flag operand, shell form", "run.txt", "bash -o pipefail ./payload.woff2"),
+    # A quoted path with a space must stay one target: outside config an
+    # extensionless first fragment is ignored, so splitting it hid the .woff2.
+    ("quoted spaced target, non-config", "run.txt", 'node "payload file.woff2"'),
     # The bare-word rule must not swallow a genuinely bare final target.
     ("bare final target still flagged", "tasks.json", "node payload"),
     ("folderOpen", "tasks.json", '"runOn": "folderOpen"'),
@@ -56,6 +59,9 @@ MUST_NOT_FLAG = [
     ("legit preload", "Makefile", "node --require ./preload.js ./app.js"),
     ("python module with file argv", "Makefile", "python3 -m pip install pkg.whl"),
     ("flag operand then real script", "run.txt", "python3 -W ignore ./app.py"),
+    # Inline code is an argument, not a command to re-parse.
+    ("inline code mentioning a command", "Makefile", 'node -e "console.log(\'node ./payload.woff2\')"'),
+    ("inline sh -c mentioning a command", "Makefile", 'sh -c "echo node ./payload.woff2"'),
 ]
 
 

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -116,6 +116,19 @@ def main():
         finally:
             shutil.rmtree(tmp)
 
+    # An unreadable .woff2 (dangling symlink) must not crash the scan.
+    tmp = tempfile.mkdtemp()
+    try:
+        os.symlink(os.path.join(tmp, "nonexistent"), os.path.join(tmp, "broken.woff2"))
+        r = run(tmp)
+        ok = r.returncode == 0 and "Traceback" not in r.stderr
+        print(f"  {'PASS' if ok else 'FAIL'}  must not crash: dangling .woff2 symlink")
+        if not ok:
+            print(f"        rc={r.returncode} stderr={r.stderr.strip()[:200]}")
+        failures += 0 if ok else 1
+    finally:
+        shutil.rmtree(tmp)
+
     print(f"\n{'ALL PASS' if failures == 0 else str(failures) + ' FAILURE(S)'}")
     return 1 if failures else 0
 

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -25,6 +25,11 @@ MUST_FLAG = [
     ("chained with &&", "tasks.json", "true && node ./evil.woff2"),
     ("piped", "tasks.json", "cat x | node ./evil.dat"),
     ("python payload", "run.yaml", "python3 ./payload.txt"),
+    # A value-taking preload flag must not shield the real program argument.
+    ("preload flag hides the target", "tasks.json", "node --require ./preload.js ./payload.txt"),
+    ("short preload flag", "tasks.json", "node -r ./preload.js ./payload.txt"),
+    ("preload operand is itself the payload", "tasks.json", "node --require ./evil.woff2 ./app.js"),
+    ("preload bound with equals", "tasks.json", "node --require=./payload.txt ./app.js"),
     ("folderOpen", "tasks.json", '"runOn": "folderOpen"'),
     ("prompt suppression", "settings.json", '"task.allowAutomaticTasks": true,'),
 ]
@@ -42,6 +47,8 @@ MUST_NOT_FLAG = [
     ("node as a JSON value", "launch.json", '      "type": "node",'),
     ("node as a package engine", "package.json", '  "engines": { "node": ">=18" },'),
     ("chained legit commands", "Makefile", "node build.js && bash deploy.sh"),
+    ("legit preload", "Makefile", "node --require ./preload.js ./app.js"),
+    ("python module with file argv", "Makefile", "python3 -m pip install pkg.whl"),
 ]
 
 

--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -44,64 +44,16 @@ jobs:
       # The marker scan above only finds the PAYLOAD. In the 2026-08 recurrence
       # the payload had already been deleted from main while the LOADER that
       # invokes it survived in .vscode/, so the scan passed and a merge from an
-      # untouched feature branch re-armed the repo. Detect the loader itself.
+      # untouched branch re-armed the repo. Detect the loader itself.
+      #
+      # This lives in a script rather than inline shell because the check has to
+      # parse each interpreter invocation separately: a line-based matcher is
+      # bypassed by appending "; node build.js" to a malicious command.
+      - name: Self-test the loader detector
+        run: python3 .github/scripts/test_detect_loaders.py
+
       - name: Scan for auto-execution loaders
-        run: |
-          set -uo pipefail
-          fail=0
-
-          # Editor auto-run config has no business in this repo at all.
-          # Recursive: a nested packages/*/.vscode/ is the same vector.
-          vscodedirs=$(find . -name .vscode -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null || true)
-          if [ -n "$vscodedirs" ]; then
-            echo "::error::committed .vscode found (gitignored for a reason — auto-run task vector):"
-            printf '%s\n' "$vscodedirs"
-            fail=1
-          fi
-
-          # Any task/config that runs on folder open, anywhere in the tree.
-          folderopen=$(grep -rlF 'folderOpen' . --exclude-dir=.git --exclude-dir=node_modules \
-            --exclude-dir=.github 2>/dev/null || true)
-          if [ -n "$folderopen" ]; then
-            echo "::error::runOn/folderOpen auto-execution found in:"
-            printf '%s\n' "$folderopen"
-            fail=1
-          fi
-
-          # Prompt suppression: turns a visible task into a silent one.
-          autotasks=$(grep -rlE '"task\.allowAutomaticTasks"[[:space:]]*:[[:space:]]*true' . \
-            --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.github 2>/dev/null || true)
-          if [ -n "$autotasks" ]; then
-            echo "::error::task.allowAutomaticTasks:true (suppresses the run prompt) in:"
-            printf '%s\n' "$autotasks"
-            fail=1
-          fi
-
-          # An interpreter pointed at anything that is not a known script type is
-          # a disguise. Allowlisting script extensions rather than denylisting
-          # payload ones means a rename (.woff2 -> .txt) does not evade it; the
-          # optional quote handles `node "payload.woff2"`.
-          disguised=$(grep -rnE '\b(node|python3?|deno|bun|ruby|perl|zsh|bash|sh)\b[[:space:]]+"?[^"[:space:]]*\.[A-Za-z0-9]+' . \
-            --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.github 2>/dev/null \
-            | grep -viE '\.(js|mjs|cjs|jsx|ts|tsx|py|sh|bash|zsh|rb|pl|lua|ps1|bat|cmd)([^A-Za-z0-9]|$)' || true)
-          if [ -n "$disguised" ]; then
-            echo "::error::interpreter invoked on a non-script file (payload disguise):"
-            printf '%s\n' "$disguised"
-            fail=1
-          fi
-
-          # Any "font" that is not actually a font. NUL-delimited so filenames
-          # with spaces survive, and fed by redirect rather than a pipe so the
-          # loop runs in this shell and $fail actually propagates.
-          while IFS= read -r -d '' f; do
-            if [ "$(head -c 4 "$f")" != "wOF2" ]; then
-              echo "::error::$f lacks the wOF2 magic bytes — not a real font."
-              fail=1
-            fi
-          done < <(find . -name '*.woff2' -not -path '*/.git/*' -not -path '*/node_modules/*' -print0 2>/dev/null)
-
-          [ "$fail" -eq 0 ] || exit 1
-          echo "Clean — no auto-execution loader, prompt suppression, or disguised payload."
+        run: python3 .github/scripts/detect-loaders.py
 
   shai-hulud-deep:
     name: shai-hulud-detect (weekly)


### PR DESCRIPTION
Follow-up to #28. The loader check merged there is bypassable, and #28 was merged before this was addressed — my error, not a review gap; CodeRabbit had flagged it 20 minutes earlier and I did not check the threads before merging.

## The bypass

The check ran two greps over complete source lines: one to find an interpreter followed by a target, a second to remove lines whose target had a permitted extension. Because the second grep operates on the whole line, any line mentioning a permitted extension *anywhere* was dropped.

Verified against the code currently on `main`:

| input | old check |
|---|---|
| `node payload.txt; node build.js` | **MISSED** — the unrelated `.js` launders the line |
| `node payload` | **MISSED** — extensionless target |
| `node "payload file.txt"` | **MISSED** — quoted target |

The first is the serious one: appending `; node build.js` to any malicious command disarms the check.

## The fix

`.github/scripts/detect-loaders.py` replaces both greps. It splits each line on shell separators (`;`, `&&`, `||`, `|`), walks the tokens of each interpreter invocation, skips flags, redirections and inline-code flags (`-e`, `-c`), and classifies each target independently.

Details that matter:

- **Quotes are delimiters, not grouping.** The original loader hid its command inside a JSON string; treating a quoted run as one atom would conceal it.
- **Extensionless targets count only inside config files**, where an invocation is always literal. In prose, "use node to build" is not an invocation.
- **Build-system variables** (`$(SCRIPT)`, `{{...}}`, `%VAR%`) are not literal paths.
- **Punctuation is stripped from tokens**, so `"type": "node",` in a launch or package config no longer reports `','` as an execution target — a false positive the previous version would have produced on any legitimate JSON naming node.

## Tests

The detector ships with `test_detect_loaders.py`, run in CI *before* the scan so a broken detector fails the build rather than silently passing everything. 26 cases:

**Must flag** — the real loader line from `96ed08f`; all three bypasses above; `&&`-chained; piped; `python3 ./payload.txt`; `folderOpen`; `task.allowAutomaticTasks: true`; committed `.vscode`; nested `packages/app/.vscode`; disguised fonts including one with a space in the name.

**Must not flag** — `node build.js`, `bash install.sh`, `python3 tool.py`, `node --version`, `node -e "..."`, `sh -c "..."`, `command -v node >/dev/null 2>&1`, prose mentioning node, `node build.js && bash deploy.sh`, `"type": "node"`, `"engines": {"node": ">=18"}`, genuine fonts including one with a space in the name.

Verified end to end: clean on this repo, and on the real backdoor restored from `96ed08f` it reports exactly the five real problems with no noise.

## Note on scope

This does not address the payload blob still reachable on GitHub via `refs/pull/13/head` … `refs/pull/19/head`. Those refs cannot be deleted by the repository owner, so no history rewrite removes them — that needs GitHub Support. Tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated scanning for suspicious editor configurations, task settings, interpreter usage, and invalid font files.
  * Expanded detection to cover nested directories, disguised files, unusual filenames, embedded commands, and other potentially unsafe content.

* **Bug Fixes**
  * Improved malware-scan reliability with dedicated validation and clearer failure reporting.

* **Tests**
  * Added coverage for flagged and permitted repository content, including symlinks, unusual filenames, and unreadable files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->