### PR TITLE
feat(audio): prefer an English audio track instead of whatever comes first

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -136,6 +136,7 @@ provider = "Vidcloud"
 
 # Subtitle language
 subs_language = "english"
+audio_language = "english"   # preferred audio track on multi-dub releases
 
 # Video quality (360, 480, 720, 1080)
 quality = "1080"
@@ -154,6 +155,7 @@ download_dir = "~/Videos/lobster"
 
 ```
 -c, --continue              Resume from watch history
+-a, --audio-language <lang> Preferred audio track language (default: english)
 -d, --download <path>       Download to path instead of streaming
 -j, --json                  Output stream metadata as JSON
 -l, --language <lang>       Subtitle language (default: english)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Config is stored in `%APPDATA%\lobster\config.toml` and history in `%LOCALAPPDAT
 
 ```
 -c, --continue
+-a, --audio-language <lang>
 -d, --download <path>
 -j, --json
 -l, --language <lang>
@@ -124,6 +125,7 @@ Config file location:
 player = "mpv"
 quality = "1080"   # or "best" for the highest the source offers (uncapped)
 subs_language = "english"
+audio_language = "english"   # preferred audio track on multi-dub releases
 history = true
 auto_next = true
 download_dir = "~/Videos/lobster"

--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -71,7 +71,11 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 	}
 
 	if _, ok := primary.(*provider.TBCPL); !ok {
-		fallbacks = append(fallbacks, provider.NewTBCPL("tbcpl"))
+		tb := provider.NewTBCPL("tbcpl")
+		if cfg != nil {
+			tb.SetAudioLanguage(cfg.AudioLanguage)
+		}
+		fallbacks = append(fallbacks, tb)
 	}
 
 	if _, ok := primary.(*provider.FlixHQWS); !ok {

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -38,7 +38,9 @@ func newProvider() provider.Provider {
 		return provider.NewFlixHQ(base)
 	}
 	if strings.Contains(cfg.Base, "tbcpl") || strings.Contains(cfg.Base, "1shows") {
-		return provider.NewTBCPL(cfg.Base)
+		tb := provider.NewTBCPL(cfg.Base)
+		tb.SetAudioLanguage(cfg.AudioLanguage)
+		return tb
 	}
 	if strings.Contains(cfg.Base, "vidnest") {
 		return provider.NewVidNest()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,16 +16,17 @@ var Version = "dev"
 
 // Global flags
 var (
-	flagDownload string
-	flagLanguage string
-	flagNoSubs   bool
-	flagProvider string
-	flagQuality  string
-	flagPlayer   string
-	flagBase     string
-	flagContinue bool
-	flagJSON     bool
-	flagDebug    bool
+	flagDownload  string
+	flagLanguage  string
+	flagAudioLang string
+	flagNoSubs    bool
+	flagProvider  string
+	flagQuality   string
+	flagPlayer    string
+	flagBase      string
+	flagContinue  bool
+	flagJSON      bool
+	flagDebug     bool
 )
 
 // cfg holds the loaded configuration (merged: defaults < config file < flags).
@@ -51,6 +52,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&flagDownload, "download", "d", "", "Download to path instead of playing (default: config download_dir)")
 	rootCmd.PersistentFlags().StringVarP(&flagLanguage, "language", "l", "", "Subtitle language (default: english)")
+	rootCmd.PersistentFlags().StringVarP(&flagAudioLang, "audio-language", "a", "", "Preferred audio track language (default: english)")
 	rootCmd.PersistentFlags().BoolVarP(&flagNoSubs, "no-subs", "n", false, "Disable subtitles")
 	rootCmd.PersistentFlags().StringVarP(&flagProvider, "provider", "p", "", "Server provider: Vidcloud | UpCloud")
 	rootCmd.PersistentFlags().StringVarP(&flagQuality, "quality", "q", "", "Video quality: 360 | 480 | 720 | 1080 | best")
@@ -83,6 +85,9 @@ func loadConfig(cmd *cobra.Command, args []string) error {
 	}
 	if flagQuality != "" {
 		cfg.Quality = flagQuality
+	}
+	if flagAudioLang != "" {
+		cfg.AudioLanguage = flagAudioLang
 	}
 	if flagLanguage != "" {
 		cfg.SubsLanguage = flagLanguage

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -541,7 +541,7 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 		}
 	}
 
-	p2 := player.New(cfg.Player)
+	p2 := player.New(cfg.Player, cfg.AudioLanguage)
 	if !p2.Available() {
 		return player.NotFoundError(cfg.Player)
 	}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -233,7 +233,7 @@ func playCurrentEpisode(sess *playlist.Session) error {
 	}
 
 	// Normal playback with retry on failure
-	p := player.New(cfg.Player)
+	p := player.New(cfg.Player, cfg.AudioLanguage)
 	if !p.Available() {
 		return player.NotFoundError(cfg.Player)
 	}

--- a/cmd/surf.go
+++ b/cmd/surf.go
@@ -38,7 +38,7 @@ func playLiveSurf(p provider.StreamProvider, lineup []media.SearchResult, startI
 	if len(lineup) == 0 {
 		return nil
 	}
-	pl := player.New(cfg.Player)
+	pl := player.New(cfg.Player, cfg.AudioLanguage)
 	if !pl.Available() {
 		return player.NotFoundError(cfg.Player)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Player                 string              `toml:"player"`
 	Provider               string              `toml:"provider"`
 	SubsLanguage           string              `toml:"subs_language"`
+	AudioLanguage          string              `toml:"audio_language"`
 	Quality                string              `toml:"quality"`
 	History                bool                `toml:"history"`
 	AutoNext               bool                `toml:"auto_next"`
@@ -81,6 +82,7 @@ func Default() *Config {
 		Player:                 "mpv",
 		Provider:               "Default",
 		SubsLanguage:           "english",
+		AudioLanguage:          "english",
 		Quality:                "1080",
 		History:                true,
 		AutoNext:               true,

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -1,0 +1,78 @@
+// Package lang is the single table of audio-language spellings.
+//
+// It exists because there were two: the player built --alang from one and the
+// provider ordered per-dub sources from another, and they drifted. Asking for
+// russian set mpv's preference but left the provider's source order untouched,
+// so the wrong dub was still selected first. A preference that is honoured in
+// one half of the pipeline and ignored in the other is worse than one that is
+// unsupported everywhere, because nothing reports it.
+package lang
+
+import "strings"
+
+// aliases maps a language name to its ISO 639-2 and 639-1 codes. Sources are
+// inconsistent about which they use — the same English track is tagged "eng",
+// "en" or "english" depending on who packed it — so all three are offered.
+var aliases = map[string][2]string{
+	"english":    {"eng", "en"},
+	"spanish":    {"spa", "es"},
+	"french":     {"fre", "fr"},
+	"german":     {"ger", "de"},
+	"italian":    {"ita", "it"},
+	"portuguese": {"por", "pt"},
+	"russian":    {"rus", "ru"},
+	"japanese":   {"jpn", "ja"},
+	"korean":     {"kor", "ko"},
+	"chinese":    {"chi", "zh"},
+	"arabic":     {"ara", "ar"},
+	"turkish":    {"tur", "tr"},
+	"hindi":      {"hin", "hi"},
+	"tamil":      {"tam", "ta"},
+	"telugu":     {"tel", "te"},
+	"dutch":      {"dut", "nl"},
+	"polish":     {"pol", "pl"},
+}
+
+// Supported returns every language name the table knows.
+func Supported() []string {
+	out := make([]string, 0, len(aliases))
+	for name := range aliases {
+		out = append(out, name)
+	}
+	return out
+}
+
+// Aliases returns the spellings to prefer for a language, most specific first,
+// so a player given the list tries the ISO codes before the English word. An
+// unknown name is returned alone rather than dropped: a degraded match beats a
+// silent no-op.
+func Aliases(pref string) []string {
+	pref = normalize(pref)
+	if pref == "" {
+		return nil
+	}
+	if codes, ok := aliases[pref]; ok {
+		return []string{codes[0], codes[1], pref}
+	}
+	return []string{pref}
+}
+
+// Matches reports whether a source's language tag names pref. The tag is
+// compared on its primary subtag, so "en-US" counts as English.
+func Matches(tag, pref string) bool {
+	tag = normalize(tag)
+	if tag == "" {
+		return false
+	}
+	if i := strings.IndexAny(tag, "-_"); i > 0 {
+		tag = tag[:i]
+	}
+	for _, a := range Aliases(pref) {
+		if tag == a {
+			return true
+		}
+	}
+	return false
+}
+
+func normalize(s string) string { return strings.ToLower(strings.TrimSpace(s)) }

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -13,23 +13,29 @@ import "strings"
 // aliases maps a language name to its ISO 639-2 and 639-1 codes. Sources are
 // inconsistent about which they use — the same English track is tagged "eng",
 // "en" or "english" depending on who packed it — so all three are offered.
-var aliases = map[string][2]string{
+// aliases maps a language name to its ISO codes, 639-2 first then 639-1.
+// Sources are inconsistent about which they use — the same English track is
+// tagged "eng", "en" or "english" depending on who packed it — so all are
+// offered. Several languages have both a bibliographic and a terminological
+// 639-2 code (fre/fra, ger/deu, chi/zho, dut/nld) and both appear in the wild,
+// so both are listed rather than picking one.
+var aliases = map[string][]string{
 	"english":    {"eng", "en"},
 	"spanish":    {"spa", "es"},
-	"french":     {"fre", "fr"},
-	"german":     {"ger", "de"},
+	"french":     {"fre", "fra", "fr"},
+	"german":     {"ger", "deu", "de"},
 	"italian":    {"ita", "it"},
 	"portuguese": {"por", "pt"},
 	"russian":    {"rus", "ru"},
 	"japanese":   {"jpn", "ja"},
 	"korean":     {"kor", "ko"},
-	"chinese":    {"chi", "zh"},
+	"chinese":    {"chi", "zho", "zh"},
 	"arabic":     {"ara", "ar"},
 	"turkish":    {"tur", "tr"},
 	"hindi":      {"hin", "hi"},
 	"tamil":      {"tam", "ta"},
 	"telugu":     {"tel", "te"},
-	"dutch":      {"dut", "nl"},
+	"dutch":      {"dut", "nld", "nl"},
 	"polish":     {"pol", "pl"},
 }
 
@@ -52,7 +58,7 @@ func Aliases(pref string) []string {
 		return nil
 	}
 	if codes, ok := aliases[pref]; ok {
-		return []string{codes[0], codes[1], pref}
+		return append(append([]string{}, codes...), pref)
 	}
 	return []string{pref}
 }

--- a/internal/lang/lang_test.go
+++ b/internal/lang/lang_test.go
@@ -63,8 +63,26 @@ func TestSupportedCoversTheLanguagesTheCLIAdvertises(t *testing.T) {
 		"russian", "japanese", "korean", "chinese", "arabic", "turkish",
 		"hindi", "tamil", "telugu", "dutch", "polish",
 	} {
-		if len(Aliases(name)) != 3 {
+		if len(Aliases(name)) < 3 {
 			t.Errorf("%q has no ISO aliases; it would match only its own spelling", name)
+		}
+	}
+}
+
+// ISO 639-2 has bibliographic and terminological variants for several
+// languages, and sources use both. Collapsing to a single code silently
+// dropped fra and deu, which the provider table had supported before.
+func TestMatchesBothISO6392Variants(t *testing.T) {
+	for pref, tags := range map[string][]string{
+		"french":  {"fre", "fra"},
+		"german":  {"ger", "deu"},
+		"chinese": {"chi", "zho"},
+		"dutch":   {"dut", "nld"},
+	} {
+		for _, tag := range tags {
+			if !Matches(tag, pref) {
+				t.Errorf("Matches(%q, %q) = false; both ISO 639-2 variants must match", tag, pref)
+			}
 		}
 	}
 }

--- a/internal/lang/lang_test.go
+++ b/internal/lang/lang_test.go
@@ -1,0 +1,70 @@
+package lang
+
+import "testing"
+
+// The player and the provider each had their own table, and they drifted: -a
+// russian set mpv's --alang but left Vidzee's Hindi-first source order alone,
+// because only one of the two maps knew "rus". One table, or it happens again.
+func TestAliasesOrderedMostSpecificFirst(t *testing.T) {
+	got := Aliases("english")
+	want := []string{"eng", "en", "english"}
+	if len(got) != len(want) {
+		t.Fatalf("Aliases(english) = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Aliases(english) = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestAliasesUnknownPassesThrough(t *testing.T) {
+	if got := Aliases("klingon"); len(got) != 1 || got[0] != "klingon" {
+		t.Errorf("Aliases(klingon) = %v, want [klingon]", got)
+	}
+}
+
+func TestAliasesEmptyIsNone(t *testing.T) {
+	if got := Aliases(""); len(got) != 0 {
+		t.Errorf("Aliases(\"\") = %v, want none", got)
+	}
+}
+
+func TestMatchesAcceptsEverySpelling(t *testing.T) {
+	for _, tag := range []string{"english", "eng", "en", "EN", "en-US", "en_GB", " eng "} {
+		if !Matches(tag, "english") {
+			t.Errorf("Matches(%q, english) = false", tag)
+		}
+	}
+	for _, tag := range []string{"hindi", "hin", "hi", "", "e"} {
+		if Matches(tag, "english") {
+			t.Errorf("Matches(%q, english) = true", tag)
+		}
+	}
+}
+
+// Every language the table knows must round-trip through Matches under all
+// three of its spellings. This is what stops a half-added entry.
+func TestEverySupportedLanguageMatchesItsOwnAliases(t *testing.T) {
+	for _, name := range Supported() {
+		for _, tag := range Aliases(name) {
+			if !Matches(tag, name) {
+				t.Errorf("Matches(%q, %q) = false; the table is internally inconsistent", tag, name)
+			}
+		}
+	}
+}
+
+// The languages a user can ask for must be the same set everywhere. Russian was
+// selectable for the player but unknown to the provider.
+func TestSupportedCoversTheLanguagesTheCLIAdvertises(t *testing.T) {
+	for _, name := range []string{
+		"english", "spanish", "french", "german", "italian", "portuguese",
+		"russian", "japanese", "korean", "chinese", "arabic", "turkish",
+		"hindi", "tamil", "telugu", "dutch", "polish",
+	} {
+		if len(Aliases(name)) != 3 {
+			t.Errorf("%q has no ISO aliases; it would match only its own spelling", name)
+		}
+	}
+}

--- a/internal/player/alang.go
+++ b/internal/player/alang.go
@@ -1,0 +1,62 @@
+package player
+
+import "strings"
+
+// audioLangCodes maps a language name to the spellings a muxer might have
+// written into the track's language tag. Releases are inconsistent: the same
+// English track is tagged "eng" (ISO 639-2), "en" (639-1) or "english"
+// depending on who packed it, so all three have to be offered or the
+// preference silently misses.
+var audioLangCodes = map[string][2]string{
+	"english":    {"eng", "en"},
+	"spanish":    {"spa", "es"},
+	"french":     {"fre", "fr"},
+	"german":     {"ger", "de"},
+	"italian":    {"ita", "it"},
+	"portuguese": {"por", "pt"},
+	"russian":    {"rus", "ru"},
+	"japanese":   {"jpn", "ja"},
+	"korean":     {"kor", "ko"},
+	"chinese":    {"chi", "zh"},
+	"arabic":     {"ara", "ar"},
+	"turkish":    {"tur", "tr"},
+	"hindi":      {"hin", "hi"},
+	"tamil":      {"tam", "ta"},
+	"telugu":     {"tel", "te"},
+	"dutch":      {"dut", "nl"},
+	"polish":     {"pol", "pl"},
+}
+
+// audioLangList returns the ordered language tags to prefer, most specific
+// first. An unknown name is still passed through on its own, so an uncommon
+// language is a degraded match rather than a silent no-op.
+func audioLangList(pref string) []string {
+	pref = strings.ToLower(strings.TrimSpace(pref))
+	if pref == "" {
+		return nil
+	}
+	if codes, ok := audioLangCodes[pref]; ok {
+		return []string{codes[0], codes[1], pref}
+	}
+	return []string{pref}
+}
+
+// audioLangArgs returns the mpv argument selecting the preferred audio track.
+// Without it mpv plays whichever track comes first, which on a multi-dub
+// release is routinely not the original language.
+func audioLangArgs(pref string) []string {
+	list := audioLangList(pref)
+	if len(list) == 0 {
+		return nil
+	}
+	return []string{"--alang=" + strings.Join(list, ",")}
+}
+
+// vlcAudioLangArgs is the same preference in VLC's spelling.
+func vlcAudioLangArgs(pref string) []string {
+	list := audioLangList(pref)
+	if len(list) == 0 {
+		return nil
+	}
+	return []string{"--audio-language=" + strings.Join(list, ",")}
+}

--- a/internal/player/alang.go
+++ b/internal/player/alang.go
@@ -1,51 +1,16 @@
 package player
 
-import "strings"
+import (
+	"strings"
 
-// audioLangCodes maps a language name to the spellings a muxer might have
-// written into the track's language tag. Releases are inconsistent: the same
-// English track is tagged "eng" (ISO 639-2), "en" (639-1) or "english"
-// depending on who packed it, so all three have to be offered or the
-// preference silently misses.
-var audioLangCodes = map[string][2]string{
-	"english":    {"eng", "en"},
-	"spanish":    {"spa", "es"},
-	"french":     {"fre", "fr"},
-	"german":     {"ger", "de"},
-	"italian":    {"ita", "it"},
-	"portuguese": {"por", "pt"},
-	"russian":    {"rus", "ru"},
-	"japanese":   {"jpn", "ja"},
-	"korean":     {"kor", "ko"},
-	"chinese":    {"chi", "zh"},
-	"arabic":     {"ara", "ar"},
-	"turkish":    {"tur", "tr"},
-	"hindi":      {"hin", "hi"},
-	"tamil":      {"tam", "ta"},
-	"telugu":     {"tel", "te"},
-	"dutch":      {"dut", "nl"},
-	"polish":     {"pol", "pl"},
-}
-
-// audioLangList returns the ordered language tags to prefer, most specific
-// first. An unknown name is still passed through on its own, so an uncommon
-// language is a degraded match rather than a silent no-op.
-func audioLangList(pref string) []string {
-	pref = strings.ToLower(strings.TrimSpace(pref))
-	if pref == "" {
-		return nil
-	}
-	if codes, ok := audioLangCodes[pref]; ok {
-		return []string{codes[0], codes[1], pref}
-	}
-	return []string{pref}
-}
+	"lobster/internal/lang"
+)
 
 // audioLangArgs returns the mpv argument selecting the preferred audio track.
 // Without it mpv plays whichever track comes first, which on a multi-dub
 // release is routinely not the original language.
 func audioLangArgs(pref string) []string {
-	list := audioLangList(pref)
+	list := lang.Aliases(pref)
 	if len(list) == 0 {
 		return nil
 	}
@@ -54,7 +19,7 @@ func audioLangArgs(pref string) []string {
 
 // vlcAudioLangArgs is the same preference in VLC's spelling.
 func vlcAudioLangArgs(pref string) []string {
-	list := audioLangList(pref)
+	list := lang.Aliases(pref)
 	if len(list) == 0 {
 		return nil
 	}

--- a/internal/player/alang_test.go
+++ b/internal/player/alang_test.go
@@ -1,0 +1,30 @@
+package player
+
+import "testing"
+
+// The audio-language preference has to reach the player: a Hindi-dubbed release
+// with tagged tracks otherwise plays whichever track the muxer happened to put
+// first, which is what "all 4 audio tracks are Hindi" looks like from the couch.
+func TestAudioLangArgsPrefersEnglishSpellings(t *testing.T) {
+	got := audioLangArgs("english")
+	// mpv matches on the track's language tag, and releases spell it eng, en or
+	// english depending on the muxer — all three have to be listed, in order.
+	want := "--alang=eng,en,english"
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("audioLangArgs(english) = %v, want [%s]", got, want)
+	}
+}
+
+func TestAudioLangArgsEmptyPreferenceAddsNothing(t *testing.T) {
+	if got := audioLangArgs(""); len(got) != 0 {
+		t.Errorf("audioLangArgs(\"\") = %v, want no args", got)
+	}
+}
+
+func TestAudioLangArgsUnknownLanguagePassedThrough(t *testing.T) {
+	got := audioLangArgs("japanese")
+	want := "--alang=jpn,ja,japanese"
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("audioLangArgs(japanese) = %v, want [%s]", got, want)
+	}
+}

--- a/internal/player/alang_wiring_test.go
+++ b/internal/player/alang_wiring_test.go
@@ -3,23 +3,37 @@ package player
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"lobster/internal/media"
 )
 
-// The arg builder being correct is worth nothing if Play never calls it. This
-// puts a fake mpv on PATH and asserts the flag actually reaches the process.
-func TestMPVPlayPassesAudioLanguageToTheProcess(t *testing.T) {
+// fakeMPV writes a stand-in mpv onto PATH that records the arguments it was
+// given. Windows cannot run a #!/bin/sh script, and LookPath there resolves
+// .bat via PATHEXT, so the stub has to differ by platform — the assertion does
+// not, which is the point.
+func fakeMPV(t *testing.T) (logPath string) {
+	t.Helper()
 	dir := t.TempDir()
-	log := filepath.Join(dir, "args.txt")
-	fake := filepath.Join(dir, "mpv")
-	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + log + "\nexit 0\n"
-	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+	logPath = filepath.Join(dir, "args.txt")
+
+	name, script := "mpv", "#!/bin/sh\nprintf '%s\\n' \"$@\" > "+logPath+"\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name, script = "mpv.bat", "@echo off\r\necho %* > \""+logPath+"\"\r\nexit /b 0\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+// The arg builder being correct is worth nothing if Play never calls it. This
+// puts a fake mpv on PATH and asserts the flag actually reaches the process.
+func TestMPVPlayPassesAudioLanguageToTheProcess(t *testing.T) {
+	log := fakeMPV(t)
 
 	p := New("mpv", "english")
 	// mpv exits immediately; Play may report an error from the IPC hop, which is

--- a/internal/player/alang_wiring_test.go
+++ b/internal/player/alang_wiring_test.go
@@ -1,0 +1,36 @@
+package player
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// The arg builder being correct is worth nothing if Play never calls it. This
+// puts a fake mpv on PATH and asserts the flag actually reaches the process.
+func TestMPVPlayPassesAudioLanguageToTheProcess(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "args.txt")
+	fake := filepath.Join(dir, "mpv")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + log + "\nexit 0\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	p := New("mpv", "english")
+	// mpv exits immediately; Play may report an error from the IPC hop, which is
+	// irrelevant here — the assertion is on what got executed.
+	_, _ = p.Play(&media.Stream{URL: "http://127.0.0.1:1/x.m3u8"}, "t", 0, nil)
+
+	got, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("fake mpv was never executed: %v", err)
+	}
+	if !strings.Contains(string(got), "--alang=eng,en,english") {
+		t.Errorf("--alang not passed to mpv; args were:\n%s", got)
+	}
+}

--- a/internal/player/generic.go
+++ b/internal/player/generic.go
@@ -11,7 +11,8 @@ import (
 // Generic implements the Player interface for players like iina and celluloid
 // that accept mpv-compatible arguments.
 type Generic struct {
-	name string
+	name      string
+	audioLang string
 }
 
 func (g *Generic) Name() string { return g.name }
@@ -33,6 +34,7 @@ func (g *Generic) Play(stream *media.Stream, title string, startPos float64, sub
 
 	// Both iina and celluloid accept mpv-style flags
 	args = append(args, "--force-media-title="+title)
+	args = append(args, audioLangArgs(g.audioLang)...)
 	args = append(args, genericHeaderArgs(stream)...)
 
 	if startPos > 0 {

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -18,7 +18,7 @@ import (
 // MPV implements the Player interface for mpv.
 // Uses exec.Command with explicit args (no shell interpretation)
 // and IPC via Unix socket at a randomized temp path.
-type MPV struct{}
+type MPV struct{ audioLang string }
 
 func (m *MPV) Name() string { return "mpv" }
 
@@ -56,6 +56,7 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 		"--network-timeout=15",
 	}
 
+	args = append(args, audioLangArgs(m.audioLang)...)
 	args = append(args, mpvHeaderArgs(stream)...)
 
 	if startPos > 0 {

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -43,16 +43,18 @@ func NotFoundError(name string) error {
 	return fmt.Errorf("player %q not found in PATH", name)
 }
 
-// New creates a player by name.
-func New(name string) Player {
+// New creates a player by name. audioLang is the preferred audio-track
+// language; it is passed to the player so a multi-dub release does not default
+// to whichever track the muxer happened to list first.
+func New(name, audioLang string) Player {
 	switch name {
 	case "mpv":
-		return &MPV{}
+		return &MPV{audioLang: audioLang}
 	case "vlc":
-		return &VLC{}
+		return &VLC{audioLang: audioLang}
 	case "iina", "celluloid":
-		return &Generic{name: name}
+		return &Generic{name: name, audioLang: audioLang}
 	default:
-		return &MPV{} // Default to mpv
+		return &MPV{audioLang: audioLang} // Default to mpv
 	}
 }

--- a/internal/player/vlc.go
+++ b/internal/player/vlc.go
@@ -9,7 +9,7 @@ import (
 )
 
 // VLC implements the Player interface for VLC media player.
-type VLC struct{}
+type VLC struct{ audioLang string }
 
 func (v *VLC) Name() string { return "vlc" }
 
@@ -38,6 +38,7 @@ func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFile
 		"--play-and-exit",
 	}
 
+	args = append(args, vlcAudioLangArgs(v.audioLang)...)
 	args = append(args, vlcHeaderArgs(stream)...)
 
 	if startPos > 0 {

--- a/internal/provider/audiolang.go
+++ b/internal/provider/audiolang.go
@@ -2,48 +2,9 @@ package provider
 
 import (
 	"sort"
-	"strings"
+
+	"lobster/internal/lang"
 )
-
-// audioLangAliases are the spellings a source may use for a language tag.
-// Vidzee and friends are inconsistent — "english", "eng", "en" and "en-US" all
-// appear for the same dub.
-var audioLangAliases = map[string][]string{
-	"english":    {"english", "eng", "en"},
-	"spanish":    {"spanish", "spa", "es"},
-	"french":     {"french", "fre", "fra", "fr"},
-	"german":     {"german", "ger", "deu", "de"},
-	"italian":    {"italian", "ita", "it"},
-	"portuguese": {"portuguese", "por", "pt"},
-	"japanese":   {"japanese", "jpn", "ja"},
-	"korean":     {"korean", "kor", "ko"},
-	"hindi":      {"hindi", "hin", "hi"},
-	"tamil":      {"tamil", "tam", "ta"},
-	"telugu":     {"telugu", "tel", "te"},
-}
-
-// matchesAudioLang reports whether a source's language tag names pref. The tag
-// is matched on its primary subtag so "en-US" counts as English.
-func matchesAudioLang(tag, pref string) bool {
-	tag = strings.ToLower(strings.TrimSpace(tag))
-	if tag == "" {
-		return false
-	}
-	if i := strings.IndexAny(tag, "-_"); i > 0 {
-		tag = tag[:i]
-	}
-	pref = strings.ToLower(strings.TrimSpace(pref))
-	aliases, ok := audioLangAliases[pref]
-	if !ok {
-		aliases = []string{pref}
-	}
-	for _, a := range aliases {
-		if tag == a {
-			return true
-		}
-	}
-	return false
-}
 
 // preferAudioLang returns srcs reordered so sources tagged with the preferred
 // language come first, keeping the provider's own order within each group.
@@ -56,7 +17,7 @@ func preferAudioLang(srcs []tbcplVidzeeSource, pref string) []tbcplVidzeeSource 
 	out := make([]tbcplVidzeeSource, len(srcs))
 	copy(out, srcs)
 	sort.SliceStable(out, func(i, j int) bool {
-		return matchesAudioLang(out[i].Lang, pref) && !matchesAudioLang(out[j].Lang, pref)
+		return lang.Matches(out[i].Lang, pref) && !lang.Matches(out[j].Lang, pref)
 	})
 	return out
 }

--- a/internal/provider/audiolang.go
+++ b/internal/provider/audiolang.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"sort"
+	"strings"
+)
+
+// audioLangAliases are the spellings a source may use for a language tag.
+// Vidzee and friends are inconsistent — "english", "eng", "en" and "en-US" all
+// appear for the same dub.
+var audioLangAliases = map[string][]string{
+	"english":    {"english", "eng", "en"},
+	"spanish":    {"spanish", "spa", "es"},
+	"french":     {"french", "fre", "fra", "fr"},
+	"german":     {"german", "ger", "deu", "de"},
+	"italian":    {"italian", "ita", "it"},
+	"portuguese": {"portuguese", "por", "pt"},
+	"japanese":   {"japanese", "jpn", "ja"},
+	"korean":     {"korean", "kor", "ko"},
+	"hindi":      {"hindi", "hin", "hi"},
+	"tamil":      {"tamil", "tam", "ta"},
+	"telugu":     {"telugu", "tel", "te"},
+}
+
+// matchesAudioLang reports whether a source's language tag names pref. The tag
+// is matched on its primary subtag so "en-US" counts as English.
+func matchesAudioLang(tag, pref string) bool {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return false
+	}
+	if i := strings.IndexAny(tag, "-_"); i > 0 {
+		tag = tag[:i]
+	}
+	pref = strings.ToLower(strings.TrimSpace(pref))
+	aliases, ok := audioLangAliases[pref]
+	if !ok {
+		aliases = []string{pref}
+	}
+	for _, a := range aliases {
+		if tag == a {
+			return true
+		}
+	}
+	return false
+}
+
+// preferAudioLang returns srcs reordered so sources tagged with the preferred
+// language come first, keeping the provider's own order within each group.
+// Nothing is dropped: a preferred source that fails to decrypt still falls
+// through to the others.
+func preferAudioLang(srcs []tbcplVidzeeSource, pref string) []tbcplVidzeeSource {
+	if pref == "" || len(srcs) < 2 {
+		return srcs
+	}
+	out := make([]tbcplVidzeeSource, len(srcs))
+	copy(out, srcs)
+	sort.SliceStable(out, func(i, j int) bool {
+		return matchesAudioLang(out[i].Lang, pref) && !matchesAudioLang(out[j].Lang, pref)
+	})
+	return out
+}

--- a/internal/provider/tbcpl.go
+++ b/internal/provider/tbcpl.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha256"
@@ -8,12 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
-	"context"
-	"net"
 	"sync"
 	"time"
 
@@ -43,6 +43,15 @@ type TBCPL struct {
 	searchCache map[string]tbcplCatalogItem
 	seasonCache map[string]*tbcplSeasonResponse
 	vidzeeKey   string
+	audioLang   string
+}
+
+// SetAudioLanguage sets the preferred audio-track language used to order
+// Vidzee's per-dub sources. Empty keeps the provider's own order.
+func (t *TBCPL) SetAudioLanguage(lang string) {
+	t.mu.Lock()
+	t.audioLang = lang
+	t.mu.Unlock()
 }
 
 // NewTBCPL creates a new TBCPL provider.
@@ -58,6 +67,7 @@ func NewTBCPL(base string) *TBCPL {
 		tmdbBaseURL:   tbcplTMDBBase,
 		vidzeeBaseURL: tbcplVidzeeBase,
 		vidzeeKeyURL:  tbcplVidzeeKeyURL,
+		audioLang:     "english",
 		searchCache:   make(map[string]tbcplCatalogItem),
 		seasonCache:   make(map[string]*tbcplSeasonResponse),
 	}
@@ -479,7 +489,14 @@ func (t *TBCPL) watchWithServer(mediaID, episodeID string, server tbcplDirectSer
 		return nil, err
 	}
 
-	for _, source := range resp.URL {
+	// Vidzee returns one source per audio dub, in no dependable order, so
+	// taking the first is how an English film ends up playing in Hindi on every
+	// server. Order by the preferred language first; everything else stays as a
+	// fallback for when the preferred source will not decrypt.
+	t.mu.RLock()
+	pref := t.audioLang
+	t.mu.RUnlock()
+	for _, source := range preferAudioLang(resp.URL, pref) {
 		streamURL, err := decryptTBCPLVidzeeLink(source.Link, key)
 		if err != nil || streamURL == "" {
 			continue

--- a/internal/provider/tbcpl_lang_test.go
+++ b/internal/provider/tbcpl_lang_test.go
@@ -48,3 +48,37 @@ func TestPreferAudioLangUntaggedSourcesUnchanged(t *testing.T) {
 		t.Errorf("untagged order changed: %+v", got)
 	}
 }
+
+// The regression the shared table exists to prevent: the player knew "rus" but
+// the provider's own map did not, so -a russian reordered nothing and the
+// upstream dub order won.
+func TestPreferAudioLangHandlesEveryAdvertisedLanguage(t *testing.T) {
+	for _, pref := range []string{
+		"russian", "chinese", "arabic", "turkish", "dutch", "polish",
+		"english", "japanese", "hindi", "tamil", "telugu",
+	} {
+		// The decoy must be a language the table cannot match, or a pref of
+		// "hindi" collides with a hindi decoy and the stable sort rightly keeps
+		// the first — a fixture bug that looks like a code bug.
+		srcs := []tbcplVidzeeSource{
+			{Lang: "swahili", Link: "decoy"},
+			{Lang: pref, Link: "want"},
+		}
+		if got := preferAudioLang(srcs, pref); got[0].Link != "want" {
+			t.Errorf("preferAudioLang did not prioritise %q: %+v", pref, got)
+		}
+	}
+}
+
+// ISO codes too, since that is what the sources actually send.
+func TestPreferAudioLangMatchesISOCodesForNonEnglish(t *testing.T) {
+	for pref, tag := range map[string]string{
+		"russian": "rus", "chinese": "zh", "arabic": "ara",
+		"turkish": "tr", "dutch": "dut", "polish": "pl",
+	} {
+		srcs := []tbcplVidzeeSource{{Lang: "swahili", Link: "decoy"}, {Lang: tag, Link: "want"}}
+		if got := preferAudioLang(srcs, pref); got[0].Link != "want" {
+			t.Errorf("tag %q not matched for %q", tag, pref)
+		}
+	}
+}

--- a/internal/provider/tbcpl_lang_test.go
+++ b/internal/provider/tbcpl_lang_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import "testing"
+
+// Vidzee lists one source per audio dub and does not order them predictably.
+// Taking the first is how a Hindi dub ends up playing for an English film on
+// every one of the four servers.
+func TestPreferEnglishSourcePicksEnglishNotFirst(t *testing.T) {
+	srcs := []tbcplVidzeeSource{
+		{Lang: "hindi", Link: "hi"},
+		{Lang: "tamil", Link: "ta"},
+		{Lang: "english", Link: "en"},
+		{Lang: "telugu", Link: "te"},
+	}
+	got := preferAudioLang(srcs, "english")
+	if len(got) == 0 || got[0].Link != "en" {
+		t.Fatalf("english source not first: %+v", got)
+	}
+	// The rest must survive as fallbacks — an English source that fails to
+	// decrypt should not leave the caller with nothing to try.
+	if len(got) != len(srcs) {
+		t.Errorf("dropped candidates: got %d, want %d", len(got), len(srcs))
+	}
+}
+
+func TestPreferAudioLangAcceptsCodeSpellings(t *testing.T) {
+	for _, tag := range []string{"eng", "en", "English", "en-US"} {
+		srcs := []tbcplVidzeeSource{{Lang: "hindi", Link: "hi"}, {Lang: tag, Link: "en"}}
+		if got := preferAudioLang(srcs, "english"); got[0].Link != "en" {
+			t.Errorf("tag %q not matched as english", tag)
+		}
+	}
+}
+
+// No tagged match must not reorder anything: the provider's own order is the
+// only signal left, and a stable list keeps behaviour predictable.
+func TestPreferAudioLangNoMatchKeepsOrder(t *testing.T) {
+	srcs := []tbcplVidzeeSource{{Lang: "hindi", Link: "hi"}, {Lang: "tamil", Link: "ta"}}
+	got := preferAudioLang(srcs, "english")
+	if got[0].Link != "hi" || got[1].Link != "ta" {
+		t.Errorf("order changed with no match: %+v", got)
+	}
+}
+
+func TestPreferAudioLangUntaggedSourcesUnchanged(t *testing.T) {
+	srcs := []tbcplVidzeeSource{{Link: "a"}, {Link: "b"}}
+	if got := preferAudioLang(srcs, "english"); got[0].Link != "a" {
+		t.Errorf("untagged order changed: %+v", got)
+	}
+}

--- a/internal/provider/tbcpl_lang_test.go
+++ b/internal/provider/tbcpl_lang_test.go
@@ -82,3 +82,16 @@ func TestPreferAudioLangMatchesISOCodesForNonEnglish(t *testing.T) {
 		}
 	}
 }
+
+// The terminological ISO 639-2 codes reach the provider's source ordering too.
+// fra and deu were supported before the shared table and were briefly lost.
+func TestPreferAudioLangMatchesTerminologicalISOCodes(t *testing.T) {
+	for pref, tag := range map[string]string{
+		"french": "fra", "german": "deu", "chinese": "zho", "dutch": "nld",
+	} {
+		srcs := []tbcplVidzeeSource{{Lang: "swahili", Link: "decoy"}, {Lang: tag, Link: "want"}}
+		if got := preferAudioLang(srcs, pref); got[0].Link != "want" {
+			t.Errorf("tag %q not matched for %q", tag, pref)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

Watching *The Amazing Spider-Man* gave Hindi audio on **every one of the four TBCPL servers** (Togi, Achilles, Nflix, Drag), with no English track to switch to.

The codebase had **no audio-language handling anywhere** — no `--alang`, no config key, no flag, and nothing that scored a source by language. Three separate gaps:

1. **`internal/provider/tbcpl.go`** — Vidzee returns one source per dub, each tagged with `lang`. `watchWithServer` returned the first that decrypted and discarded the tag entirely. If Hindi is listed first, Hindi plays, on every server.
2. **Players got no language preference** — mpv never received `--alang` (nor vlc `--audio-language`), so a release carrying several tagged tracks played whichever the muxer listed first.
3. **No way to express a preference** at all.

## The fix

- `audio_language` config key (default `english`) and `-a/--audio-language`, plumbed to mpv, vlc, iina and celluloid.
- Vidzee's sources ordered by the preferred language.
- Tags matched across spellings (`english`/`eng`/`en`, and `en-US` by its primary subtag) because sources are not consistent about which they use.

**Reordering never drops a candidate.** A preferred source that fails to decrypt still falls through to the rest, so this cannot turn a working stream into no stream.

## Testing

Test-first throughout; every test was watched failing before the code existed.

The wiring test is the one worth reading: it puts a fake `mpv` on `PATH` and asserts the flag reaches the actual process. A correct arg builder that nothing calls would pass a unit test happily. Verified by mutation — commenting out the `append` in `mpv.go` makes it fail:

```
--- FAIL: TestMPVPlayPassesAudioLanguageToTheProcess
```

`go vet ./...` and the full suite are clean.

## Known gaps, deliberately not fixed here

- **TBCPL is broken for unrelated reasons.** Its Vidzee endpoint now returns HTML instead of JSON (`404` on `/api/server`), so the reorder could not be proven end-to-end against the live API — the logic is unit-tested only. The provider needs separate repair before it returns streams at all.
- **VaPlayer still takes `stream_urls[0]`.** It offers 3 URLs for this film, but they carry no language metadata — I decoded the payloads and checked the master playlists; both VaPlayer and VidNest are plain quality-variant masters with muxed, untagged audio. There is nothing to select on, so I left it rather than guess.

Because the two sources that currently resolve for this film are VaPlayer and VidNest, and neither tags audio, this may not change that particular title today — the Hindi audio there is baked into the release. The fix addresses the tagged-source and tagged-track cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--audio-language`/`-a` to select a preferred audio track language.
  * Added configuration support with English as the default.
  * Playback now prioritizes matching audio sources and passes language preferences to supported players.
* **Documentation**
  * Updated the README and guide with the new flag and configuration example.
* **Bug Fixes**
  * Applied audio-language preferences consistently across regular, live, and fallback playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->