### PR TITLE
feat(vaplayer): expose every stream URL as a selectable source

### DIFF
--- a/internal/provider/vaplayer.go
+++ b/internal/provider/vaplayer.go
@@ -182,10 +182,17 @@ func (vp *VaPlayer) GetServers(id string, episodeID string) ([]media.Server, err
 // never issued) keeps the first source rather than failing.
 func vaplayerSourceIndex(server string, n int) int {
 	var i int
-	if _, err := fmt.Sscanf(strings.TrimSpace(server), "Source %d", &i); err != nil {
+	name := strings.TrimSpace(server)
+	if _, err := fmt.Sscanf(name, "Source %d", &i); err != nil {
 		return 0
 	}
 	if i < 1 || i > n {
+		return 0
+	}
+	// Sscanf stops after %d and ignores anything that follows, so names like
+	// "Source 2 legacy" would otherwise select source 2. Only a name this
+	// provider actually issued may pick a source; everything else falls back.
+	if name != fmt.Sprintf("Source %d", i) {
 		return 0
 	}
 	return i - 1

--- a/internal/provider/vaplayer.go
+++ b/internal/provider/vaplayer.go
@@ -12,10 +12,10 @@ import (
 	"lobster/internal/media"
 )
 
-const (
-	vaplayerBase    = "https://streamdata.vaplayer.ru/api.php"
-	vaplayerReferer = "https://nextgencloudfabric.com/"
-)
+const vaplayerReferer = "https://nextgencloudfabric.com/"
+
+// vaplayerBase is a var so tests can point it at a stub server.
+var vaplayerBase = "https://streamdata.vaplayer.ru/api.php"
 
 // VaPlayer implements the StreamProvider interface using the vaplayer
 // streaming API. It accepts TMDB IDs and returns direct HLS m3u8 URLs.
@@ -151,8 +151,44 @@ func (vp *VaPlayer) GetEpisodes(id string, seasonID string) ([]media.Episode, er
 }
 
 // GetServers returns a single server.
+// GetServers lists one entry per stream URL the API offers. They are separate
+// mirrors and, in practice, sometimes separate dubs — collapsing them to a
+// single "VaPlayer" server meant only the first was ever reachable, so an
+// English film served Hindi-first had no alternative to fall back to.
 func (vp *VaPlayer) GetServers(id string, episodeID string) ([]media.Server, error) {
-	return []media.Server{{Name: "VaPlayer", ID: "default"}}, nil
+	apiURL, err := vp.apiURLFor(id, episodeID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := vp.fetchAPI(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("vaplayer: %w", err)
+	}
+	if len(resp.Data.StreamURLs) == 0 {
+		return nil, fmt.Errorf("vaplayer: no stream URLs")
+	}
+	servers := make([]media.Server, 0, len(resp.Data.StreamURLs))
+	for i := range resp.Data.StreamURLs {
+		servers = append(servers, media.Server{
+			Name: fmt.Sprintf("Source %d", i+1),
+			ID:   strconv.Itoa(i),
+		})
+	}
+	return servers, nil
+}
+
+// vaplayerSourceIndex maps a server name back to its stream_urls index. An
+// unknown name (the resolver and watch history both pass names this provider
+// never issued) keeps the first source rather than failing.
+func vaplayerSourceIndex(server string, n int) int {
+	var i int
+	if _, err := fmt.Sscanf(strings.TrimSpace(server), "Source %d", &i); err != nil {
+		return 0
+	}
+	if i < 1 || i > n {
+		return 0
+	}
+	return i - 1
 }
 
 // GetEmbedURL is not used for this provider.
@@ -161,33 +197,45 @@ func (vp *VaPlayer) GetEmbedURL(serverID string) (string, error) {
 }
 
 // Watch resolves a stream URL through the vaplayer API.
-func (vp *VaPlayer) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+// apiURLFor builds the vaplayer API URL for a movie or a specific episode.
+func (vp *VaPlayer) apiURLFor(mediaID, episodeID string) (string, error) {
 	tmdbID := extractTMDBID(mediaID)
 	if err := httputil.ValidateNumericID(tmdbID); err != nil {
-		return nil, fmt.Errorf("vaplayer: invalid TMDB ID: %w", err)
+		return "", fmt.Errorf("vaplayer: invalid TMDB ID: %w", err)
 	}
 
 	var apiURL string
 	if episodeID != "" {
 		parts := strings.SplitN(episodeID, ":", 3)
 		if len(parts) != 3 {
-			return nil, fmt.Errorf("invalid episode ID: %s", episodeID)
+			return "", fmt.Errorf("invalid episode ID: %s", episodeID)
 		}
 		if err := httputil.ValidateNumericID(parts[0]); err != nil {
-			return nil, fmt.Errorf("vaplayer: invalid TMDB ID in episode: %w", err)
+			return "", fmt.Errorf("vaplayer: invalid TMDB ID in episode: %w", err)
 		}
 		seasonNum, err := strconv.Atoi(parts[1])
 		if err != nil || seasonNum <= 0 {
-			return nil, fmt.Errorf("vaplayer: invalid season in episode ID: %s", episodeID)
+			return "", fmt.Errorf("vaplayer: invalid season in episode ID: %s", episodeID)
 		}
 		episodeNum, err := strconv.Atoi(parts[2])
 		if err != nil || episodeNum <= 0 {
-			return nil, fmt.Errorf("vaplayer: invalid episode in episode ID: %s", episodeID)
+			return "", fmt.Errorf("vaplayer: invalid episode in episode ID: %s", episodeID)
 		}
 		apiURL = fmt.Sprintf("%s?tmdb=%s&type=tv&season=%s&episode=%s",
 			vaplayerBase, parts[0], parts[1], parts[2])
 	} else {
 		apiURL = fmt.Sprintf("%s?tmdb=%s&type=movie", vaplayerBase, tmdbID)
+	}
+	return apiURL, nil
+}
+
+// Watch resolves a stream URL through the vaplayer API. server selects which of
+// the API's stream_urls to use ("Source N", as listed by GetServers); anything
+// unrecognised keeps the first, which is the historical behaviour.
+func (vp *VaPlayer) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	apiURL, err := vp.apiURLFor(mediaID, episodeID)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := vp.fetchAPI(apiURL)
@@ -216,7 +264,7 @@ func (vp *VaPlayer) Watch(mediaID, episodeID, server, quality string) (*media.St
 	}
 
 	return &media.Stream{
-		URL:       resp.Data.StreamURLs[0],
+		URL:       resp.Data.StreamURLs[vaplayerSourceIndex(server, len(resp.Data.StreamURLs))],
 		Quality:   quality,
 		Subtitles: subs,
 		Referer:   vaplayerReferer,

--- a/internal/provider/vaplayer_sources_test.go
+++ b/internal/provider/vaplayer_sources_test.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// vaplayer returns several stream URLs per title — different mirrors, and in
+// practice different dubs. Only the first was ever used, so an English film
+// served with a Hindi track first had no reachable alternative.
+func TestVaPlayerGetServersExposesEveryStreamURL(t *testing.T) {
+	srv := vaplayerStub(t, []string{"http://a/1.m3u8", "http://b/2.m3u8", "http://c/3.m3u8"})
+	defer srv.Close()
+
+	vp := NewVaPlayer()
+	servers, err := vp.GetServers("movie/1930", "")
+	if err != nil {
+		t.Fatalf("GetServers: %v", err)
+	}
+	if len(servers) != 3 {
+		t.Fatalf("got %d servers, want 3: %+v", len(servers), servers)
+	}
+	if servers[0].Name != "Source 1" || servers[2].Name != "Source 3" {
+		t.Errorf("unexpected names: %+v", servers)
+	}
+}
+
+func TestVaPlayerWatchHonoursSelectedSource(t *testing.T) {
+	srv := vaplayerStub(t, []string{"http://a/1.m3u8", "http://b/2.m3u8", "http://c/3.m3u8"})
+	defer srv.Close()
+
+	vp := NewVaPlayer()
+	for name, want := range map[string]string{
+		"Source 1": "http://a/1.m3u8",
+		"Source 2": "http://b/2.m3u8",
+		"Source 3": "http://c/3.m3u8",
+	} {
+		st, err := vp.Watch("movie/1930", "", name, "1080")
+		if err != nil {
+			t.Fatalf("Watch(%s): %v", name, err)
+		}
+		if st.URL != want {
+			t.Errorf("Watch(%s) = %s, want %s", name, st.URL, want)
+		}
+	}
+}
+
+// An unknown or legacy server name must still play rather than error — the
+// resolver and history both pass names this provider never issued.
+func TestVaPlayerWatchUnknownSourceFallsBackToFirst(t *testing.T) {
+	srv := vaplayerStub(t, []string{"http://a/1.m3u8", "http://b/2.m3u8"})
+	defer srv.Close()
+
+	vp := NewVaPlayer()
+	for _, name := range []string{"", "Default", "VaPlayer", "Source 99"} {
+		st, err := vp.Watch("movie/1930", "", name, "1080")
+		if err != nil {
+			t.Fatalf("Watch(%q): %v", name, err)
+		}
+		if st.URL != "http://a/1.m3u8" {
+			t.Errorf("Watch(%q) = %s, want the first source", name, st.URL)
+		}
+	}
+}
+
+func vaplayerStub(t *testing.T, urls []string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"status_code": "200",
+			"data": map[string]any{
+				"title":       "The Amazing Spider-Man",
+				"stream_urls": urls,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	old := vaplayerBase
+	vaplayerBase = srv.URL
+	t.Cleanup(func() { vaplayerBase = old })
+	return srv
+}

--- a/internal/provider/vaplayer_sources_test.go
+++ b/internal/provider/vaplayer_sources_test.go
@@ -54,7 +54,10 @@ func TestVaPlayerWatchUnknownSourceFallsBackToFirst(t *testing.T) {
 	defer srv.Close()
 
 	vp := NewVaPlayer()
-	for _, name := range []string{"", "Default", "VaPlayer", "Source 99"} {
+	// "Source 2 legacy" must NOT select source 2: fmt.Sscanf stops after %d
+	// and ignores the trailing text, so a name this provider never issued
+	// would otherwise index stream_urls[1] instead of falling back.
+	for _, name := range []string{"", "Default", "VaPlayer", "Source 99", "Source 2 legacy", "Source 2x", "Source 2."} {
 		st, err := vp.Watch("movie/1930", "", name, "1080")
 		if err != nil {
 			t.Fatalf("Watch(%q): %v", name, err)


### PR DESCRIPTION
## The bug

The vaplayer API returns several `stream_urls` per title and `Watch` always used `[0]`.

They are separate mirrors and, in practice, sometimes separate dubs. *The Amazing Spider-Man* resolves to **three**, and the first plays a Hindi track for a film whose own `file_name` the API reports as an English YIFY BrRip:

```
The.Amazing.Spiderman.2012.1080p.BrRip.x264.YIFY.mp4
```

There was no way to reach the other two.

## The change

`GetServers` now lists one entry per stream URL (`Source 1`…`Source N`) and `Watch` maps that name back to the index. The existing server-cycling loop and `-p/--provider` selection reach them with no new UI:

```
lobster -p "Source 2" "The Amazing Spider-Man"
```

Verified live:

```
servers: [{Source 1 0} {Source 2 1} {Source 3 2}]
  Source 1 -> https://innovationdrivenstudio.site/...
  Source 2 -> https://innovationdrivenstudio.site/...   (different)
  Source 3 -> https://innovationdrivenstudio.site/...   (different)
```

## Compatibility

An unrecognised or empty server name still resolves to the first source. This mattered: the resolver passes `"Default"` and watch history replays whatever name was stored, so it had to stay a no-op for every existing caller rather than becoming an error. There's a test for exactly that (`""`, `"Default"`, `"VaPlayer"`, `"Source 99"`).

The movie/episode URL construction moved into `apiURLFor` so `GetServers` and `Watch` agree on it instead of duplicating the branching. `vaplayerBase` becomes a var so tests can point it at a stub.

## Honest limitation

This does **not** identify which source is English — the URLs carry no language metadata, and I checked: both vaplayer and vidnest serve plain quality-variant masters with muxed, untagged audio. It makes the alternatives reachable so a user can try them; it does not choose for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting from all available VaPlayer stream sources.
  * Each stream is now displayed as a separate source, allowing viewers to choose their preferred option.
  * Existing or unrecognized source selections continue to open the first available stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->