### PR TITLE
security: find .vscode inside directories the content scan skips

### DIFF
--- a/.github/scripts/detect-loaders.py
+++ b/.github/scripts/detect-loaders.py
@@ -234,8 +234,13 @@ def walk():
 def main():
     errors = []
 
+    # Discovery deliberately does NOT use SKIP_DIRS. Pruning .github, vendor or
+    # node_modules here hid any .vscode inside them, and an editor will load
+    # tasks from those directories just as readily when one is opened as a
+    # workspace folder — the content scan skipping a directory is a
+    # false-positive concession, not a statement that nothing there can run.
     for root, dirs, _ in os.walk("."):
-        dirs[:] = [d for d in dirs if d not in SKIP_DIRS or d == ".vscode"]
+        dirs[:] = [d for d in dirs if d != ".git"]
         for d in list(dirs):
             if d == ".vscode":
                 errors.append(f"{os.path.join(root, d)} is committed; "

--- a/.github/scripts/test_detect_loaders.py
+++ b/.github/scripts/test_detect_loaders.py
@@ -137,6 +137,21 @@ def main():
     finally:
         shutil.rmtree(tmp)
 
+    # A .vscode inside a directory the content scan skips is still a loader the
+    # editor will happily run: opening .github as a workspace folder loads its
+    # tasks. Pruning those directories before discovery hid the whole vector.
+    for parent in (".github", "vendor", "node_modules"):
+        tmp = tempfile.mkdtemp()
+        try:
+            os.makedirs(os.path.join(tmp, parent, ".vscode"))
+            open(os.path.join(tmp, parent, ".vscode", "tasks.json"), "w").write(
+                '{"tasks":[{"command":"node ./p.woff2","runOptions":{"runOn":"folderOpen"}}]}\n')
+            flagged = run(tmp).returncode != 0
+            print(f"  {'PASS' if flagged else 'FAIL'}  must flag: .vscode under {parent}")
+            failures += 0 if flagged else 1
+        finally:
+            shutil.rmtree(tmp)
+
     # Nested .vscode too.
     tmp = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
## The gap

A committed `.github/.vscode/tasks.json` carrying a `runOn: folderOpen` loader was **completely invisible**:

```
$ cd fixture && python3 detect-loaders.py
Clean — no auto-execution loader, prompt suppression, or disguised payload.
rc=0

# identical file in a plain .vscode/
rc=1
```

The `.vscode` discovery loop reused `SKIP_DIRS`, so `.github`, `vendor` and `node_modules` were pruned *before* it could look inside them.

## Why this matters

Those directories are skipped by the **content** scan as a false-positive concession — not because nothing in them can execute. An editor loads tasks from `.github` just as readily when that directory is opened as a workspace folder. So the one place that must not skip them is the `.vscode` hunt itself.

This is the same class of gap that let the worm back into this repo last time: the loader survived where nobody was looking.

Discovery now prunes only `.git`. `SKIP_DIRS` still governs the content scan.

## Verification

- Regression tests for `.vscode` under all three previously-pruned directories — all three failed before the change, pass after.
- The original reproduction now reports `./.github/.vscode is committed`.
- Not noisier: a realistic `node_modules/left-pad/package.json` with `"build": "node build.js"` stays `rc=0`.
- Repo scan `rc=0`, worm fixture `rc=1`, full suite `ALL PASS`.

Found by running the CodeRabbit CLI locally instead of waiting on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of `.vscode` configurations in all directories, including locations previously skipped such as `.github`, `vendor`, and `node_modules`.
  - Suspicious `folderOpen` tasks are now identified consistently regardless of their parent directory.

- **Tests**
  - Added coverage confirming detection works for nested `.vscode` directories across previously excluded locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->