### PR TITLE
feat(doctor): report which stage of each provider is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ Config is stored in `%APPDATA%\lobster\config.toml` and history in `%LOCALAPPDAT
 
 ---
 
+## Checking provider health
+
+Providers break constantly — a domain moves, a player is replaced, an API starts
+signing its requests. `lobster doctor` probes each one and names the stage that
+broke, which is the difference between a cheap fix and a rewrite:
+
+```
+$ lobster doctor
+Provider health (query: "The Matrix")
+
+  ok   AniPub         2.912s           26 results, stream resolved
+  ok   FlixHQWS       3.815s           4 results, 3 servers, embed via Vidmoly
+  FAIL FlixHQ        20.514s  search   unexpected status 522
+  FAIL MovieBox        569ms  search   unexpected status 440
+  FAIL Soap2Day       1.848s  watch    no embed ID in video URL
+
+4 of 11 providers usable.
+```
+
+A failure at `search` usually means a moved domain or a renamed field. A failure
+at `watch` or `embed` means the player changed. Pass a title to probe with
+something else; anime providers are probed with an anime title automatically.
+Exits non-zero when nothing is usable, so it works as a check.
+
 ## Configuration
 
 Config file location:

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"lobster/internal/doctor"
+	"lobster/internal/provider"
+	"lobster/internal/ui"
+)
+
+const (
+	doctorDefaultQuery = "The Matrix"
+	// Probed against the anime providers, whose catalogues do not carry the
+	// default title at all.
+	doctorAnimeQuery = "Naruto"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor [query]",
+	Short: "Check which providers work, and where the others break",
+	Long: `Probe every provider and report the stage at which each one fails.
+
+Providers break constantly, and "it doesn't work" hides the difference between
+a moved domain (a cheap fix) and a replaced player (a rewrite). This runs each
+provider through search, servers and embed resolution and names the stage that
+broke, so a repairable one is visible the moment it becomes repairable.
+
+A well-known title is used by default so an empty result means the provider is
+broken rather than the catalogue being thin.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: doctorRun,
+}
+
+func doctorRun(cmd *cobra.Command, args []string) error {
+	query := doctorDefaultQuery
+	if len(args) > 0 && args[0] != "" {
+		query = args[0]
+	}
+
+	providers := []doctor.Named{
+		{Name: "MovieBox", Provider: provider.NewMovieBox()},
+		{Name: "VaPlayer", Provider: provider.NewVaPlayer()},
+		{Name: "VidNest", Provider: provider.NewVidNest()},
+		{Name: "Soap2Day", Provider: provider.NewSoap2Day()},
+		{Name: "TBCPL", Provider: provider.NewTBCPL("tbcpl")},
+		{Name: "FlixHQ", Provider: provider.NewFlixHQ("flixhq.to")},
+		{Name: "FlixHQWS", Provider: provider.NewFlixHQWS("flixhq.ws")},
+		{Name: "KimCartoon", Provider: provider.NewKimCartoon("kimcartoon.com.co")},
+		// 1shows.org is the same TBCPL provider on a different base, and the two
+		// domains fail independently — worth probing as its own entry.
+		{Name: "TBCPL(1shows)", Provider: provider.NewTBCPL("1shows.org")},
+		// Anime catalogues need an anime title, or they report broken for being
+		// asked about the wrong film.
+		{Name: "AllAnime", Provider: provider.NewAllAnime(false), Query: doctorAnimeQuery},
+		{Name: "AniPub", Provider: provider.NewAniPub(), Query: doctorAnimeQuery},
+	}
+
+	stop := ui.StartSpinner(fmt.Sprintf("Probing %d providers with %q...", len(providers), query))
+	results := doctor.CheckAll(providers, query)
+	stop()
+
+	// Report on stdout so it can be piped or grepped; only the spinner is
+	// progress chatter and belongs on stderr.
+	fmt.Printf("\nProvider health (query: %q)\n\n", query)
+	fmt.Print(doctor.Format(results))
+
+	// Exit non-zero when nothing works, so this is usable as a check.
+	for _, r := range results {
+		if r.OK {
+			return nil
+		}
+	}
+	return fmt.Errorf("no providers are usable")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | moviebox | vaplayer | vidnest | tbcpl | 1shows.org | allanime")
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
 
+	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(historyCmd)
 	rootCmd.AddCommand(trendingCmd)
 	rootCmd.AddCommand(recentCmd)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,158 @@
+// Package doctor probes each content provider and reports which stage of the
+// pipeline fails.
+//
+// "The provider is broken" is what a user already knows. Which stage broke is
+// what makes a repair findable: a provider whose search works but whose embeds
+// fail has moved its player and needs new extraction work, while one that fails
+// at search has usually just moved a domain or renamed a field — a cheap fix,
+// and invisible unless something reports the difference.
+package doctor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"lobster/internal/provider"
+)
+
+// Stages of the resolution pipeline, in the order they run.
+const (
+	StageSearch  = "search"
+	StageServers = "servers"
+	StageEmbed   = "embed"
+	StageWatch   = "watch"
+	StageOK      = "ok"
+)
+
+// Result is one provider's diagnosis.
+type Result struct {
+	Provider string
+	Stage    string // the stage that failed, or StageOK
+	OK       bool
+	Detail   string // what happened, in the provider's own words where possible
+	Latency  time.Duration
+}
+
+// Check runs a provider through the pipeline against query and reports the
+// first stage that fails.
+//
+// It deliberately stops at an embed URL rather than extracting: extraction is a
+// separate subsystem, and probing it would turn doctor into a playback test
+// that is slow and fails for unrelated reasons.
+func Check(name string, p provider.Provider, query string) Result {
+	start := time.Now()
+	res := Result{Provider: name}
+	finish := func(stage, detail string, ok bool) Result {
+		res.Stage, res.Detail, res.OK = stage, detail, ok
+		res.Latency = time.Since(start)
+		return res
+	}
+
+	results, err := p.Search(query)
+	if err != nil {
+		return finish(StageSearch, err.Error(), false)
+	}
+	if len(results) == 0 {
+		// Distinct from an error: the endpoint answered, so the parse or the
+		// query shape is what is wrong, which is a much cheaper fix.
+		return finish(StageSearch, "no results (endpoint answered but nothing parsed)", false)
+	}
+	pick := results[0]
+
+	if sp, ok := p.(provider.StreamProvider); ok {
+		stream, err := sp.Watch(pick.ID, "", "Default", "1080")
+		if err != nil {
+			return finish(StageWatch, err.Error(), false)
+		}
+		if stream == nil || stream.URL == "" {
+			return finish(StageWatch, "no stream URL returned", false)
+		}
+		return finish(StageOK, fmt.Sprintf("%d results, stream resolved", len(results)), true)
+	}
+
+	servers, err := p.GetServers(pick.ID, "")
+	if err != nil {
+		return finish(StageServers, err.Error(), false)
+	}
+	if len(servers) == 0 {
+		return finish(StageServers, "no servers offered", false)
+	}
+
+	var lastErr string
+	for _, srv := range servers {
+		embed, err := p.GetEmbedURL(srv.ID)
+		if err != nil {
+			lastErr = err.Error()
+			continue
+		}
+		if embed == "" {
+			lastErr = "empty embed URL"
+			continue
+		}
+		return finish(StageOK,
+			fmt.Sprintf("%d results, %d servers, embed via %s", len(results), len(servers), srv.Name), true)
+	}
+	return finish(StageEmbed, fmt.Sprintf("all %d servers failed: %s", len(servers), lastErr), false)
+}
+
+// Named pairs a display name with a provider, and optionally its own probe
+// query. Anime providers index a different catalogue, so probing them with a
+// live-action title reports "broken" for a provider that is working fine.
+type Named struct {
+	Name     string
+	Provider provider.Provider
+	Query    string // empty uses the shared query
+}
+
+// CheckAll probes every provider concurrently and returns the results ordered
+// healthy-first, then by name, so the usable sources are what you read first.
+func CheckAll(providers []Named, query string) []Result {
+	results := make([]Result, len(providers))
+	var wg sync.WaitGroup
+	for i, np := range providers {
+		wg.Add(1)
+		go func(idx int, n Named) {
+			defer wg.Done()
+			q := n.Query
+			if q == "" {
+				q = query
+			}
+			results[idx] = Check(n.Name, n.Provider, q)
+		}(i, np)
+	}
+	wg.Wait()
+
+	sort.SliceStable(results, func(a, b int) bool {
+		if results[a].OK != results[b].OK {
+			return results[a].OK
+		}
+		return results[a].Provider < results[b].Provider
+	})
+	return results
+}
+
+// Format renders results as an aligned report.
+func Format(results []Result) string {
+	width := 0
+	for _, r := range results {
+		if len(r.Provider) > width {
+			width = len(r.Provider)
+		}
+	}
+	var b strings.Builder
+	healthy := 0
+	for _, r := range results {
+		mark, stage := "FAIL", r.Stage
+		if r.OK {
+			mark, stage = "ok", ""
+			healthy++
+		}
+		fmt.Fprintf(&b, "  %-4s %-*s  %6s  %-8s %s\n",
+			mark, width, r.Provider, r.Latency.Round(time.Millisecond), stage, r.Detail)
+	}
+	fmt.Fprintf(&b, "\n%d of %d providers usable.\n", healthy, len(results))
+	return b.String()
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,184 @@
+package doctor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// fakeProvider stands in for a real one. Each stage can be made to fail so the
+// diagnosis can be checked against a known cause.
+type fakeProvider struct {
+	name      string
+	results   []media.SearchResult
+	searchErr error
+	servers   []media.Server
+	serverErr error
+	embed     string
+	embedErr  error
+	stream    *media.Stream
+	watchErr  error
+	isStream  bool
+}
+
+func (f *fakeProvider) Search(string) ([]media.SearchResult, error) { return f.results, f.searchErr }
+func (f *fakeProvider) GetDetails(string) (*media.ContentDetail, error) { return nil, nil }
+func (f *fakeProvider) GetSeasons(string) ([]media.Season, error)       { return nil, nil }
+func (f *fakeProvider) GetEpisodes(string, string) ([]media.Episode, error) {
+	return nil, nil
+}
+func (f *fakeProvider) GetServers(string, string) ([]media.Server, error) {
+	return f.servers, f.serverErr
+}
+func (f *fakeProvider) GetEmbedURL(string) (string, error) { return f.embed, f.embedErr }
+func (f *fakeProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
+	return nil, nil
+}
+func (f *fakeProvider) Recent(media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+
+type fakeStreamProvider struct{ fakeProvider }
+
+func (f *fakeStreamProvider) Watch(string, string, string, string) (*media.Stream, error) {
+	return f.stream, f.watchErr
+}
+
+func oneResult() []media.SearchResult {
+	return []media.SearchResult{{ID: "movie/1", Title: "Foo", Type: media.Movie, Year: "2012"}}
+}
+
+// The whole point is naming the stage that broke. "Provider is down" is what
+// the user already knows; "search works, embeds fail" is what makes a repair
+// findable.
+func TestCheckReportsSearchFailure(t *testing.T) {
+	got := Check("Fake", &fakeProvider{searchErr: errors.New("status 522")}, "foo")
+	if got.OK {
+		t.Fatal("want failure")
+	}
+	if got.Stage != StageSearch {
+		t.Errorf("stage = %q, want %q", got.Stage, StageSearch)
+	}
+	if !strings.Contains(got.Detail, "522") {
+		t.Errorf("detail should carry the cause, got %q", got.Detail)
+	}
+}
+
+// A search that succeeds but returns nothing is a different failure from one
+// that errors: the endpoint is alive and the parse or the query is wrong.
+func TestCheckDistinguishesEmptySearchFromSearchError(t *testing.T) {
+	got := Check("Fake", &fakeProvider{results: nil}, "foo")
+	if got.OK {
+		t.Fatal("want failure")
+	}
+	if got.Stage != StageSearch {
+		t.Errorf("stage = %q, want %q", got.Stage, StageSearch)
+	}
+	if !strings.Contains(strings.ToLower(got.Detail), "no results") {
+		t.Errorf("detail should say the search was empty, got %q", got.Detail)
+	}
+}
+
+func TestCheckReportsServerStageFailure(t *testing.T) {
+	got := Check("Fake", &fakeProvider{results: oneResult(), serverErr: errors.New("404")}, "foo")
+	if got.Stage != StageServers {
+		t.Errorf("stage = %q, want %q", got.Stage, StageServers)
+	}
+}
+
+func TestCheckReportsEmbedStageFailure(t *testing.T) {
+	p := &fakeProvider{
+		results:  oneResult(),
+		servers:  []media.Server{{Name: "S1", ID: "1"}},
+		embedErr: errors.New("no embed id"),
+	}
+	got := Check("Fake", p, "foo")
+	if got.Stage != StageEmbed {
+		t.Errorf("stage = %q, want %q", got.Stage, StageEmbed)
+	}
+}
+
+// A StreamProvider skips the embed hop entirely, so its failures must be
+// attributed to watch rather than to a stage it never runs.
+func TestCheckStreamProviderReportsWatchFailure(t *testing.T) {
+	p := &fakeStreamProvider{fakeProvider{results: oneResult(), isStream: true}}
+	p.watchErr = errors.New("all candidates failed")
+	got := Check("Fake", p, "foo")
+	if got.Stage != StageWatch {
+		t.Errorf("stage = %q, want %q", got.Stage, StageWatch)
+	}
+}
+
+func TestCheckHealthyStreamProvider(t *testing.T) {
+	p := &fakeStreamProvider{fakeProvider{results: oneResult()}}
+	p.stream = &media.Stream{URL: "https://cdn/x.m3u8"}
+	got := Check("Fake", p, "foo")
+	if !got.OK {
+		t.Fatalf("want OK, got stage=%q detail=%q", got.Stage, got.Detail)
+	}
+	if got.Stage != StageOK {
+		t.Errorf("stage = %q, want %q", got.Stage, StageOK)
+	}
+}
+
+// A magnet is a legitimate result: YTS never returns an http URL.
+func TestCheckAcceptsMagnetAsHealthy(t *testing.T) {
+	p := &fakeStreamProvider{fakeProvider{results: oneResult()}}
+	p.stream = &media.Stream{URL: "magnet:?xt=urn:btih:abc"}
+	if got := Check("Fake", p, "foo"); !got.OK {
+		t.Errorf("magnet should count as a resolved stream, got %q/%q", got.Stage, got.Detail)
+	}
+}
+
+// An embed provider that reaches a URL has done all it can here; extraction is
+// a separate subsystem and probing it would make doctor a playback test.
+func TestCheckEmbedProviderOKAtEmbedURL(t *testing.T) {
+	p := &fakeProvider{
+		results: oneResult(),
+		servers: []media.Server{{Name: "S1", ID: "1"}},
+		embed:   "https://host/embed/x",
+	}
+	got := Check("Fake", p, "foo")
+	if !got.OK {
+		t.Errorf("want OK, got stage=%q detail=%q", got.Stage, got.Detail)
+	}
+}
+
+func TestCheckRecordsLatency(t *testing.T) {
+	p := &fakeStreamProvider{fakeProvider{results: oneResult()}}
+	p.stream = &media.Stream{URL: "https://cdn/x.m3u8"}
+	if got := Check("Fake", p, "foo"); got.Latency < 0 {
+		t.Error("latency must be recorded")
+	}
+}
+
+// Anime providers index a different catalogue, so probing them with a live-
+// action title reports "broken" for a provider that is fine. Each entry can
+// carry its own probe query.
+func TestCheckAllUsesPerProviderQuery(t *testing.T) {
+	var gotDefault, gotOverride string
+	def := &recordingProvider{seen: &gotDefault}
+	ovr := &recordingProvider{seen: &gotOverride}
+
+	CheckAll([]Named{
+		{Name: "Default", Provider: def},
+		{Name: "Anime", Provider: ovr, Query: "Naruto"},
+	}, "The Matrix")
+
+	if gotDefault != "The Matrix" {
+		t.Errorf("default query = %q, want the shared one", gotDefault)
+	}
+	if gotOverride != "Naruto" {
+		t.Errorf("override query = %q, want Naruto", gotOverride)
+	}
+}
+
+type recordingProvider struct {
+	fakeProvider
+	seen *string
+}
+
+func (r *recordingProvider) Search(q string) ([]media.SearchResult, error) {
+	*r.seen = q
+	return oneResult(), nil
+}


### PR DESCRIPTION
## Why

"The provider is down" is what a user already knows. **Which stage broke** is what makes a repair findable:

- fails at `search` → usually a moved domain or a renamed field. Cheap.
- searches fine but fails at `embed`/`watch` → the player was replaced. A rewrite.

Nothing reported that difference, so both looked identical from the outside — and a provider that became repairable stayed invisible.

## What it does

```
$ lobster doctor
Provider health (query: "The Matrix")

  ok   AniPub         2.912s           26 results, stream resolved
  ok   FlixHQWS       3.815s           4 results, 3 servers, embed via Vidmoly
  ok   VaPlayer       1.763s           20 results, stream resolved
  ok   VidNest        3.123s           20 results, stream resolved
  FAIL AllAnime       1.763s  watch    no sources for cstcbG4EquLyDnAwN ep 1
  FAIL FlixHQ        20.514s  search   searching for "The Matrix": unexpected status 522
  FAIL KimCartoon     2.142s  servers  no embed URL found on episode page
  FAIL MovieBox        569ms  search   moviebox search: unexpected status 440
  FAIL Soap2Day       1.848s  watch    stream resolution failed: no embed ID in video URL
  FAIL TBCPL          2.511s  watch    tbcpl watch failed: status 404 for player.vidzee.wtf
  FAIL TBCPL(1shows)  2.455s  watch    tbcpl watch failed: status 404 for player.vidzee.wtf

4 of 11 providers usable.
```

Probes run concurrently, results are ordered healthy-first, and each carries the provider's own error text plus latency.

## Design decisions worth reviewing

**An empty search is reported separately from a failed one.** The endpoint answered, so the parse or query shape is wrong rather than the host being gone — a much cheaper fix, and indistinguishable otherwise.

**Probing stops at an embed URL rather than extracting.** Extraction is a separate subsystem; running it would turn this into a slow playback test that fails for unrelated reasons.

**Anime providers carry their own probe query.** Asked about *The Matrix* they'd report broken for being asked about the wrong catalogue — exactly the false signal this command exists to remove.

**`1shows.org` is probed separately from `tbcpl`** — same provider, different base, and they can fail independently.

Report goes to stdout so it can be piped (only the spinner is on stderr), and the command exits non-zero when nothing is usable, so it works as a check.

## Validation

It independently confirms what was previously only anecdotal: AllAnime is broken at `watch` while AniPub works.

Unit tests cover every stage attribution with fakes, including the StreamProvider path (which skips `embed` entirely and must not be blamed for a stage it never runs) and magnets counting as resolved streams.

The missing `1shows.org`/`allanime` coverage was caught by a local CodeRabbit pass before pushing — `--base` advertises both and the first version probed neither.

## Note

YTS isn't in the list because it lives on #33. I'll add it once that merges.