### PR TITLE
fix(player): forward the audio language in each frontend's own spelling

### DIFF
--- a/internal/player/alang.go
+++ b/internal/player/alang.go
@@ -17,6 +17,31 @@ func audioLangArgs(pref string) []string {
 	return []string{"--alang=" + strings.Join(list, ",")}
 }
 
+// genericAudioLangArgs returns the audio-language argument for the mpv-frontend
+// players, each of which has its own way of forwarding an mpv option.
+//
+// iina-cli ignores bare mpv flags entirely — passing --alang was a silent
+// no-op, so the preference appeared to be set and did nothing. Its documented
+// forms are a --mpv- prefix or a -- delimiter; the prefix is used here because
+// it keeps the arguments a flat slice. Celluloid takes mpv options through
+// --mpv-options instead. An unrecognised player keeps the plain spelling rather
+// than guessing at a wrapper that may not exist.
+func genericAudioLangArgs(player, pref string) []string {
+	list := lang.Aliases(pref)
+	if len(list) == 0 {
+		return nil
+	}
+	joined := strings.Join(list, ",")
+	switch player {
+	case "iina":
+		return []string{"--mpv-alang=" + joined}
+	case "celluloid":
+		return []string{"--mpv-options=--alang=" + joined}
+	default:
+		return []string{"--alang=" + joined}
+	}
+}
+
 // vlcAudioLangArgs is the same preference in VLC's spelling.
 func vlcAudioLangArgs(pref string) []string {
 	list := lang.Aliases(pref)

--- a/internal/player/generic.go
+++ b/internal/player/generic.go
@@ -34,7 +34,7 @@ func (g *Generic) Play(stream *media.Stream, title string, startPos float64, sub
 
 	// Both iina and celluloid accept mpv-style flags
 	args = append(args, "--force-media-title="+title)
-	args = append(args, audioLangArgs(g.audioLang)...)
+	args = append(args, genericAudioLangArgs(g.name, g.audioLang)...)
 	args = append(args, genericHeaderArgs(stream)...)
 
 	if startPos > 0 {

--- a/internal/player/generic_alang_test.go
+++ b/internal/player/generic_alang_test.go
@@ -1,0 +1,38 @@
+package player
+
+import "testing"
+
+// iina-cli does not forward bare mpv options: --alang is simply ignored, so the
+// preference silently did nothing on IINA. The documented forms are a --mpv-
+// prefix or a -- delimiter; the prefix keeps the args a flat slice.
+func TestGenericAudioLangUsesMpvPrefixForIINA(t *testing.T) {
+	got := genericAudioLangArgs("iina", "english")
+	if len(got) != 1 || got[0] != "--mpv-alang=eng,en,english" {
+		t.Errorf("iina args = %v, want [--mpv-alang=eng,en,english]", got)
+	}
+}
+
+// Celluloid takes mpv options through --mpv-options, not as bare flags.
+func TestGenericAudioLangWrapsForCelluloid(t *testing.T) {
+	got := genericAudioLangArgs("celluloid", "english")
+	if len(got) != 1 || got[0] != "--mpv-options=--alang=eng,en,english" {
+		t.Errorf("celluloid args = %v, want [--mpv-options=--alang=eng,en,english]", got)
+	}
+}
+
+func TestGenericAudioLangEmptyPreferenceAddsNothing(t *testing.T) {
+	for _, p := range []string{"iina", "celluloid"} {
+		if got := genericAudioLangArgs(p, ""); len(got) != 0 {
+			t.Errorf("%s with no preference = %v, want none", p, got)
+		}
+	}
+}
+
+// An unknown generic player keeps the plain mpv spelling rather than guessing
+// at a wrapper that may not exist.
+func TestGenericAudioLangUnknownPlayerUsesPlainFlag(t *testing.T) {
+	got := genericAudioLangArgs("someplayer", "english")
+	if len(got) != 1 || got[0] != "--alang=eng,en,english" {
+		t.Errorf("unknown player args = %v, want the plain --alang form", got)
+	}
+}


### PR DESCRIPTION
## The bug

`iina-cli` **ignores bare mpv options**. The `--alang` added in #31 was therefore a silent no-op on IINA — the preference looked set and did nothing.

Its documented forms are a `--mpv-` prefix or a `--` delimiter. The prefix is used here because it keeps the arguments a flat slice. Celluloid takes mpv options through `--mpv-options` rather than as bare flags.

| player | before | after |
|---|---|---|
| iina | `--alang=eng,en,english` (ignored) | `--mpv-alang=eng,en,english` |
| celluloid | `--alang=eng,en,english` | `--mpv-options=--alang=eng,en,english` |
| other | `--alang=…` | unchanged |

An unrecognised generic player keeps the plain spelling rather than guessing at a wrapper that may not exist.

## Scope

**Only the audio-language argument is changed.** `--force-media-title`, `--start` and `--sub-file` are passed to these frontends exactly as they were before #31. If they have the same problem it predates this work, and it deserves its own change with its own verification rather than being folded in silently here.

## Provenance

Found by CodeRabbit on **#36**, against code that had already merged via **#31** — i.e. this is a defect currently live on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-language preference handling for generic media players.
  * Added player-specific argument formatting for IINA and Celluloid, while preserving compatibility with other players.
  * Empty language preferences no longer produce unnecessary playback arguments.

* **Tests**
  * Added coverage for supported players, fallback behavior, and empty preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->