### PR TITLE
feat(config): expand a leading ~/ in live_tv playlist paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Lobster is a security-hardened Go rewrite of [lobster.sh](https://github.com/jus
 - 🌍 Subtitles with automatic language matching
 - ▶ Watch history with resume support (`--continue`)
 - 🎞 Quality selection — 360p, 480p, 720p, 1080p (HLS variant matching)
+- 📺 Live TV — free IPTV channels including a 456-channel Sports category ([jump to guide](#live-tv-and-sports))
 - 📦 JSON output mode for scripting and piping
 
 See [GUIDE.md](GUIDE.md) for detailed usage instructions.
@@ -115,6 +116,92 @@ Config is stored in `%APPDATA%\lobster\config.toml` and history in `%LOCALAPPDAT
 
 ---
 
+## Live TV and Sports
+
+Live TV streams free, public IPTV playlists — by default the community-maintained
+[iptv-org](https://github.com/iptv-org/iptv) index. No account and no API key.
+
+### Watching football
+
+Live TV lives in the dashboard, so start it with **no search query**:
+
+```bash
+./lobster
+```
+
+Then:
+
+1. Press **`5`** to open the **Live TV** tab.
+2. Pick the **Sports** category and press **Enter**. (It currently carries **456 channels**.)
+3. Pick a channel and press **Enter** — it opens in your player.
+
+After a channel starts, you get a **Next channel / Previous channel / Back to browser / Quit**
+menu, so you can flip through the Sports lineup looking for the match without going
+back to the list each time. On **mpv** the dead channels are skipped automatically;
+on other players use the menu, and lobster tells you so on startup.
+
+### Finding a specific match faster
+
+456 channels is a lot to scroll. Press **`s`** or **`/`** to search channel names
+directly — searching is a plain case-insensitive substring match on the channel
+name, so search by **broadcaster, not by fixture**:
+
+```
+bein        → beIN SPORTS XTRA, beIN Sports USA, …
+sky sport   → Sky Sport channels
+espn        → ESPN feeds
+dazn        → DAZN Combat, DAZN Darts, …
+football    → CCTV-Storm Football, …
+sport       → the broadest net
+```
+
+Searching `arsenal vs chelsea` will find nothing — there is no fixture metadata
+in a playlist, only channel names.
+
+### What to expect
+
+These are free public streams, so a few things are worth knowing before kickoff:
+
+- **Channel names carry annotations.** `[Geo-blocked]` means it will fail unless
+  you are in the right country; `[Not 24/7]` means it only broadcasts part of the
+  day. `beIN Sports USA (1080p) [Geo-blocked]` is a typical Sports entry.
+- **Dead channels are normal.** Public IPTV links rot. mpv auto-skips them; after
+  12 consecutive failures lobster stops so a fully-unreachable network can't loop.
+- **Live channels can't be downloaded.** `--download` is rejected for Live TV.
+- **First load is slow.** The category playlist is ~3 MB and is fetched once, then
+  cached for the session.
+
+### Adding your own playlists
+
+If a match isn't on a free channel, point lobster at your own M3U playlists or an
+Xtream-codes subscription in `config.toml`:
+
+```toml
+[live_tv]
+# Include the built-in iptv-org playlist (default: true).
+# Set false to use only your own sources.
+iptv_org = true
+
+# Extra M3U URLs or local file paths.
+# Local paths must be absolute — unlike download_dir, `~` is NOT expanded here.
+playlists = [
+  "https://example.com/sports.m3u8",
+  "/home/you/playlists/mine.m3u",
+]
+
+# Optional Xtream-codes subscription. When server is set, lobster builds the
+# get.php m3u_plus URL for you.
+[live_tv.xtream]
+server = "example.com:8080"
+username = "your-username"
+password = "your-password"
+```
+
+Sources are merged in that order — iptv-org first, then your playlists, then
+Xtream — so your own channels appear alongside the free ones.
+
+---
+
 ## Configuration
 
 Config file location:
@@ -139,6 +226,11 @@ download_dir = "~/Videos/lobster"
 # Self-host from: https://github.com/consumet/api.consumet.org
 # When set, lobster uses this API for search, streaming, etc.
 # api_url = "https://your-consumet-instance.example.com"
+
+# Live TV sources. See "Live TV and Sports" above.
+[live_tv]
+iptv_org = true          # include the built-in iptv-org playlist
+playlists = []           # extra M3U URLs or local file paths
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -182,11 +182,10 @@ Xtream-codes subscription in `config.toml`:
 # Set false to use only your own sources.
 iptv_org = true
 
-# Extra M3U URLs or local file paths.
-# Local paths must be absolute — unlike download_dir, `~` is NOT expanded here.
+# Extra M3U URLs or local file paths. A leading "~/" is expanded.
 playlists = [
   "https://example.com/sports.m3u8",
-  "/home/you/playlists/mine.m3u",
+  "~/playlists/mine.m3u",
 ]
 
 # Optional Xtream-codes subscription. When server is set, lobster builds the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,9 @@ func (c LiveTVConfig) Sources() []string {
 	if c.IPTVOrg {
 		s = append(s, iptvOrgPlaylist)
 	}
-	s = append(s, c.Playlists...)
+	for _, pl := range c.Playlists {
+		s = append(s, expandTilde(pl))
+	}
 	if c.Xtream.Server != "" {
 		server := c.Xtream.Server
 		if !strings.HasPrefix(server, "http://") && !strings.HasPrefix(server, "https://") {
@@ -187,6 +189,21 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// expandTilde resolves a leading "~/" (or `~\` on Windows) to the user's home
+// directory, leaving anything else — URLs, absolute paths, and "~user" forms we
+// cannot resolve — untouched. On failure it returns the input unchanged so the
+// caller reports the original path rather than a surprising one.
+func expandTilde(p string) string {
+	if !strings.HasPrefix(p, "~/") && !strings.HasPrefix(p, `~\`) {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(home, p[2:])
 }
 
 // ExpandDownloadDir resolves ~ in the download directory path.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -195,8 +196,14 @@ func (c *Config) Validate() error {
 // directory, leaving anything else — URLs, absolute paths, and "~user" forms we
 // cannot resolve — untouched. On failure it returns the input unchanged so the
 // caller reports the original path rather than a surprising one.
+//
+// The backslash form is gated on Windows deliberately. Everywhere else a
+// backslash is an ordinary filename character, so `~\playlists\mine.m3u` names
+// a real relative path; expanding it there would quietly load a different file
+// than the one written in the config.
 func expandTilde(p string) string {
-	if !strings.HasPrefix(p, "~/") && !strings.HasPrefix(p, `~\`) {
+	if !strings.HasPrefix(p, "~/") &&
+		!(runtime.GOOS == "windows" && strings.HasPrefix(p, `~\`)) {
 		return p
 	}
 	home, err := os.UserHomeDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -295,3 +295,28 @@ func TestLiveTVSourcesExpandsTilde(t *testing.T) {
 		t.Fatalf("Sources() = %v, want %v", got, want)
 	}
 }
+
+// The `~\` form is a home reference on Windows only. On Unix a backslash is an
+// ordinary filename character, so `~\playlists\mine.m3u` names a real relative
+// path and expanding it silently loads a different file than the user asked
+// for. expandTilde's own doc comment says "on Windows"; this pins the code to
+// that promise.
+func TestExpandTildeBackslashIsWindowsOnly(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	const in = `~\playlists\mine.m3u`
+	got := expandTilde(in)
+
+	if runtime.GOOS == "windows" {
+		want := filepath.Join(home, `playlists\mine.m3u`)
+		if got != want {
+			t.Fatalf("expandTilde(%q) = %q, want %q (backslash is a home reference on Windows)", in, got, want)
+		}
+		return
+	}
+	if got != in {
+		t.Fatalf("expandTilde(%q) = %q, want it unchanged: on %s a backslash is part of the filename, not a separator", in, got, runtime.GOOS)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 )
@@ -264,5 +265,33 @@ func TestValidateAcceptsBestQuality(t *testing.T) {
 		if err := c.Validate(); err == nil {
 			t.Errorf("Quality=%q should be rejected: one documented spelling only", q)
 		}
+	}
+}
+
+// A "~/..." playlist path must expand like download_dir does, rather than
+// reaching os.ReadFile verbatim and failing with "no such file or directory".
+func TestLiveTVSourcesExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	c := LiveTVConfig{
+		IPTVOrg: false,
+		Playlists: []string{
+			"~/playlists/mine.m3u",
+			"https://example.com/keep.m3u8", // URLs must pass through untouched
+			"/already/absolute.m3u",
+			"~notauser/literal.m3u", // only "~/" is a home reference
+		},
+	}
+	got := c.Sources()
+	want := []string{
+		filepath.Join(home, "playlists/mine.m3u"),
+		"https://example.com/keep.m3u8",
+		"/already/absolute.m3u",
+		"~notauser/literal.m3u",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Sources() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Follow-up to #38, which documented this wart rather than fixing it.

`~` was expanded only for `download_dir`; `live_tv.playlists` entries went straight to `os.ReadFile`, so a natural-looking config silently loaded nothing.

Before / after, through the real provider:

```
before: cats=0 err=open ~/lobster_tilde_probe/p.m3u: no such file or directory
after:  cats=1 err=<nil>
```

URLs, absolute paths, and `~user` forms (which we cannot resolve) pass through untouched. Also flips the README line from "`~` is NOT expanded" to documenting the new behavior.

**Based on `docs/livetv-sports`, not `main`** — it edits a README section that only exists in #38. Merge #38 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live TV playlist paths now support the `~/` home-directory shortcut.
  - On Windows, paths beginning with `~\` are also expanded; on other platforms, they remain unchanged.
  - URLs, absolute paths, and other non-home-relative paths continue to be preserved.

- **Documentation**
  - Updated configuration examples and guidance to explain home-directory shortcuts and no longer require local playlist paths to be absolute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->