### PR TITLE
feat(providers): revive dead providers behind a parallel health gate

### DIFF
--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -48,9 +48,9 @@ func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType)
 }
 
 // fallbackProviders returns all available fallback providers, excluding the primary.
-// Both StreamProviders (Soap2Day, Consumet, MovieBox, TBCPL) and regular
-// Providers (FlixHQ, FlixHQWS) are included so the app tries every source
-// before giving up.
+// Both StreamProviders (Soap2Day, MovieBox, TBCPL) and regular Providers
+// (FlixHQWS, KimCartoon) are included so the app tries every source before
+// giving up. Consumet joins them only when api_url is configured.
 func fallbackProviders(primary provider.Provider) []provider.Provider {
 	var fallbacks []provider.Provider
 
@@ -78,13 +78,24 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 		fallbacks = append(fallbacks, tb)
 	}
 
+	// Consumet is an aggregator, so it is worth more than any single scraper —
+	// but it has no public instance, only whatever the user self-hosts. Without
+	// api_url there is nothing to talk to, so it joins the chain only when one
+	// is configured rather than failing every request.
+	if _, ok := primary.(*provider.Consumet); !ok {
+		if cfg != nil && cfg.APIURL != "" {
+			fallbacks = append(fallbacks, provider.NewConsumet(cfg.APIURL))
+		}
+	}
+
 	if _, ok := primary.(*provider.FlixHQWS); !ok {
 		fallbacks = append(fallbacks, provider.NewFlixHQWS("flixhq.ws"))
 	}
 
-	if _, ok := primary.(*provider.FlixHQ); !ok {
-		fallbacks = append(fallbacks, provider.NewFlixHQ("flixhq.to"))
-	}
+	// flixhq.to is gone — it does not answer at all, so every attempt spends the
+	// full request timeout before the resolver gives up on it. flixhq.ws is a
+	// separate deployment and still works, so nothing is lost by dropping this.
+	// It stays reachable through `--base flixhq.to` for anyone who sees it return.
 
 	if _, ok := primary.(*provider.KimCartoon); !ok {
 		fallbacks = append(fallbacks, provider.NewKimCartoon("kimcartoon.com.co"))

--- a/cmd/fallback.go
+++ b/cmd/fallback.go
@@ -30,6 +30,10 @@ func sharedHealth() *resolver.HealthStore {
 	return sharedHealthStore
 }
 
+// flixhqDomain resolves a healthy FlixHQ mirror, memoized per session.
+// Package var so tests can stub the probe.
+var flixhqDomain = provider.FirstHealthyDomainCached
+
 func cfgQuality() string {
 	if cfg != nil && cfg.Quality != "" {
 		return cfg.Quality
@@ -92,21 +96,32 @@ func fallbackProviders(primary provider.Provider) []provider.Provider {
 		fallbacks = append(fallbacks, provider.NewFlixHQWS("flixhq.ws"))
 	}
 
-	// flixhq.to is gone — it does not answer at all, so every attempt spends the
-	// full request timeout before the resolver gives up on it. flixhq.ws is a
-	// separate deployment and still works, so nothing is lost by dropping this.
-	// It stays reachable through `--base flixhq.to` for anyone who sees it return.
+	// The flixhq.to engine family (flixhq.to, sflix.to, myflixerz.to, ...) has
+	// been origin-down since ~Aug 2026, so the scraper joins the chain only when
+	// a health probe finds a live mirror. The probe runs in parallel across all
+	// candidates and is cached for the session, so while everything is dead this
+	// costs one probe timeout per run — and the provider revives automatically
+	// the moment any mirror answers again.
+	if _, ok := primary.(*provider.FlixHQ); !ok {
+		var overrides map[string][]string
+		if cfg != nil {
+			overrides = cfg.DomainOverrides
+		}
+		if d := flixhqDomain("flixhq", overrides); d != "" {
+			fallbacks = append(fallbacks, provider.NewFlixHQ(d))
+		}
+	}
 
 	if _, ok := primary.(*provider.KimCartoon); !ok {
 		fallbacks = append(fallbacks, provider.NewKimCartoon("kimcartoon.com.co"))
 	}
 
 	// Last so movie/TV scrapers keep priority; these catch anime the others
-	// lack. AniPub matters most: AllAnime's sources endpoint is crypto-gated
-	// (AA_CRYPTO_MISSING, mid-2026), so its Watch fails until that's cracked.
-	if _, ok := primary.(*provider.AllAnime); !ok {
-		fallbacks = append(fallbacks, provider.NewAllAnime(cfg != nil && cfg.AnimeDub))
-	}
+	// lack. AniPub is the anime path. AllAnime is retired: its API now sits behind a
+	// Cloudflare bot challenge on top of the crypto-gated sources endpoint
+	// (AA_CRYPTO_MISSING, mid-2026), so it can neither search nor stream. The
+	// provider code stays for the day either gate lifts.
+
 	if _, ok := primary.(*provider.AniPub); !ok {
 		fallbacks = append(fallbacks, provider.NewAniPub())
 	}

--- a/cmd/fallback_allanime_test.go
+++ b/cmd/fallback_allanime_test.go
@@ -7,20 +7,20 @@ import (
 	"lobster/internal/provider"
 )
 
-func TestFallbackProvidersIncludeAllAnime(t *testing.T) {
-	found := false
+func TestFallbackProvidersAllAnimeRetired(t *testing.T) {
+	// AllAnime is retired: its API now sits behind a Cloudflare bot challenge
+	// on top of the crypto-gated sources endpoint (AA_CRYPTO_MISSING, mid-2026).
+	// It should never appear in the fallback chain, even when another provider
+	// is primary.
 	for _, p := range fallbackProviders(provider.NewFlixHQ("flixhq.to")) {
 		if _, ok := p.(*provider.AllAnime); ok {
-			found = true
+			t.Fatal("AllAnime should be retired from the fallback chain")
 		}
-	}
-	if !found {
-		t.Fatal("AllAnime missing from fallback chain")
 	}
 
 	for _, p := range fallbackProviders(provider.NewAllAnime(false)) {
 		if _, ok := p.(*provider.AllAnime); ok {
-			t.Fatal("AllAnime duplicated when it is the primary")
+			t.Fatal("AllAnime should be retired from the fallback chain")
 		}
 	}
 }

--- a/cmd/fallback_providers_test.go
+++ b/cmd/fallback_providers_test.go
@@ -28,6 +28,15 @@ func hasProvider[T provider.Provider](ps []provider.Provider) bool {
 	return false
 }
 
+func TestMain(m *testing.M) {
+	// Stub flixhqDomain to prevent live network probes in tests.
+	// Tests that need a healthy or dead result override this with t.Cleanup restore.
+	prev := flixhqDomain
+	flixhqDomain = func(string, map[string][]string) string { return "" }
+	defer func() { flixhqDomain = prev }()
+	m.Run()
+}
+
 // Consumet is a full aggregator that was implemented but never reachable from
 // the fallback chain — it was only ever built as the primary, and only when
 // api_url was set. Wiring it in is the cheapest provider we can add.
@@ -64,23 +73,6 @@ func TestFallbackProvidersOmitsConsumetWithNilConfig(t *testing.T) {
 	got := fallbackProviders(nil)
 	if hasProvider[*provider.Consumet](got) {
 		t.Fatalf("Consumet present with nil cfg: %v", providerNames(got))
-	}
-}
-
-// flixhq.to stopped responding entirely; every attempt burns the full request
-// timeout before the resolver moves on. flixhq.ws is a separate, working
-// provider, so dropping the dead one costs no coverage.
-func TestFallbackProvidersOmitsDeadFlixHQ(t *testing.T) {
-	prev := cfg
-	cfg = &config.Config{}
-	t.Cleanup(func() { cfg = prev })
-
-	got := fallbackProviders(nil)
-	if hasProvider[*provider.FlixHQ](got) {
-		t.Fatalf("dead flixhq.to still in chain: %v", providerNames(got))
-	}
-	if !hasProvider[*provider.FlixHQWS](got) {
-		t.Fatalf("flixhq.ws must remain: %v", providerNames(got))
 	}
 }
 

--- a/cmd/fallback_providers_test.go
+++ b/cmd/fallback_providers_test.go
@@ -95,8 +95,12 @@ func TestFallbackProvidersOmitsFlixHQWhenAllDomainsDead(t *testing.T) {
 	flixhqDomain = func(name string, overrides map[string][]string) string { return "" }
 	t.Cleanup(func() { flixhqDomain = prev })
 
-	if hasProvider[*provider.FlixHQ](fallbackProviders(nil)) {
+	got := fallbackProviders(nil)
+	if hasProvider[*provider.FlixHQ](got) {
 		t.Fatal("FlixHQ present in chain although no domain is healthy")
+	}
+	if !hasProvider[*provider.FlixHQWS](got) {
+		t.Fatal("FlixHQWS should stay in the chain even when the flixhq gate is closed")
 	}
 }
 

--- a/cmd/fallback_providers_test.go
+++ b/cmd/fallback_providers_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/provider"
+)
+
+// providerNames lists the concrete Go types in a provider slice, which is what
+// these tests assert on — the chain is defined by which providers are in it,
+// not by their configuration. Provider has no Name method, so use %T.
+func providerNames(ps []provider.Provider) []string {
+	names := make([]string, 0, len(ps))
+	for _, p := range ps {
+		names = append(names, fmt.Sprintf("%T", p))
+	}
+	return names
+}
+
+func hasProvider[T provider.Provider](ps []provider.Provider) bool {
+	for _, p := range ps {
+		if _, ok := p.(T); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Consumet is a full aggregator that was implemented but never reachable from
+// the fallback chain — it was only ever built as the primary, and only when
+// api_url was set. Wiring it in is the cheapest provider we can add.
+func TestFallbackProvidersIncludesConsumetWhenAPIURLSet(t *testing.T) {
+	prev := cfg
+	cfg = &config.Config{APIURL: "https://api.consumet.example"}
+	t.Cleanup(func() { cfg = prev })
+
+	got := fallbackProviders(nil)
+	if !hasProvider[*provider.Consumet](got) {
+		t.Fatalf("Consumet missing from fallback chain: %v", providerNames(got))
+	}
+}
+
+// Without a base URL there is nothing for Consumet to talk to, so it must stay
+// out rather than join the chain and fail every request.
+func TestFallbackProvidersOmitsConsumetWithoutAPIURL(t *testing.T) {
+	prev := cfg
+	cfg = &config.Config{}
+	t.Cleanup(func() { cfg = prev })
+
+	got := fallbackProviders(nil)
+	if hasProvider[*provider.Consumet](got) {
+		t.Fatalf("Consumet present without api_url: %v", providerNames(got))
+	}
+}
+
+// A nil cfg must not panic and must not produce a Consumet with an empty base.
+func TestFallbackProvidersOmitsConsumetWithNilConfig(t *testing.T) {
+	prev := cfg
+	cfg = nil
+	t.Cleanup(func() { cfg = prev })
+
+	got := fallbackProviders(nil)
+	if hasProvider[*provider.Consumet](got) {
+		t.Fatalf("Consumet present with nil cfg: %v", providerNames(got))
+	}
+}
+
+// flixhq.to stopped responding entirely; every attempt burns the full request
+// timeout before the resolver moves on. flixhq.ws is a separate, working
+// provider, so dropping the dead one costs no coverage.
+func TestFallbackProvidersOmitsDeadFlixHQ(t *testing.T) {
+	prev := cfg
+	cfg = &config.Config{}
+	t.Cleanup(func() { cfg = prev })
+
+	got := fallbackProviders(nil)
+	if hasProvider[*provider.FlixHQ](got) {
+		t.Fatalf("dead flixhq.to still in chain: %v", providerNames(got))
+	}
+	if !hasProvider[*provider.FlixHQWS](got) {
+		t.Fatalf("flixhq.ws must remain: %v", providerNames(got))
+	}
+}

--- a/cmd/fallback_providers_test.go
+++ b/cmd/fallback_providers_test.go
@@ -83,3 +83,35 @@ func TestFallbackProvidersOmitsDeadFlixHQ(t *testing.T) {
 		t.Fatalf("flixhq.ws must remain: %v", providerNames(got))
 	}
 }
+
+// FlixHQ (the flixhq.to-engine scraper) is gated on a live health probe: it
+// joins the chain only when some mirror in knownDomains/overrides answers, so
+// a dead provider costs one parallel probe per session instead of a full
+// request timeout on every search.
+func TestFallbackProvidersIncludesFlixHQWhenDomainHealthy(t *testing.T) {
+	prev := flixhqDomain
+	flixhqDomain = func(name string, overrides map[string][]string) string { return "flixhq.to" }
+	t.Cleanup(func() { flixhqDomain = prev })
+
+	if !hasProvider[*provider.FlixHQ](fallbackProviders(nil)) {
+		t.Fatal("FlixHQ missing from chain despite a healthy domain")
+	}
+}
+
+func TestFallbackProvidersOmitsFlixHQWhenAllDomainsDead(t *testing.T) {
+	prev := flixhqDomain
+	flixhqDomain = func(name string, overrides map[string][]string) string { return "" }
+	t.Cleanup(func() { flixhqDomain = prev })
+
+	if hasProvider[*provider.FlixHQ](fallbackProviders(nil)) {
+		t.Fatal("FlixHQ present in chain although no domain is healthy")
+	}
+}
+
+// AllAnime is retired: its API sits behind a Cloudflare bot challenge and its
+// watch path has been crypto-gated since mid-2026. AniPub covers anime.
+func TestFallbackProvidersNeverIncludesAllAnime(t *testing.T) {
+	if hasProvider[*provider.AllAnime](fallbackProviders(nil)) {
+		t.Fatal("AllAnime should be retired from the fallback chain")
+	}
+}

--- a/docs/superpowers/plans/2026-09-01-revive-dead-providers.md
+++ b/docs/superpowers/plans/2026-09-01-revive-dead-providers.md
@@ -1,0 +1,464 @@
+# Revive Dead Providers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-add FlixHQ to the fallback chain behind a parallel health gate so it revives automatically when any mirror returns, and retire AllAnime from the chain.
+
+**Architecture:** A new `FirstHealthyDomain` in `internal/provider/failover.go` probes all candidate domains in parallel (bounded by one probe timeout) and returns the first healthy one by list preference; a memoized wrapper caches the answer per provider name for the process lifetime. `cmd/fallback.go` uses it to conditionally add FlixHQ and drops AllAnime (Cloudflare bot-challenge + crypto-gated watch path; AniPub covers anime).
+
+**Tech Stack:** Go 1.22+, stdlib only (`net/http`, `net`, `sync`, `httptest` for tests).
+
+## Global Constraints
+
+- No new scrapers — reuse the existing `FlixHQ` scraper (`NewFlixHQ(base string)`); sflix.to / myflixerz.to run the identical engine.
+- Tests must never touch the live network: all probes hit `httptest` servers via the `healthURLFor` seam.
+- No `Co-Authored-By` lines in commits.
+- Run `go test ./...` (not just the package) before each commit.
+- Spec: `docs/superpowers/specs/2026-09-01-revive-dead-providers-design.md`.
+
+---
+
+### Task 1: Parallel `FirstHealthyDomain` in the provider package
+
+**Files:**
+- Modify: `internal/provider/failover.go`
+- Create: `internal/provider/failover_test.go`
+
+**Interfaces:**
+- Consumes: existing `checkDomainHealth(domain string) bool`, `knownDomains`.
+- Produces: `func FirstHealthyDomain(providerName string, overrides map[string][]string) string` — probes all candidates in parallel, returns the first healthy domain in preference order (overrides first, then `knownDomains[providerName]`), or `""` if none respond. Package var `healthURLFor func(domain string) string` (test seam). Package var `probeTimeout = 3 * time.Second`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// pointProbesAt makes every probed "domain" hit the given handler by rewriting
+// the probe URL. The domain string itself is ignored except when it matches a
+// key in routes, which maps domain -> httptest server URL. Unrouted domains
+// get an unreachable address so they fail fast.
+func pointProbesAt(t *testing.T, routes map[string]string) {
+	t.Helper()
+	old := healthURLFor
+	healthURLFor = func(domain string) string {
+		if u, ok := routes[domain]; ok {
+			return u
+		}
+		return "http://127.0.0.1:1/" // closed port: immediate refusal
+	}
+	t.Cleanup(func() { healthURLFor = old })
+}
+
+func TestFirstHealthyDomainPrefersListOrder(t *testing.T) {
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ok.Close()
+	pointProbesAt(t, map[string]string{"b.example": ok.URL, "c.example": ok.URL})
+
+	got := FirstHealthyDomain("testprov", map[string][]string{
+		"testprov": {"a.example", "b.example", "c.example"},
+	})
+	if got != "b.example" {
+		t.Fatalf("got %q, want b.example (first healthy in preference order)", got)
+	}
+}
+
+func TestFirstHealthyDomainAllDeadReturnsEmpty(t *testing.T) {
+	pointProbesAt(t, nil)
+	if got := FirstHealthyDomain("testprov", map[string][]string{"testprov": {"a.example", "b.example"}}); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestFirstHealthyDomainHangingProbeDoesNotBlock(t *testing.T) {
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Second)
+	}))
+	defer hang.Close()
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ok.Close()
+	pointProbesAt(t, map[string]string{"hang.example": hang.URL, "ok.example": ok.URL})
+
+	oldTimeout := probeTimeout
+	probeTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { probeTimeout = oldTimeout })
+
+	start := time.Now()
+	got := FirstHealthyDomain("testprov", map[string][]string{
+		"testprov": {"hang.example", "ok.example"},
+	})
+	elapsed := time.Since(start)
+	if got != "ok.example" {
+		t.Fatalf("got %q, want ok.example", got)
+	}
+	// Parallel: total time ~ one probe timeout, not the sum of probes.
+	if elapsed > 2*time.Second {
+		t.Fatalf("gate took %s; probes are not parallel or timeout ignored", elapsed)
+	}
+}
+
+func TestFirstHealthyDomainUsesKnownDomains(t *testing.T) {
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ok.Close()
+	oldKnown := knownDomains["_fhd_test"]
+	knownDomains["_fhd_test"] = []string{"known.example"}
+	t.Cleanup(func() {
+		if oldKnown == nil {
+			delete(knownDomains, "_fhd_test")
+		} else {
+			knownDomains["_fhd_test"] = oldKnown
+		}
+	})
+	pointProbesAt(t, map[string]string{"known.example": ok.URL})
+
+	if got := FirstHealthyDomain("_fhd_test", nil); got != "known.example" {
+		t.Fatalf("got %q, want known.example", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/provider/ -run TestFirstHealthyDomain -v`
+Expected: FAIL to build — `healthURLFor`, `probeTimeout`, `FirstHealthyDomain` undefined.
+
+- [ ] **Step 3: Implement in `internal/provider/failover.go`**
+
+Refactor `checkDomainHealth` to use the seam and timeout var, then add the parallel gate. Replace the existing `checkDomainHealth` and add below `knownDomains`:
+
+```go
+// healthURLFor maps a domain to the URL probed for health. A package var so
+// tests can point probes at httptest servers instead of the live network.
+var healthURLFor = func(domain string) string { return "https://" + domain + "/" }
+
+// probeTimeout bounds a single health probe. Package var for tests.
+var probeTimeout = 3 * time.Second
+
+// checkDomainHealth sends a HEAD request to the domain's health URL and
+// returns true if the server responds with a non-5xx status in time.
+func checkDomainHealth(domain string) bool {
+	// Explicit dialer with Happy Eyeballs (FallbackDelay > 0): a broken IPv6
+	// route must not make a live domain look dead — the dial races v6 and v4
+	// and takes whichever connects. Go enables this by default; the explicit
+	// dialer pins the behavior so a future custom transport can't lose it.
+	client := &http.Client{
+		Timeout: probeTimeout,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:       probeTimeout,
+				FallbackDelay: 100 * time.Millisecond,
+			}).DialContext,
+		},
+	}
+	resp, err := client.Head(healthURLFor(domain))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
+// candidateDomains returns the preference-ordered candidate list for a
+// provider: config overrides first (case-insensitive key match), then the
+// built-in known domains.
+func candidateDomains(providerName string, overrides map[string][]string) []string {
+	var candidates []string
+	if overrides != nil {
+		lowerName := strings.ToLower(providerName)
+		for key, domains := range overrides {
+			if strings.ToLower(key) == lowerName {
+				candidates = append(candidates, domains...)
+				break
+			}
+		}
+	}
+	return append(candidates, knownDomains[providerName]...)
+}
+
+// FirstHealthyDomain probes every candidate domain for a provider in parallel
+// and returns the first healthy one in preference order, or "" if none
+// respond. Wall-clock cost is roughly one probeTimeout regardless of how many
+// candidates are dead, which is what makes gating a usually-dead provider
+// affordable.
+func FirstHealthyDomain(providerName string, overrides map[string][]string) string {
+	candidates := candidateDomains(providerName, overrides)
+	if len(candidates) == 0 {
+		return ""
+	}
+	healthy := make([]bool, len(candidates))
+	var wg sync.WaitGroup
+	for i, d := range candidates {
+		wg.Add(1)
+		go func(i int, d string) {
+			defer wg.Done()
+			healthy[i] = checkDomainHealth(d)
+		}(i, d)
+	}
+	wg.Wait()
+	for i, ok := range healthy {
+		if ok {
+			return candidates[i]
+		}
+	}
+	return ""
+}
+```
+
+Add `"net"` to the imports of `failover.go`. Also update `ResolveDomain`'s inline candidate-building block (lines building `candidates` from overrides + knownDomains) to call `candidateDomains(providerName, overrides)` instead of duplicating it. Add `"sync"` to imports. `ResolveDomain`'s behavior is otherwise unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/provider/ -run 'TestFirstHealthyDomain|TestResolveDomain' -v` then `go test ./...`
+Expected: PASS (the hanging-probe test takes ~0.5–1s, not 10s).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/provider/failover.go internal/provider/failover_test.go
+git commit -m "feat(failover): parallel FirstHealthyDomain gate with test seam"
+```
+
+---
+
+### Task 2: Session cache + seeded flixhq mirror list
+
+**Files:**
+- Modify: `internal/provider/failover.go`
+- Modify: `internal/provider/failover_test.go` (append)
+
+**Interfaces:**
+- Consumes: `FirstHealthyDomain(providerName string, overrides map[string][]string) string` from Task 1.
+- Produces: `func FirstHealthyDomainCached(providerName string, overrides map[string][]string) string` — memoizes the Task 1 result per provider name for the process lifetime (including a "" miss, so a dead provider is probed once per session, not once per search). `knownDomains["flixhq"]` seeded with the mirror list. Test helper `ResetDomainCache()` (exported for cmd tests in Task 3).
+
+- [ ] **Step 1: Write the failing tests (append to `internal/provider/failover_test.go`)**
+
+```go
+func TestFirstHealthyDomainCachedProbesOnce(t *testing.T) {
+	ResetDomainCache()
+	t.Cleanup(ResetDomainCache)
+	var probes int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&probes, 1)
+	}))
+	defer srv.Close()
+	pointProbesAt(t, map[string]string{"a.example": srv.URL})
+	ov := map[string][]string{"cachedprov": {"a.example"}}
+
+	first := FirstHealthyDomainCached("cachedprov", ov)
+	second := FirstHealthyDomainCached("cachedprov", ov)
+	if first != "a.example" || second != "a.example" {
+		t.Fatalf("got %q then %q, want a.example twice", first, second)
+	}
+	if n := atomic.LoadInt32(&probes); n != 1 {
+		t.Fatalf("probed %d times, want 1 (cached)", n)
+	}
+}
+
+func TestFirstHealthyDomainCachedCachesMiss(t *testing.T) {
+	ResetDomainCache()
+	t.Cleanup(ResetDomainCache)
+	pointProbesAt(t, nil)
+	ov := map[string][]string{"deadprov": {"a.example"}}
+	if got := FirstHealthyDomainCached("deadprov", ov); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	// Second call must not re-probe; verify by making probes impossible to
+	// distinguish — we just assert it still returns "" instantly.
+	start := time.Now()
+	if got := FirstHealthyDomainCached("deadprov", ov); got != "" {
+		t.Fatalf("second call got %q, want empty", got)
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Fatal("second call re-probed instead of using the cache")
+	}
+}
+
+func TestKnownDomainsFlixhqSeeded(t *testing.T) {
+	want := []string{"flixhq.to", "flixhq.click", "flixhq.pe", "flixhq.bz", "sflix.to", "myflixerz.to"}
+	if !reflect.DeepEqual(knownDomains["flixhq"], want) {
+		t.Fatalf("knownDomains[flixhq] = %v, want %v", knownDomains["flixhq"], want)
+	}
+}
+```
+
+Add `"reflect"` and `"sync/atomic"` to the test file imports.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/provider/ -run 'TestFirstHealthyDomainCached|TestKnownDomainsFlixhqSeeded' -v`
+Expected: FAIL to build — `FirstHealthyDomainCached`, `ResetDomainCache` undefined; seed test fails on the old one-entry list.
+
+- [ ] **Step 3: Implement**
+
+In `internal/provider/failover.go`, change the `knownDomains` entry:
+
+```go
+	// flixhq.to's origin cluster has been down since ~Aug 2026 (Cloudflare 522).
+	// sflix.to and myflixerz.to run the identical engine (same markup and /ajax/
+	// endpoints), so the FlixHQ scraper works on them unchanged; they are listed
+	// as revival candidates for whenever any of the family's origins return.
+	"flixhq": {"flixhq.to", "flixhq.click", "flixhq.pe", "flixhq.bz", "sflix.to", "myflixerz.to"},
+```
+
+Add below `FirstHealthyDomain`:
+
+```go
+var (
+	domainCacheMu sync.Mutex
+	domainCache   = map[string]string{}
+)
+
+// FirstHealthyDomainCached memoizes FirstHealthyDomain per provider name for
+// the process lifetime. A miss ("" — nothing healthy) is cached too: a dead
+// provider costs one parallel probe per session, not one per search.
+func FirstHealthyDomainCached(providerName string, overrides map[string][]string) string {
+	domainCacheMu.Lock()
+	if d, ok := domainCache[providerName]; ok {
+		domainCacheMu.Unlock()
+		return d
+	}
+	domainCacheMu.Unlock()
+
+	d := FirstHealthyDomain(providerName, overrides)
+
+	domainCacheMu.Lock()
+	domainCache[providerName] = d
+	domainCacheMu.Unlock()
+	return d
+}
+
+// ResetDomainCache clears the memoized probe results. Test helper.
+func ResetDomainCache() {
+	domainCacheMu.Lock()
+	domainCache = map[string]string{}
+	domainCacheMu.Unlock()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/provider/ -v -run 'FirstHealthyDomain|KnownDomains'` then `go test ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/provider/failover.go internal/provider/failover_test.go
+git commit -m "feat(failover): session-cached domain gate; seed flixhq mirror candidates"
+```
+
+---
+
+### Task 3: Wire the gate into the fallback chain; retire AllAnime
+
+**Files:**
+- Modify: `cmd/fallback.go`
+- Modify: `cmd/fallback_providers_test.go` (append)
+
+**Interfaces:**
+- Consumes: `provider.FirstHealthyDomainCached(name string, overrides map[string][]string) string`, `provider.ResetDomainCache()`, `provider.NewFlixHQ(base string) *FlixHQ` (existing).
+- Produces: `fallbackProviders` includes `*provider.FlixHQ` iff a healthy domain exists, and never includes `*provider.AllAnime`. Package var `flixhqDomain = provider.FirstHealthyDomainCached` in `cmd/fallback.go` as the cmd-level test seam.
+
+- [ ] **Step 1: Write the failing tests (append to `cmd/fallback_providers_test.go`)**
+
+```go
+// FlixHQ (the flixhq.to-engine scraper) is gated on a live health probe: it
+// joins the chain only when some mirror in knownDomains/overrides answers, so
+// a dead provider costs one parallel probe per session instead of a full
+// request timeout on every search.
+func TestFallbackProvidersIncludesFlixHQWhenDomainHealthy(t *testing.T) {
+	prev := flixhqDomain
+	flixhqDomain = func(name string, overrides map[string][]string) string { return "flixhq.to" }
+	t.Cleanup(func() { flixhqDomain = prev })
+
+	if !hasProvider[*provider.FlixHQ](fallbackProviders(nil)) {
+		t.Fatal("FlixHQ missing from chain despite a healthy domain")
+	}
+}
+
+func TestFallbackProvidersOmitsFlixHQWhenAllDomainsDead(t *testing.T) {
+	prev := flixhqDomain
+	flixhqDomain = func(name string, overrides map[string][]string) string { return "" }
+	t.Cleanup(func() { flixhqDomain = prev })
+
+	if hasProvider[*provider.FlixHQ](fallbackProviders(nil)) {
+		t.Fatal("FlixHQ present in chain although no domain is healthy")
+	}
+}
+
+// AllAnime is retired: its API sits behind a Cloudflare bot challenge and its
+// watch path has been crypto-gated since mid-2026. AniPub covers anime.
+func TestFallbackProvidersNeverIncludesAllAnime(t *testing.T) {
+	if hasProvider[*provider.AllAnime](fallbackProviders(nil)) {
+		t.Fatal("AllAnime should be retired from the fallback chain")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/ -run 'TestFallbackProviders' -v`
+Expected: FAIL to build — `flixhqDomain` undefined (and once defined, AllAnime test fails until Step 3 completes).
+
+- [ ] **Step 3: Implement in `cmd/fallback.go`**
+
+Add near the top of the file (after the `sharedHealth` block):
+
+```go
+// flixhqDomain resolves a healthy FlixHQ mirror, memoized per session.
+// Package var so tests can stub the probe.
+var flixhqDomain = provider.FirstHealthyDomainCached
+```
+
+Replace the `// flixhq.to is gone —` comment block (cmd/fallback.go:95-98) with:
+
+```go
+	// The flixhq.to engine family (flixhq.to, sflix.to, myflixerz.to, ...) has
+	// been origin-down since ~Aug 2026, so the scraper joins the chain only when
+	// a health probe finds a live mirror. The probe runs in parallel across all
+	// candidates and is cached for the session, so while everything is dead this
+	// costs one probe timeout per run — and the provider revives automatically
+	// the moment any mirror answers again.
+	if _, ok := primary.(*provider.FlixHQ); !ok {
+		var overrides map[string][]string
+		if cfg != nil {
+			overrides = cfg.DomainOverrides
+		}
+		if d := flixhqDomain("flixhq", overrides); d != "" {
+			fallbacks = append(fallbacks, provider.NewFlixHQ(d))
+		}
+	}
+```
+
+Replace the AllAnime block (cmd/fallback.go:104-109, keeping the AniPub block that follows) with:
+
+```go
+	// AniPub is the anime path. AllAnime is retired: its API now sits behind a
+	// Cloudflare bot challenge on top of the crypto-gated sources endpoint
+	// (AA_CRYPTO_MISSING, mid-2026), so it can neither search nor stream. The
+	// provider code stays for the day either gate lifts.
+```
+
+(The `if _, ok := primary.(*provider.AllAnime)` block is deleted; the `AniPub` block stays.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/ -run 'TestFallbackProviders' -v` then `go test ./...`
+Expected: PASS, full suite green. Also build the binary: `go build ./...`.
+
+- [ ] **Step 5: Verify the live behavior once**
+
+Run: `go run . search --debug "breaking bad" 2>&1 | head -30` — expect no FlixHQ in the raced providers (all mirrors currently dead) and no multi-second stall attributable to flixhq probing beyond the single gate probe. This is an observation step; if the TUI blocks interactively, skip it and rely on the test suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/fallback.go cmd/fallback_providers_test.go
+git commit -m "feat(providers): health-gate FlixHQ revival, retire AllAnime from the chain"
+```

--- a/docs/superpowers/specs/2026-09-01-revive-dead-providers-design.md
+++ b/docs/superpowers/specs/2026-09-01-revive-dead-providers-design.md
@@ -1,0 +1,73 @@
+# Revive Dead Providers — Design
+
+Date: 2026-09-01
+Branch: feat/wire-idle-providers (builds on 824374f)
+
+## Problem
+
+Lobster's fallback chain has lost providers to domain deaths:
+
+- **flixhq.to** — dropped in 824374f because its origin is down (Cloudflare 522
+  from multiple vantages) and every attempt burned the full request timeout.
+- **AllAnime** — API is behind a Cloudflare bot challenge and its watch path has
+  been crypto-gated since Aug 2026. Not legitimately revivable.
+
+A mirror hunt (2026-09-01) found **no live FlixHQ-engine deployment**: flixhq.to,
+flixhq.click, flixhq.pe, flixhq.bz, sflix.to, myflixerz.to all return Cloudflare
+522 (origin down), suggesting the engine family shares one dead backend cluster.
+flixhq.ws (separate deployment) is alive.
+
+Goal: providers come back **automatically** the moment any mirror resurfaces,
+and cost near-zero while dead.
+
+## Design
+
+### 1. Health-gated FlixHQ revival
+
+- Expand `knownDomains["flixhq"]` in `internal/provider/failover.go` to:
+  `flixhq.to, flixhq.click, flixhq.pe, flixhq.bz, sflix.to, myflixerz.to`.
+  The last two are same-engine deployments (identical `flw-item` markup and
+  `/ajax/` endpoints); the existing scraper works on them unchanged. This reuses
+  the existing scraper — no new scraper is authored.
+- Re-add FlixHQ to `fallbackProviders` (cmd/fallback.go), gated: a new
+  `provider.FirstHealthyDomain(name)` probes all candidate domains **in
+  parallel** (HEAD, ~3s timeout each; wall clock ≈ one probe) and returns the
+  first healthy domain by list preference. If none is healthy, FlixHQ is not
+  added to the chain at all.
+- Probe results are cached in-memory for the process lifetime (sync.Once per
+  provider name) so the gate runs once per session, not per search.
+- PR #36's TBCPL mirror feed extends the same candidate list dynamically via
+  `MergeOverrides`; no coupling changes needed here.
+
+### 2. AllAnime retirement
+
+- Remove AllAnime from `fallbackProviders`; keep the code and tests.
+- Comment at the removal site: Cloudflare challenge + crypto gate, AniPub
+  (anipub.xyz → megaplay.buzz, verified alive) is the anime path.
+
+### 3. IPv6-robust probing
+
+This dev machine's broken IPv6 made live domains look dead (TLS over v6 never
+completed while v4 worked). Health probes must not repeat that mistake:
+
+- The probe HTTP client uses a dialer that attempts IPv4 and IPv6 concurrently
+  and takes whichever connects first (Go's default Happy Eyeballs via
+  `net.Dialer{DualStack}` semantics is acceptable; verify the current transport
+  isn't pinning v6). If needed, probe falls back to an explicit `tcp4` dial when
+  the default dial fails.
+
+### 4. Testing
+
+- `FirstHealthyDomain`: healthy stub server wins; hanging server (never
+  responds) does not block past the timeout; all-dead list returns "" and the
+  provider is omitted from `fallbackProviders`.
+- Parallelism bound: total gate time ≈ single probe timeout, not sum.
+- Extend `cmd/fallback_providers_test.go`: FlixHQ present when a domain is
+  healthy, absent when none are; AllAnime absent unconditionally.
+- All probes in tests hit `httptest` servers — no live-network tests.
+
+## Out of scope
+
+- Reviving AllAnime (bot-challenge bypass is off the table).
+- New scrapers for unrelated sites.
+- Persisting probe results across runs (session cache only).

--- a/internal/provider/failover.go
+++ b/internal/provider/failover.go
@@ -45,6 +45,7 @@ func checkDomainHealth(domain string) bool {
 			}).DialContext,
 		},
 	}
+	defer client.CloseIdleConnections()
 	resp, err := client.Head(healthURLFor(domain))
 	if err != nil {
 		return false
@@ -106,6 +107,11 @@ var (
 // FirstHealthyDomainCached memoizes FirstHealthyDomain per provider name for
 // the process lifetime. A miss ("" — nothing healthy) is cached too: a dead
 // provider costs one parallel probe per session, not one per search.
+//
+// Invariant: the cache key is providerName only, not overrides. Callers must
+// pass stable overrides for a given provider name within a process; calling
+// with differing overrides for the same name will share whatever result was
+// cached on the first call.
 func FirstHealthyDomainCached(providerName string, overrides map[string][]string) string {
 	domainCacheMu.Lock()
 	if d, ok := domainCache[providerName]; ok {
@@ -143,16 +149,12 @@ func ResolveDomain(configured string, providerName string, overrides map[string]
 	}
 	fmt.Fprintf(os.Stderr, "[failover] %s (%s) is unreachable, trying alternatives...\n", configured, providerName)
 
-	candidates := candidateDomains(providerName, overrides)
-
-	for _, domain := range candidates {
-		if domain == configured {
-			continue // already tried
-		}
-		if checkDomainHealth(domain) {
-			fmt.Fprintf(os.Stderr, "[failover] switching %s to %s\n", providerName, domain)
-			return domain
-		}
+	// Delegate the candidate scan to FirstHealthyDomain so the alternatives
+	// are probed in parallel (~one probeTimeout) instead of sequentially,
+	// which matters once a provider has several known mirrors.
+	if alt := FirstHealthyDomain(providerName, overrides); alt != "" && alt != configured {
+		fmt.Fprintf(os.Stderr, "[failover] switching %s to %s\n", providerName, alt)
+		return alt
 	}
 
 	fmt.Fprintf(os.Stderr, "[failover] no healthy domain found for %s, using %s anyway\n", providerName, configured)

--- a/internal/provider/failover.go
+++ b/internal/provider/failover.go
@@ -14,8 +14,12 @@ import (
 // The first domain in each list is the preferred one.
 var knownDomains = map[string][]string{
 	"kimcartoon": {"kimcartoon.com.co", "kimcartoon.com.rs", "kimcartoon.li"},
-	"flixhq":     {"flixhq.to"},
-	"flixhqws":   {"flixhq.ws"},
+	// flixhq.to's origin cluster has been down since ~Aug 2026 (Cloudflare 522).
+	// sflix.to and myflixerz.to run the identical engine (same markup and /ajax/
+	// endpoints), so the FlixHQ scraper works on them unchanged; they are listed
+	// as revival candidates for whenever any of the family's origins return.
+	"flixhq":   {"flixhq.to", "flixhq.click", "flixhq.pe", "flixhq.bz", "sflix.to", "myflixerz.to"},
+	"flixhqws": {"flixhq.ws"},
 }
 
 // healthURLFor maps a domain to the URL probed for health. A package var so
@@ -92,6 +96,37 @@ func FirstHealthyDomain(providerName string, overrides map[string][]string) stri
 		}
 	}
 	return ""
+}
+
+var (
+	domainCacheMu sync.Mutex
+	domainCache   = map[string]string{}
+)
+
+// FirstHealthyDomainCached memoizes FirstHealthyDomain per provider name for
+// the process lifetime. A miss ("" — nothing healthy) is cached too: a dead
+// provider costs one parallel probe per session, not one per search.
+func FirstHealthyDomainCached(providerName string, overrides map[string][]string) string {
+	domainCacheMu.Lock()
+	if d, ok := domainCache[providerName]; ok {
+		domainCacheMu.Unlock()
+		return d
+	}
+	domainCacheMu.Unlock()
+
+	d := FirstHealthyDomain(providerName, overrides)
+
+	domainCacheMu.Lock()
+	domainCache[providerName] = d
+	domainCacheMu.Unlock()
+	return d
+}
+
+// ResetDomainCache clears the memoized probe results. Test helper.
+func ResetDomainCache() {
+	domainCacheMu.Lock()
+	domainCache = map[string]string{}
+	domainCacheMu.Unlock()
 }
 
 // ResolveDomain picks a working domain for a provider. It checks the

--- a/internal/provider/failover.go
+++ b/internal/provider/failover.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,16 +18,80 @@ var knownDomains = map[string][]string{
 	"flixhqws":   {"flixhq.ws"},
 }
 
-// checkDomainHealth sends a HEAD request to https://<domain>/ and returns
-// true if the server responds with a non-error status within 5 seconds.
+// healthURLFor maps a domain to the URL probed for health. A package var so
+// tests can point probes at httptest servers instead of the live network.
+var healthURLFor = func(domain string) string { return "https://" + domain + "/" }
+
+// probeTimeout bounds a single health probe. Package var for tests.
+var probeTimeout = 3 * time.Second
+
+// checkDomainHealth sends a HEAD request to the domain's health URL and
+// returns true if the server responds with a non-5xx status in time.
 func checkDomainHealth(domain string) bool {
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Head("https://" + domain + "/")
+	// Explicit dialer with Happy Eyeballs (FallbackDelay > 0): a broken IPv6
+	// route must not make a live domain look dead — the dial races v6 and v4
+	// and takes whichever connects. Go enables this by default; the explicit
+	// dialer pins the behavior so a future custom transport can't lose it.
+	client := &http.Client{
+		Timeout: probeTimeout,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:       probeTimeout,
+				FallbackDelay: 100 * time.Millisecond,
+			}).DialContext,
+		},
+	}
+	resp, err := client.Head(healthURLFor(domain))
 	if err != nil {
 		return false
 	}
 	resp.Body.Close()
 	return resp.StatusCode < 500
+}
+
+// candidateDomains returns the preference-ordered candidate list for a
+// provider: config overrides first (case-insensitive key match), then the
+// built-in known domains.
+func candidateDomains(providerName string, overrides map[string][]string) []string {
+	var candidates []string
+	if overrides != nil {
+		lowerName := strings.ToLower(providerName)
+		for key, domains := range overrides {
+			if strings.ToLower(key) == lowerName {
+				candidates = append(candidates, domains...)
+				break
+			}
+		}
+	}
+	return append(candidates, knownDomains[providerName]...)
+}
+
+// FirstHealthyDomain probes every candidate domain for a provider in parallel
+// and returns the first healthy one in preference order, or "" if none
+// respond. Wall-clock cost is roughly one probeTimeout regardless of how many
+// candidates are dead, which is what makes gating a usually-dead provider
+// affordable.
+func FirstHealthyDomain(providerName string, overrides map[string][]string) string {
+	candidates := candidateDomains(providerName, overrides)
+	if len(candidates) == 0 {
+		return ""
+	}
+	healthy := make([]bool, len(candidates))
+	var wg sync.WaitGroup
+	for i, d := range candidates {
+		wg.Add(1)
+		go func(i int, d string) {
+			defer wg.Done()
+			healthy[i] = checkDomainHealth(d)
+		}(i, d)
+	}
+	wg.Wait()
+	for i, ok := range healthy {
+		if ok {
+			return candidates[i]
+		}
+	}
+	return ""
 }
 
 // ResolveDomain picks a working domain for a provider. It checks the
@@ -42,19 +108,7 @@ func ResolveDomain(configured string, providerName string, overrides map[string]
 	}
 	fmt.Fprintf(os.Stderr, "[failover] %s (%s) is unreachable, trying alternatives...\n", configured, providerName)
 
-	// Build candidate list: config overrides first, then built-in known domains.
-	// Override keys are matched case-insensitively.
-	var candidates []string
-	if overrides != nil {
-		lowerName := strings.ToLower(providerName)
-		for key, domains := range overrides {
-			if strings.ToLower(key) == lowerName {
-				candidates = append(candidates, domains...)
-				break
-			}
-		}
-	}
-	candidates = append(candidates, knownDomains[providerName]...)
+	candidates := candidateDomains(providerName, overrides)
 
 	for _, domain := range candidates {
 		if domain == configured {

--- a/internal/provider/failover.go
+++ b/internal/provider/failover.go
@@ -102,7 +102,19 @@ func FirstHealthyDomain(providerName string, overrides map[string][]string) stri
 var (
 	domainCacheMu sync.Mutex
 	domainCache   = map[string]string{}
+	// domainProbes tracks probes currently in flight, keyed by provider name.
+	// Without it two callers can miss the cache at the same instant and both
+	// probe every candidate; the download manager runs several workers by
+	// default and each builds the fallback chain, so that is a real path.
+	domainProbes = map[string]*domainProbe{}
 )
+
+// domainProbe is one in-flight probe. done is closed when result is set, so
+// later callers wait rather than starting a probe of their own.
+type domainProbe struct {
+	done   chan struct{}
+	result string
+}
 
 // FirstHealthyDomainCached memoizes FirstHealthyDomain per provider name for
 // the process lifetime. A miss ("" — nothing healthy) is cached too: a dead
@@ -118,14 +130,29 @@ func FirstHealthyDomainCached(providerName string, overrides map[string][]string
 		domainCacheMu.Unlock()
 		return d
 	}
+	// Someone else is already probing this provider: wait for their result
+	// instead of duplicating the work.
+	if p, ok := domainProbes[providerName]; ok {
+		domainCacheMu.Unlock()
+		<-p.done
+		return p.result
+	}
+	p := &domainProbe{done: make(chan struct{})}
+	domainProbes[providerName] = p
 	domainCacheMu.Unlock()
 
-	d := FirstHealthyDomain(providerName, overrides)
+	// Publish to waiters even if FirstHealthyDomain panics, so a failure here
+	// cannot strand every other caller blocked on done forever.
+	defer func() {
+		domainCacheMu.Lock()
+		domainCache[providerName] = p.result
+		delete(domainProbes, providerName)
+		domainCacheMu.Unlock()
+		close(p.done)
+	}()
 
-	domainCacheMu.Lock()
-	domainCache[providerName] = d
-	domainCacheMu.Unlock()
-	return d
+	p.result = FirstHealthyDomain(providerName, overrides)
+	return p.result
 }
 
 // ResetDomainCache clears the memoized probe results. Test helper.

--- a/internal/provider/failover_test.go
+++ b/internal/provider/failover_test.go
@@ -115,19 +115,25 @@ func TestFirstHealthyDomainCachedProbesOnce(t *testing.T) {
 func TestFirstHealthyDomainCachedCachesMiss(t *testing.T) {
 	ResetDomainCache()
 	t.Cleanup(ResetDomainCache)
-	pointProbesAt(t, nil)
+	var probes int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&probes, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	pointProbesAt(t, map[string]string{"a.example": srv.URL})
 	ov := map[string][]string{"deadprov": {"a.example"}}
+
 	if got := FirstHealthyDomainCached("deadprov", ov); got != "" {
 		t.Fatalf("got %q, want empty", got)
 	}
-	// Second call must not re-probe; verify by making probes impossible to
-	// distinguish — we just assert it still returns "" instantly.
-	start := time.Now()
+	firstCount := atomic.LoadInt32(&probes)
+
 	if got := FirstHealthyDomainCached("deadprov", ov); got != "" {
 		t.Fatalf("second call got %q, want empty", got)
 	}
-	if time.Since(start) > 100*time.Millisecond {
-		t.Fatal("second call re-probed instead of using the cache")
+	if n := atomic.LoadInt32(&probes); n != firstCount {
+		t.Fatalf("probed %d times after second call, want %d (cached, no re-probe)", n, firstCount)
 	}
 }
 

--- a/internal/provider/failover_test.go
+++ b/internal/provider/failover_test.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -86,5 +88,52 @@ func TestFirstHealthyDomainUsesKnownDomains(t *testing.T) {
 
 	if got := FirstHealthyDomain("_fhd_test", nil); got != "known.example" {
 		t.Fatalf("got %q, want known.example", got)
+	}
+}
+
+func TestFirstHealthyDomainCachedProbesOnce(t *testing.T) {
+	ResetDomainCache()
+	t.Cleanup(ResetDomainCache)
+	var probes int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&probes, 1)
+	}))
+	defer srv.Close()
+	pointProbesAt(t, map[string]string{"a.example": srv.URL})
+	ov := map[string][]string{"cachedprov": {"a.example"}}
+
+	first := FirstHealthyDomainCached("cachedprov", ov)
+	second := FirstHealthyDomainCached("cachedprov", ov)
+	if first != "a.example" || second != "a.example" {
+		t.Fatalf("got %q then %q, want a.example twice", first, second)
+	}
+	if n := atomic.LoadInt32(&probes); n != 1 {
+		t.Fatalf("probed %d times, want 1 (cached)", n)
+	}
+}
+
+func TestFirstHealthyDomainCachedCachesMiss(t *testing.T) {
+	ResetDomainCache()
+	t.Cleanup(ResetDomainCache)
+	pointProbesAt(t, nil)
+	ov := map[string][]string{"deadprov": {"a.example"}}
+	if got := FirstHealthyDomainCached("deadprov", ov); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	// Second call must not re-probe; verify by making probes impossible to
+	// distinguish — we just assert it still returns "" instantly.
+	start := time.Now()
+	if got := FirstHealthyDomainCached("deadprov", ov); got != "" {
+		t.Fatalf("second call got %q, want empty", got)
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Fatal("second call re-probed instead of using the cache")
+	}
+}
+
+func TestKnownDomainsFlixhqSeeded(t *testing.T) {
+	want := []string{"flixhq.to", "flixhq.click", "flixhq.pe", "flixhq.bz", "sflix.to", "myflixerz.to"}
+	if !reflect.DeepEqual(knownDomains["flixhq"], want) {
+		t.Fatalf("knownDomains[flixhq] = %v, want %v", knownDomains["flixhq"], want)
 	}
 }

--- a/internal/provider/failover_test.go
+++ b/internal/provider/failover_test.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// pointProbesAt makes every probed "domain" hit the given handler by rewriting
+// the probe URL. The domain string itself is ignored except when it matches a
+// key in routes, which maps domain -> httptest server URL. Unrouted domains
+// get an unreachable address so they fail fast.
+func pointProbesAt(t *testing.T, routes map[string]string) {
+	t.Helper()
+	old := healthURLFor
+	healthURLFor = func(domain string) string {
+		if u, ok := routes[domain]; ok {
+			return u
+		}
+		return "http://127.0.0.1:1/" // closed port: immediate refusal
+	}
+	t.Cleanup(func() { healthURLFor = old })
+}
+
+func TestFirstHealthyDomainPrefersListOrder(t *testing.T) {
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ok.Close()
+	pointProbesAt(t, map[string]string{"b.example": ok.URL, "c.example": ok.URL})
+
+	got := FirstHealthyDomain("testprov", map[string][]string{
+		"testprov": {"a.example", "b.example", "c.example"},
+	})
+	if got != "b.example" {
+		t.Fatalf("got %q, want b.example (first healthy in preference order)", got)
+	}
+}
+
+func TestFirstHealthyDomainAllDeadReturnsEmpty(t *testing.T) {
+	pointProbesAt(t, nil)
+	if got := FirstHealthyDomain("testprov", map[string][]string{"testprov": {"a.example", "b.example"}}); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestFirstHealthyDomainHangingProbeDoesNotBlock(t *testing.T) {
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Second)
+	}))
+	defer hang.Close()
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ok.Close()
+	pointProbesAt(t, map[string]string{"hang.example": hang.URL, "ok.example": ok.URL})
+
+	oldTimeout := probeTimeout
+	probeTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { probeTimeout = oldTimeout })
+
+	start := time.Now()
+	got := FirstHealthyDomain("testprov", map[string][]string{
+		"testprov": {"hang.example", "ok.example"},
+	})
+	elapsed := time.Since(start)
+	if got != "ok.example" {
+		t.Fatalf("got %q, want ok.example", got)
+	}
+	// Parallel: total time ~ one probe timeout, not the sum of probes.
+	if elapsed > 2*time.Second {
+		t.Fatalf("gate took %s; probes are not parallel or timeout ignored", elapsed)
+	}
+}
+
+func TestFirstHealthyDomainUsesKnownDomains(t *testing.T) {
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ok.Close()
+	oldKnown := knownDomains["_fhd_test"]
+	knownDomains["_fhd_test"] = []string{"known.example"}
+	t.Cleanup(func() {
+		if oldKnown == nil {
+			delete(knownDomains, "_fhd_test")
+		} else {
+			knownDomains["_fhd_test"] = oldKnown
+		}
+	})
+	pointProbesAt(t, map[string]string{"known.example": ok.URL})
+
+	if got := FirstHealthyDomain("_fhd_test", nil); got != "known.example" {
+		t.Fatalf("got %q, want known.example", got)
+	}
+}

--- a/internal/provider/failover_test.go
+++ b/internal/provider/failover_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -46,8 +47,11 @@ func TestFirstHealthyDomainAllDeadReturnsEmpty(t *testing.T) {
 }
 
 func TestFirstHealthyDomainHangingProbeDoesNotBlock(t *testing.T) {
+	// Block until the client gives up rather than sleeping a fixed 10s: a bare
+	// sleep keeps running after the probe timeout cancels the request, and
+	// hang.Close() then waits the full remainder, adding ~10s to the suite.
 	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Second)
+		<-r.Context().Done()
 	}))
 	defer hang.Close()
 	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
@@ -141,5 +145,52 @@ func TestKnownDomainsFlixhqSeeded(t *testing.T) {
 	want := []string{"flixhq.to", "flixhq.click", "flixhq.pe", "flixhq.bz", "sflix.to", "myflixerz.to"}
 	if !reflect.DeepEqual(knownDomains["flixhq"], want) {
 		t.Fatalf("knownDomains[flixhq] = %v, want %v", knownDomains["flixhq"], want)
+	}
+}
+
+// Two goroutines missing the cache at the same moment must produce one probe,
+// not two. The download manager runs several workers by default, and each one
+// builds the fallback chain, so this path is genuinely concurrent in
+// production rather than only in tests.
+func TestFirstHealthyDomainCachedCoalescesConcurrentMisses(t *testing.T) {
+	ResetDomainCache()
+	t.Cleanup(ResetDomainCache)
+
+	var probes int32
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&probes, 1)
+		// Hold the first probe open so a second caller is guaranteed to arrive
+		// while it is still in flight; without that the race is timing-dependent
+		// and the test would pass by luck.
+		<-release
+	}))
+	defer srv.Close()
+	pointProbesAt(t, map[string]string{"a.example": srv.URL})
+	ov := map[string][]string{"raceprov": {"a.example"}}
+
+	const callers = 2
+	got := make([]string, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			got[i] = FirstHealthyDomainCached("raceprov", ov)
+		}(i)
+	}
+
+	// Give both goroutines time to reach the probe before letting it answer.
+	time.Sleep(200 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if n := atomic.LoadInt32(&probes); n != 1 {
+		t.Fatalf("probed %d times, want 1 (concurrent misses must coalesce)", n)
+	}
+	for i, g := range got {
+		if g != "a.example" {
+			t.Fatalf("caller %d got %q, want a.example", i, g)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Wire **Consumet** into the fallback chain (it was implemented but unreachable — only ever built as the primary); it joins only when `api_url` is configured.
- **FlixHQ revived structurally**: rejoins the fallback chain behind a health gate. `FirstHealthyDomain` probes all candidate mirrors in parallel (bounded by one ~3s probe timeout), the result is cached per session, and the provider is simply omitted while everything is dead — so it costs one probe per run instead of full request timeouts per search, and it comes back automatically the moment any mirror answers.
- Seed `knownDomains["flixhq"]` with `flixhq.to`, `flixhq.click`, `flixhq.pe`, `flixhq.bz`, plus same-engine deployments `sflix.to` / `myflixerz.to` (identical markup and `/ajax/` endpoints — the existing scraper works unchanged). Verified from two network vantages that the whole engine family is currently origin-down (Cloudflare 522), hence the gate rather than a hardcoded mirror.
- `ResolveDomain` (`--base` failover) now delegates its candidate scan to the same parallel probe — previously the seeded list would have cost ~18s of sequential probing on a dead primary.
- **AllAnime retired** from the fallback chain: its API sits behind a Cloudflare bot challenge on top of the crypto-gated sources endpoint. Provider code stays for the day either gate lifts; AniPub (verified alive) is the anime path.
- Health probes pin Happy-Eyeballs dialing (`FallbackDelay`) so a broken IPv6 route can't make a live domain look dead.

## Testing
- New unit tests for the parallel gate (preference order, all-dead, hanging-probe timeout bound, session cache incl. cached misses, seeded mirror list) — all against `httptest` seams, zero live network in tests (`TestMain` stubs the gate package-wide in `cmd`).
- `go test ./...`, `go vet ./...`, and `go test -race` on the touched packages: green.

Design/plan docs included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193xW7mNDXnmCSF48Lu9N8U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic FlixHQ mirror selection using health checks to improve availability.
  * Consumet is included in fallback options when an API URL is configured.
  * Fallback selection remembers provider availability during the session.

* **Bug Fixes**
  * Removed retired AllAnime from fallback options.
  * AniPub remains available as the anime fallback provider.
  * Improved provider failover across IPv4 and IPv6 connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->