### PR TITLE
feat(agent): non-interactive find/episodes/play plus the lobster-play skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,12 @@ lobster play --ref <REF> --detach        # start playback, return immediately
 All three print JSON on stdout and never prompt — including on failure. `find`
 and `episodes` print nothing else, so their stdout is always parseable; `play`
 shares stdout with the player unless you pass `--detach` (see below).
-`play --ref` and `episodes --ref` both
-resolve against the base the ref was found under, and `play` forwards any flags you pass
-explicitly (`--base`, `--quality`, `--player`, `--provider`, `--language`,
-`--audio-language`, `--no-subs`, `--debug`, `--continue`) to the detached
-child so overrides still apply in the background.
+
+`play --ref` and `episodes --ref` both resolve against the base the ref was
+found under, and `play` forwards any flags you pass explicitly (`--base`,
+`--quality`, `--player`, `--provider`, `--language`, `--audio-language`,
+`--no-subs`, `--debug`, `--continue`) to the detached child so overrides still
+apply in the background.
 
 `--detach` is what makes the stdout-is-only-JSON guarantee hold: attached, the
 player inherits lobster's stdout and its progress output is interleaved with

--- a/README.md
+++ b/README.md
@@ -247,11 +247,18 @@ lobster episodes --ref <REF> --season 2  # JSON season/episode listing
 lobster play --ref <REF> --detach        # start playback, return immediately
 ```
 
-All three print JSON on stdout and never prompt. `play --ref` resolves
-against the base the ref was found under, and forwards any flags you pass
+All three print JSON on stdout and never prompt — including on failure, so a
+caller can parse stdout unconditionally. `play --ref` and `episodes --ref` both
+resolve against the base the ref was found under, and `play` forwards any flags you pass
 explicitly (`--base`, `--quality`, `--player`, `--provider`, `--language`,
 `--audio-language`, `--no-subs`, `--debug`, `--continue`) to the detached
 child so overrides still apply in the background.
+
+`--detach` is what makes the stdout-is-only-JSON guarantee hold: attached, the
+player inherits lobster's stdout and its progress output is interleaved with
+the envelope. That is deliberate — a human running `lobster play --ref` should
+still see the player — so a script must pass `--detach` and read the player's
+output from the `log` path in the response.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,34 @@ Xtream — so your own channels appear alongside the free ones.
 
 ---
 
+## Use it from a coding agent
+
+`lobster` ships an agent skill so you can ask Claude Code (or another agent)
+to find and play something for you.
+
+```bash
+mkdir -p ~/.claude/skills
+cp -r skills/lobster-play ~/.claude/skills/
+```
+
+Then just ask: *"find me The Matrix and play it"*. The agent will show you the
+matches and wait for you to pick one before starting playback.
+
+Under the hood it uses three non-interactive commands, which are useful for
+scripting on their own:
+
+```bash
+lobster find "the matrix" --limit 5      # JSON candidates, each with a ref
+lobster episodes --ref <REF> --season 2  # JSON season/episode listing
+lobster play --ref <REF> --detach        # start playback, return immediately
+```
+
+All three print JSON on stdout and never prompt. `play --ref` resolves
+against the base the ref was found under, and forwards any flags you pass
+explicitly (`--base`, `--quality`, `--player`, `--provider`, `--language`,
+`--audio-language`, `--no-subs`, `--debug`, `--continue`) to the detached
+child so overrides still apply in the background.
+
 ## Configuration
 
 Config file location:

--- a/README.md
+++ b/README.md
@@ -247,8 +247,10 @@ lobster episodes --ref <REF> --season 2  # JSON season/episode listing
 lobster play --ref <REF> --detach        # start playback, return immediately
 ```
 
-All three print JSON on stdout and never prompt — including on failure, so a
-caller can parse stdout unconditionally. `play --ref` and `episodes --ref` both
+All three print JSON on stdout and never prompt — including on failure. `find`
+and `episodes` print nothing else, so their stdout is always parseable; `play`
+shares stdout with the player unless you pass `--detach` (see below).
+`play --ref` and `episodes --ref` both
 resolve against the base the ref was found under, and `play` forwards any flags you pass
 explicitly (`--base`, `--quality`, `--player`, `--provider`, `--language`,
 `--audio-language`, `--no-subs`, `--debug`, `--continue`) to the detached

--- a/cmd/agenterr_test.go
+++ b/cmd/agenterr_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// cliRun is the result of driving the real cobra tree end to end.
+type cliRun struct {
+	stdout *bytes.Buffer // what an agent parses: the JSON envelope writer
+	stderr *bytes.Buffer // what cobra prints for humans
+	err    error
+}
+
+// rootPersistentFlagNames is every persistent flag an Execute() in these
+// tests can mutate; snapshotting them keeps one run from leaking Changed
+// bits or values into the next (the commands are package-level singletons).
+var rootPersistentFlagNames = []string{
+	"download", "language", "audio-language", "no-subs", "provider",
+	"quality", "player", "continue", "json", "base", "debug",
+}
+
+// runCLI executes the real root command with args, exactly as main() would,
+// but with the JSON writer and cobra's error stream captured and with every
+// global the run mutates restored afterwards.
+//
+// Driving Execute() rather than calling the RunE functions directly is the
+// whole point: the failures this covers (argument validation, flag parsing,
+// PersistentPreRunE) all happen *before* RunE is ever reached, so a test that
+// calls findRun/playRun cannot see them at all.
+func runCLI(t *testing.T, args ...string) cliRun {
+	t.Helper()
+
+	// Keep config.Load away from the developer's real config file.
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, "cache"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "data"))
+
+	snapshotFlags(t, rootCmd, rootPersistentFlagNames...)
+	snapshotFlags(t, findCmd, "type", "limit")
+	snapshotFlags(t, episodesCmd, "ref", "season")
+	snapshotFlags(t, playCmd, "ref", "season", "episode", "detach", "supervised")
+
+	prevCfg := cfg
+	t.Cleanup(func() { cfg = prevCfg })
+
+	out := captureAgentOut(t)
+
+	var errBuf bytes.Buffer
+	rootCmd.SetOut(&errBuf)
+	rootCmd.SetErr(&errBuf)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err := rootCmd.Execute()
+	return cliRun{stdout: out, stderr: &errBuf, err: err}
+}
+
+// snapshotFlags records the named flags' values and Changed bits, restoring
+// them when the test ends. The *pflag.Flag values are obtained through cobra's
+// accessors and only ever held in inferred-type variables, so this file needs
+// no direct pflag dependency.
+func snapshotFlags(t *testing.T, c *cobra.Command, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		f := c.PersistentFlags().Lookup(name)
+		if f == nil {
+			f = c.Flags().Lookup(name)
+		}
+		if f == nil {
+			t.Fatalf("flag %q not found on %q; the snapshot list is stale", name, c.Name())
+		}
+		changed, val := f.Changed, f.Value.String()
+		t.Cleanup(func() {
+			_ = f.Value.Set(val)
+			f.Changed = changed
+		})
+	}
+}
+
+// wantEnvelope asserts stdout carries a parseable error envelope and returns
+// its code.
+func wantEnvelope(t *testing.T, r cliRun) string {
+	t.Helper()
+	var got struct {
+		Schema int `json:"schema"`
+		Error  struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if r.stdout.Len() == 0 {
+		t.Fatalf("stdout was empty; an agent parsing it unconditionally gets nothing (stderr=%q, err=%v)", r.stderr.String(), r.err)
+	}
+	if err := json.Unmarshal(r.stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v (%q)", err, r.stdout.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if got.Error.Code == "" {
+		t.Fatalf("error.code is empty in %q", r.stdout.String())
+	}
+	if got.Error.Message == "" {
+		t.Fatalf("error.message is empty in %q", r.stdout.String())
+	}
+	return got.Error.Code
+}
+
+// wantExitCode asserts the run failed with an *exitError carrying want.
+func wantExitCode(t *testing.T, r cliRun, want int) {
+	t.Helper()
+	var ee *exitError
+	if !errors.As(r.err, &ee) {
+		t.Fatalf("Execute returned %T (%v), want *exitError so Execute() can pick the exit code", r.err, r.err)
+	}
+	if ee.code != want {
+		t.Fatalf("exit code = %d, want %d", ee.code, want)
+	}
+}
+
+// Class 1: Args validation. "lobster find" with no query fails cobra's
+// MinimumNArgs before RunE runs, and SilenceErrors means nothing is printed
+// at all unless the command converts it into an envelope itself.
+func TestAgentCommandArgsErrorIsJSON(t *testing.T) {
+	r := runCLI(t, "find")
+	if code := wantEnvelope(t, r); code != "usage" {
+		t.Fatalf("error.code = %q, want usage", code)
+	}
+	wantExitCode(t, r, exitUsage)
+}
+
+// Class 2: flag parsing. An unknown flag is rejected inside ParseFlags,
+// before Args validation and before PersistentPreRunE.
+func TestAgentCommandFlagErrorIsJSON(t *testing.T) {
+	r := runCLI(t, "find", "x", "--bogus")
+	if code := wantEnvelope(t, r); code != "usage" {
+		t.Fatalf("error.code = %q, want usage", code)
+	}
+	wantExitCode(t, r, exitUsage)
+}
+
+// Class 3: PersistentPreRunE. loadConfig rejects an invalid --quality after
+// flags parse and args validate, on the way to RunE.
+func TestAgentCommandConfigErrorIsJSON(t *testing.T) {
+	r := runCLI(t, "find", "x", "--quality", "9999")
+	if code := wantEnvelope(t, r); code != "config_invalid" {
+		t.Fatalf("error.code = %q, want config_invalid", code)
+	}
+	wantExitCode(t, r, exitUsage)
+}
+
+// The other two agent commands must behave the same way; the envelope is a
+// property of the agent surface, not of one command.
+func TestAgentCommandsAllEnvelopeUsageErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"episodes-args", []string{"episodes", "stray-positional"}},
+		{"episodes-flag", []string{"episodes", "--bogus"}},
+		{"play-args", []string{"play", "stray-positional"}},
+		{"play-flag", []string{"play", "--bogus"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := runCLI(t, tc.args...)
+			wantEnvelope(t, r)
+			wantExitCode(t, r, exitUsage)
+		})
+	}
+}
+
+// Hard constraint: the interactive root command is not an agent surface and
+// its human-facing behaviour must not change. A bad --quality must still
+// print "Error: ..." on stderr and must not emit a JSON envelope.
+func TestRootCommandConfigErrorStaysHumanReadable(t *testing.T) {
+	r := runCLI(t, "somequery", "--quality", "9999")
+
+	if r.err == nil {
+		t.Fatal("Execute succeeded with an invalid --quality")
+	}
+	var ee *exitError
+	if errors.As(r.err, &ee) {
+		t.Fatalf("root command returned an *exitError (%v); it must stay a plain error", r.err)
+	}
+	if r.stdout.Len() != 0 {
+		t.Fatalf("root command wrote a JSON envelope to stdout: %q", r.stdout.String())
+	}
+	if !strings.Contains(r.stderr.String(), "Error:") {
+		t.Fatalf("stderr = %q, want cobra's human-readable \"Error: ...\"", r.stderr.String())
+	}
+	if !strings.Contains(r.stderr.String(), "invalid configuration") {
+		t.Fatalf("stderr = %q, want the invalid-configuration message", r.stderr.String())
+	}
+}

--- a/cmd/agenthelp_test.go
+++ b/cmd/agenthelp_test.go
@@ -43,11 +43,24 @@ func hostileEnv(t *testing.T) {
 
 // stubProvider is a provider.Provider that answers from fixed data and never
 // touches the network.
+//
+// GetEpisodes is season-aware on purpose. While it ignored its seasonID and
+// returned one fixed list, no test could tell a command that selects the
+// requested season from one that always serves season 1 — which is precisely
+// the class of bug play had (a non-existent season silently played S1E1).
+// Populate episodesBySeason keyed by media.Season.ID to exercise selection;
+// the flat episodes list remains for tests that do not care which season.
 type stubProvider struct {
-	results   []media.SearchResult
-	seasons   []media.Season
-	episodes  []media.Episode
-	searchErr error
+	results          []media.SearchResult
+	seasons          []media.Season
+	episodes         []media.Episode
+	episodesBySeason map[string][]media.Episode
+	searchErr        error
+	seasonsErr       error
+	episodesErr      error
+
+	// lastSeasonID records what GetEpisodes was actually asked for.
+	lastSeasonID string
 }
 
 func (s *stubProvider) Search(string) ([]media.SearchResult, error) {
@@ -56,8 +69,17 @@ func (s *stubProvider) Search(string) ([]media.SearchResult, error) {
 func (s *stubProvider) GetDetails(string) (*media.ContentDetail, error) {
 	return &media.ContentDetail{}, nil
 }
-func (s *stubProvider) GetSeasons(string) ([]media.Season, error) { return s.seasons, nil }
-func (s *stubProvider) GetEpisodes(string, string) ([]media.Episode, error) {
+func (s *stubProvider) GetSeasons(string) ([]media.Season, error) {
+	return s.seasons, s.seasonsErr
+}
+func (s *stubProvider) GetEpisodes(_, seasonID string) ([]media.Episode, error) {
+	s.lastSeasonID = seasonID
+	if s.episodesErr != nil {
+		return nil, s.episodesErr
+	}
+	if s.episodesBySeason != nil {
+		return s.episodesBySeason[seasonID], nil
+	}
 	return s.episodes, nil
 }
 func (s *stubProvider) GetServers(string, string) ([]media.Server, error) {

--- a/cmd/agenthelp_test.go
+++ b/cmd/agenthelp_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// hostileEnv makes any attempt to prompt the user fail the test rather than
+// hang it. Injecting ui.Select alone is not enough: ui.Input execs fzf
+// directly, ui.SelectWithTimeout reads os.Stdin raw before reaching Select,
+// and tui.StartApp is Bubble Tea rather than fzf. Closing stdin and shimming
+// fzf on PATH catches all of those, including any added later.
+func hostileEnv(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shim relies on a POSIX shell; the guarantee is covered on unix CI")
+	}
+
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "fzf")
+	script := "#!/bin/sh\necho 'fzf was invoked by a non-interactive command' >&2\nexit 97\n"
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fzf shim: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	w.Close() // reads return EOF immediately instead of blocking
+	prev := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = prev
+		r.Close()
+	})
+}
+
+// stubProvider is a provider.Provider that answers from fixed data and never
+// touches the network.
+type stubProvider struct {
+	results   []media.SearchResult
+	seasons   []media.Season
+	episodes  []media.Episode
+	searchErr error
+}
+
+func (s *stubProvider) Search(string) ([]media.SearchResult, error) {
+	return s.results, s.searchErr
+}
+func (s *stubProvider) GetDetails(string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+func (s *stubProvider) GetSeasons(string) ([]media.Season, error) { return s.seasons, nil }
+func (s *stubProvider) GetEpisodes(string, string) ([]media.Episode, error) {
+	return s.episodes, nil
+}
+func (s *stubProvider) GetServers(string, string) ([]media.Server, error) {
+	return []media.Server{{ID: "srv1", Name: "stub"}}, nil
+}
+func (s *stubProvider) GetEmbedURL(string) (string, error) { return "https://example.invalid/e", nil }
+func (s *stubProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
+	return s.results, nil
+}
+func (s *stubProvider) Recent(media.MediaType) ([]media.SearchResult, error) {
+	return s.results, nil
+}

--- a/cmd/agentjson.go
+++ b/cmd/agentjson.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// agentSchema versions the machine-readable contract. A skill written against a
+// different lobster can detect the mismatch instead of silently misparsing.
+const agentSchema = 1
+
+// Exit codes for the agent-facing commands. 2 and 3 are deliberately distinct:
+// "no such title" and "the title exists but every source is down" call for
+// completely different advice, and on this repo the latter is the common one.
+const (
+	exitNoResults         = 2
+	exitProvidersFailed   = 3
+	exitPlayerUnavailable = 4
+)
+
+// agentOut is where JSON payloads go. A package var so tests can capture them
+// without touching the real stdout.
+var agentOut io.Writer = os.Stdout
+
+// exitError carries a process exit code up to Execute. The JSON envelope has
+// already been written by the time this is returned, so Execute must not print
+// it again.
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
+// emitJSON writes one payload to stdout with the schema marker attached.
+func emitJSON(payload map[string]any) error {
+	out := make(map[string]any, len(payload)+1)
+	out["schema"] = agentSchema
+	for k, v := range payload {
+		out[k] = v
+	}
+	enc := json.NewEncoder(agentOut)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// emitErr writes the error envelope and returns an *exitError carrying the
+// process exit code.
+func emitErr(code string, exit int, format string, a ...any) error {
+	msg := fmt.Sprintf(format, a...)
+	_ = emitJSON(map[string]any{
+		"error": map[string]any{"code": code, "message": msg},
+	})
+	return &exitError{code: exit, err: fmt.Errorf("%s: %s", code, msg)}
+}

--- a/cmd/agentjson.go
+++ b/cmd/agentjson.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 // agentSchema versions the machine-readable contract. A skill written against a
@@ -15,6 +17,10 @@ const agentSchema = 1
 // "no such title" and "the title exists but every source is down" call for
 // completely different advice, and on this repo the latter is the common one.
 const (
+	// exitUsage covers everything the caller could have got right by
+	// invoking the command differently: a bad ref, a missing argument, an
+	// unknown flag, an invalid configuration value.
+	exitUsage             = 1
 	exitNoResults         = 2
 	exitProvidersFailed   = 3
 	exitPlayerUnavailable = 4
@@ -57,4 +63,54 @@ func emitErr(code string, exit int, format string, a ...any) error {
 		"error": map[string]any{"code": code, "message": msg},
 	})
 	return &exitError{code: exit, err: fmt.Errorf("%s: %s", code, msg)}
+}
+
+// agentCommands is the set of commands that speak the JSON envelope contract.
+// It is consulted by loadConfig, which is registered on the *root* command and
+// therefore runs for interactive and agent invocations alike; the root's
+// human-facing "Error: ..." on stderr must not change.
+var agentCommands = map[*cobra.Command]bool{}
+
+// markAgentCommand makes cmd's every failure mode machine-readable.
+//
+// RunE failures already emit an envelope, because every return path inside the
+// agent RunE funcs goes through emitErr. But cobra can fail a command before
+// RunE is ever called — ParseFlags rejects an unknown flag, ValidateArgs
+// rejects the wrong argument count, PersistentPreRunE (loadConfig) rejects an
+// invalid --quality. Those three paths returned a bare error which
+// SilenceErrors then swallowed, so `lobster find` exited 1 having written
+// nothing at all to either stream — while SKILL.md tells the agent that errors
+// are JSON on stdout and to parse unconditionally.
+//
+// Both hooks are installed here rather than on each command literal so the
+// three commands cannot drift apart, and so adding a fourth agent command is a
+// single call.
+func markAgentCommand(cmd *cobra.Command) {
+	agentCommands[cmd] = true
+
+	// Cobra would otherwise print the error and the usage block on stderr,
+	// which is noise for a caller parsing stdout; the envelope carries the
+	// same information in a form it can branch on.
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return emitErr("usage", exitUsage, "%v", err)
+	})
+
+	inner := cmd.Args
+	if inner == nil {
+		inner = cobra.ArbitraryArgs
+	}
+	cmd.Args = func(c *cobra.Command, args []string) error {
+		if err := inner(c, args); err != nil {
+			return emitErr("usage", exitUsage, "%v", err)
+		}
+		return nil
+	}
+}
+
+// isAgentCommand reports whether cmd speaks the JSON envelope contract.
+func isAgentCommand(cmd *cobra.Command) bool {
+	return cmd != nil && agentCommands[cmd]
 }

--- a/cmd/agentjson.go
+++ b/cmd/agentjson.go
@@ -38,10 +38,12 @@ func (e *exitError) Unwrap() error { return e.err }
 // emitJSON writes one payload to stdout with the schema marker attached.
 func emitJSON(payload map[string]any) error {
 	out := make(map[string]any, len(payload)+1)
-	out["schema"] = agentSchema
 	for k, v := range payload {
 		out[k] = v
 	}
+	// Set after the copy so a caller-supplied "schema" key can never win;
+	// the envelope's schema marker must always be authoritative.
+	out["schema"] = agentSchema
 	enc := json.NewEncoder(agentOut)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)

--- a/cmd/agentjson_test.go
+++ b/cmd/agentjson_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// captureAgentOut redirects the agent JSON writer to a buffer for the test.
+func captureAgentOut(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := agentOut
+	agentOut = &buf
+	t.Cleanup(func() { agentOut = prev })
+	return &buf
+}
+
+func TestEmitJSONCarriesSchema(t *testing.T) {
+	buf := captureAgentOut(t)
+	if err := emitJSON(map[string]any{"results": []any{}}); err != nil {
+		t.Fatalf("emitJSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got["schema"] != float64(1) {
+		t.Fatalf("schema = %v, want 1", got["schema"])
+	}
+}
+
+// Errors must be machine-readable on stdout too, so an agent can parse
+// unconditionally instead of guessing whether a run produced JSON.
+func TestEmitErrWritesEnvelopeAndCarriesExitCode(t *testing.T) {
+	buf := captureAgentOut(t)
+	err := emitErr("no_results", exitNoResults, "nothing matched %q", "the matirx")
+
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("emitErr returned %T, want *exitError", err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+
+	var got struct {
+		Schema int `json:"schema"`
+		Error  struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("error output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if got.Error.Code != "no_results" {
+		t.Fatalf("code = %q, want no_results", got.Error.Code)
+	}
+	if got.Error.Message != `nothing matched "the matirx"` {
+		t.Fatalf("message = %q", got.Error.Message)
+	}
+}

--- a/cmd/agentjson_test.go
+++ b/cmd/agentjson_test.go
@@ -31,6 +31,27 @@ func TestEmitJSONCarriesSchema(t *testing.T) {
 	}
 }
 
+// A caller-supplied "schema" key must never win over the envelope's own
+// schema marker; the guarantee has to be enforced by emitJSON, not by
+// callers remembering not to use that key.
+func TestEmitJSONSchemaIsAuthoritative(t *testing.T) {
+	buf := captureAgentOut(t)
+	if err := emitJSON(map[string]any{"schema": 99, "results": []any{"ok"}}); err != nil {
+		t.Fatalf("emitJSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got["schema"] != float64(1) {
+		t.Fatalf("schema = %v, want 1 (caller's schema key must not win)", got["schema"])
+	}
+	results, ok := got["results"].([]any)
+	if !ok || len(results) != 1 || results[0] != "ok" {
+		t.Fatalf("results = %v, want [\"ok\"] to survive alongside the enforced schema", got["results"])
+	}
+}
+
 // Errors must be machine-readable on stdout too, so an agent can parse
 // unconditionally instead of guessing whether a run produced JSON.
 func TestEmitErrWritesEnvelopeAndCarriesExitCode(t *testing.T) {

--- a/cmd/detach.go
+++ b/cmd/detach.go
@@ -67,7 +67,13 @@ func forwardedArgs(cmd *cobra.Command) []string {
 	}
 	for _, f := range forwardedBoolFlags {
 		if cmd.Flags().Changed(f.name) {
-			args = append(args, "--"+f.name)
+			// Changed is also true for an explicit "--flag=false": the caller
+			// set it, they just set it to false. A bare "--"+name always means
+			// true to cobra, so an explicit --continue=false would forward as
+			// a bare --continue and the child would resume when the caller
+			// asked it not to — the opposite of what was requested. Emitting
+			// the value explicitly is required, not cosmetic.
+			args = append(args, "--"+f.name+"="+strconv.FormatBool(*f.val))
 		}
 	}
 	return args
@@ -110,20 +116,6 @@ func lobsterCacheDir() (string, error) {
 		return "", fmt.Errorf("creating %s: %w", dir, err)
 	}
 	return dir, nil
-}
-
-// detachLogPath is a deterministic per-pid path under lobsterCacheDir.
-// playDetached itself does not use it — it uses createDetachLog below, which
-// sidesteps a rename-after-Start scheme that turned out to be unreliable on
-// Windows — but it is kept as a small, independently useful, independently
-// testable building block (e.g. for locating a specific run's log by pid
-// from outside the process).
-func detachLogPath(pid int) (string, error) {
-	dir, err := lobsterCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, fmt.Sprintf("play-%d.log", pid)), nil
 }
 
 // createDetachLog opens a fresh, uniquely named log file for a detached

--- a/cmd/detach.go
+++ b/cmd/detach.go
@@ -37,12 +37,19 @@ var forwardedStringFlags = []struct {
 }
 
 // forwardedBoolFlags is forwardedStringFlags' counterpart for boolean flags.
+//
+// --json is deliberately absent, and this is a decision, not an oversight:
+// flagJSON is read inside playStream (cmd/search.go:470), where it prints
+// stream metadata and returns *before playing*. Forwarding it would make the
+// supervised child print JSON into its log and exit without ever starting
+// playback, while the parent had already reported "status":"playing".
 var forwardedBoolFlags = []struct {
 	name string
 	val  *bool
 }{
 	{"no-subs", &flagNoSubs},
 	{"debug", &flagDebug},
+	{"continue", &flagContinue},
 }
 
 // forwardedArgs returns argv fragments for every persistent flag the caller

--- a/cmd/detach.go
+++ b/cmd/detach.go
@@ -17,16 +17,60 @@ var (
 	flagSupervised bool
 )
 
+// forwardedStringFlags are persistent flags whose value config.Load folds
+// into cfg (root.go's loadConfig) and that must therefore be forwarded to a
+// supervised child when the caller passed them explicitly on this
+// invocation. Without this, the child re-derives cfg from the config
+// file/defaults on its own and silently drops the override — the same hole
+// --base had. --download is deliberately absent: playRun rejects it before
+// playDetached is ever reached, so detach never needs to carry it.
+var forwardedStringFlags = []struct {
+	name string
+	val  *string
+}{
+	{"base", &flagBase},
+	{"quality", &flagQuality},
+	{"player", &flagPlayer},
+	{"provider", &flagProvider},
+	{"language", &flagLanguage},
+	{"audio-language", &flagAudioLang},
+}
+
+// forwardedBoolFlags is forwardedStringFlags' counterpart for boolean flags.
+var forwardedBoolFlags = []struct {
+	name string
+	val  *bool
+}{
+	{"no-subs", &flagNoSubs},
+	{"debug", &flagDebug},
+}
+
+// forwardedArgs returns argv fragments for every persistent flag the caller
+// passed explicitly on this invocation (cmd.Flags().Changed), so the
+// supervised child sees the same overrides instead of falling back to
+// config/defaults. This is the same detection playRun already uses for
+// --base (cmd/play.go), generalized over a table instead of one flag at a
+// time.
+func forwardedArgs(cmd *cobra.Command) []string {
+	var args []string
+	for _, f := range forwardedStringFlags {
+		if cmd.Flags().Changed(f.name) {
+			args = append(args, "--"+f.name, *f.val)
+		}
+	}
+	for _, f := range forwardedBoolFlags {
+		if cmd.Flags().Changed(f.name) {
+			args = append(args, "--"+f.name)
+		}
+	}
+	return args
+}
+
 // supervisorArgs builds the argv for the background lobster that actually
 // plays. It carries --supervised so the child does not spawn a child of its
-// own, and drops --detach for the same reason.
-//
-// base is the value of an explicit --base the caller passed on the
-// foreground invocation, or "" if they did not pass one. playRun applies the
-// ref's own Base unless --base was explicit (cmd/play.go), so an explicit
-// --base must be forwarded here too — otherwise the supervised child would
-// fall back to the ref's Base and silently ignore the caller's override.
-func supervisorArgs(exe, ref string, season, episode int, base string) []string {
+// own, and drops --detach for the same reason. extra carries any explicitly
+// passed flags to forward (see forwardedArgs); nil/empty means none.
+func supervisorArgs(exe, ref string, season, episode int, extra []string) []string {
 	args := []string{exe, "play", "--ref", ref, "--supervised"}
 	if season > 0 {
 		args = append(args, "--season", strconv.Itoa(season))
@@ -34,16 +78,22 @@ func supervisorArgs(exe, ref string, season, episode int, base string) []string 
 	if episode > 0 {
 		args = append(args, "--episode", strconv.Itoa(episode))
 	}
-	if base != "" {
-		args = append(args, "--base", base)
-	}
+	args = append(args, extra...)
 	return args
 }
 
-// detachLogPath is where a detached play writes its output. Per-pid so
-// concurrent plays do not interleave, and so the JSON payload can point at a
-// specific run.
-func detachLogPath(pid int) (string, error) {
+// detachChildArgv computes the full argv for the supervised child from the
+// current invocation. It is the decision point: forwardedArgs decides which
+// explicit flags travel with the child, using cmd's actual Changed() state
+// rather than a value threaded in by hand, so a change that hardcodes "no
+// override" or unconditionally forwards a value cannot pass a test written
+// against this function.
+func detachChildArgv(cmd *cobra.Command, exe string) []string {
+	return supervisorArgs(exe, flagRef, flagSeason, flagEpisode, forwardedArgs(cmd))
+}
+
+// lobsterCacheDir is the directory detached play artifacts (logs) live in.
+func lobsterCacheDir() (string, error) {
 	dir, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("locating cache dir: %w", err)
@@ -52,7 +102,43 @@ func detachLogPath(pid int) (string, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("creating %s: %w", dir, err)
 	}
+	return dir, nil
+}
+
+// detachLogPath is a deterministic per-pid path under lobsterCacheDir.
+// playDetached itself does not use it — it uses createDetachLog below, which
+// sidesteps a rename-after-Start scheme that turned out to be unreliable on
+// Windows — but it is kept as a small, independently useful, independently
+// testable building block (e.g. for locating a specific run's log by pid
+// from outside the process).
+func detachLogPath(pid int) (string, error) {
+	dir, err := lobsterCacheDir()
+	if err != nil {
+		return "", err
+	}
 	return filepath.Join(dir, fmt.Sprintf("play-%d.log", pid)), nil
+}
+
+// createDetachLog opens a fresh, uniquely named log file for a detached
+// play. Named once, up front, via os.CreateTemp rather than created under
+// our own pid and renamed to the child's pid once it is known: on Windows,
+// os.Create opens without FILE_SHARE_DELETE, the child inherits that same
+// handle once started, and a later os.Rename then fails with
+// ERROR_SHARING_VIOLATION while both handles are open — which the original
+// code tolerated silently, breaking "find the log from its pid" on exactly
+// the platform that needs it spelled out. The exact path is returned so the
+// caller can put it straight into the JSON payload; the pid is reported
+// there separately, so nothing depends on the log's name matching it.
+func createDetachLog() (*os.File, error) {
+	dir, err := lobsterCacheDir()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.CreateTemp(dir, "play-*.log")
+	if err != nil {
+		return nil, fmt.Errorf("creating log in %s: %w", dir, err)
+	}
+	return f, nil
 }
 
 // detachLiveness is how long the foreground waits before declaring success.
@@ -61,6 +147,26 @@ func detachLogPath(pid int) (string, error) {
 // This does not close the race, it removes the common case of reporting
 // success for a stream that never started.
 var detachLiveness = 1 * time.Second
+
+// waitLiveness reports whether c is still running once liveness elapses.
+// It must reap via c.Wait rather than merely poll the pid: an un-waited
+// child becomes a zombie on Unix, where kill(pid, 0) — the only pid-based
+// liveness check available — still succeeds against a zombie, and holds an
+// open process handle on Windows that reserves the pid regardless of exit
+// status. Either way a pid-only check always reports "alive", which is
+// exactly the bug this replaces. Waiting is what makes failure detectable at
+// all; the blocked goroutine in the "still alive" case costs nothing, since
+// the caller returns immediately after and the whole process exits.
+func waitLiveness(c *exec.Cmd, liveness time.Duration) bool {
+	done := make(chan error, 1)
+	go func() { done <- c.Wait() }()
+	select {
+	case <-done:
+		return false
+	case <-time.After(liveness):
+		return true
+	}
+}
 
 // playDetached re-executes lobster as a background supervisor and returns as
 // soon as it looks alive. The child performs an ordinary attached play, so the
@@ -72,15 +178,7 @@ func playDetached(cmd *cobra.Command, r playRef) error {
 		return emitErr("internal", 1, "locating lobster binary: %v", err)
 	}
 
-	// Propagate an explicit --base the same way playRun honors it: only when
-	// the caller passed it on this invocation, so the child falls back to the
-	// ref's own Base otherwise.
-	base := ""
-	if cmd.Flags().Changed("base") {
-		base = flagBase
-	}
-
-	argv := supervisorArgs(exe, flagRef, flagSeason, flagEpisode, base)
+	argv := detachChildArgv(cmd, exe)
 
 	c := exec.Command(argv[0], argv[1:]...)
 	c.SysProcAttr = detachSpawnAttr()
@@ -89,13 +187,9 @@ func playDetached(cmd *cobra.Command, r playRef) error {
 	// The child's output must never reach the pipe the caller is parsing: all
 	// three players set cmd.Stdout = os.Stdout, which would interleave with the
 	// JSON envelope and corrupt it.
-	tmpLog, err := detachLogPath(os.Getpid())
+	lf, err := createDetachLog()
 	if err != nil {
 		return emitErr("internal", 1, "%v", err)
-	}
-	lf, err := os.Create(tmpLog)
-	if err != nil {
-		return emitErr("internal", 1, "creating log %s: %v", tmpLog, err)
 	}
 	defer lf.Close()
 	c.Stdout = lf
@@ -105,24 +199,16 @@ func playDetached(cmd *cobra.Command, r playRef) error {
 		return emitErr("player_unavailable", exitPlayerUnavailable, "starting background player: %v", err)
 	}
 
-	// Rename the log to the child's pid now that we know it, so the payload
-	// points at a file the user can find from the pid alone.
-	finalLog, err := detachLogPath(c.Process.Pid)
-	if err == nil && os.Rename(tmpLog, finalLog) == nil {
-		tmpLog = finalLog
-	}
-
-	time.Sleep(detachLiveness)
-	if !processAlive(c.Process.Pid) {
+	if !waitLiveness(c, detachLiveness) {
 		return emitErr("providers_failed", exitProvidersFailed,
-			"playback exited immediately; see %s", tmpLog)
+			"playback exited immediately; see %s", lf.Name())
 	}
 
 	return emitJSON(map[string]any{
 		"status":          "playing",
 		"pid":             c.Process.Pid,
 		"title":           r.Title,
-		"log":             tmpLog,
+		"log":             lf.Name(),
 		"resume_tracking": playerTracksPosition(),
 	})
 }

--- a/cmd/detach.go
+++ b/cmd/detach.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagDetach     bool
+	flagSupervised bool
+)
+
+// supervisorArgs builds the argv for the background lobster that actually
+// plays. It carries --supervised so the child does not spawn a child of its
+// own, and drops --detach for the same reason.
+//
+// base is the value of an explicit --base the caller passed on the
+// foreground invocation, or "" if they did not pass one. playRun applies the
+// ref's own Base unless --base was explicit (cmd/play.go), so an explicit
+// --base must be forwarded here too — otherwise the supervised child would
+// fall back to the ref's Base and silently ignore the caller's override.
+func supervisorArgs(exe, ref string, season, episode int, base string) []string {
+	args := []string{exe, "play", "--ref", ref, "--supervised"}
+	if season > 0 {
+		args = append(args, "--season", strconv.Itoa(season))
+	}
+	if episode > 0 {
+		args = append(args, "--episode", strconv.Itoa(episode))
+	}
+	if base != "" {
+		args = append(args, "--base", base)
+	}
+	return args
+}
+
+// detachLogPath is where a detached play writes its output. Per-pid so
+// concurrent plays do not interleave, and so the JSON payload can point at a
+// specific run.
+func detachLogPath(pid int) (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("locating cache dir: %w", err)
+	}
+	dir = filepath.Join(dir, "lobster")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating %s: %w", dir, err)
+	}
+	return filepath.Join(dir, fmt.Sprintf("play-%d.log", pid)), nil
+}
+
+// detachLiveness is how long the foreground waits before declaring success.
+// cmd.Start succeeding only means the binary exec'd; mpv's own failure
+// detection is "exited within 5s with no playback" (internal/player/mpv.go).
+// This does not close the race, it removes the common case of reporting
+// success for a stream that never started.
+var detachLiveness = 1 * time.Second
+
+// playDetached re-executes lobster as a background supervisor and returns as
+// soon as it looks alive. The child performs an ordinary attached play, so the
+// HLS proxy, torrent server, subtitle temp dir and mpv IPC all behave exactly
+// as they do interactively.
+func playDetached(cmd *cobra.Command, r playRef) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return emitErr("internal", 1, "locating lobster binary: %v", err)
+	}
+
+	// Propagate an explicit --base the same way playRun honors it: only when
+	// the caller passed it on this invocation, so the child falls back to the
+	// ref's own Base otherwise.
+	base := ""
+	if cmd.Flags().Changed("base") {
+		base = flagBase
+	}
+
+	argv := supervisorArgs(exe, flagRef, flagSeason, flagEpisode, base)
+
+	c := exec.Command(argv[0], argv[1:]...)
+	c.SysProcAttr = detachSpawnAttr()
+	c.Stdin = nil // no TTY to inherit
+
+	// The child's output must never reach the pipe the caller is parsing: all
+	// three players set cmd.Stdout = os.Stdout, which would interleave with the
+	// JSON envelope and corrupt it.
+	tmpLog, err := detachLogPath(os.Getpid())
+	if err != nil {
+		return emitErr("internal", 1, "%v", err)
+	}
+	lf, err := os.Create(tmpLog)
+	if err != nil {
+		return emitErr("internal", 1, "creating log %s: %v", tmpLog, err)
+	}
+	defer lf.Close()
+	c.Stdout = lf
+	c.Stderr = lf
+
+	if err := c.Start(); err != nil {
+		return emitErr("player_unavailable", exitPlayerUnavailable, "starting background player: %v", err)
+	}
+
+	// Rename the log to the child's pid now that we know it, so the payload
+	// points at a file the user can find from the pid alone.
+	finalLog, err := detachLogPath(c.Process.Pid)
+	if err == nil && os.Rename(tmpLog, finalLog) == nil {
+		tmpLog = finalLog
+	}
+
+	time.Sleep(detachLiveness)
+	if !processAlive(c.Process.Pid) {
+		return emitErr("providers_failed", exitProvidersFailed,
+			"playback exited immediately; see %s", tmpLog)
+	}
+
+	return emitJSON(map[string]any{
+		"status":          "playing",
+		"pid":             c.Process.Pid,
+		"title":           r.Title,
+		"log":             tmpLog,
+		"resume_tracking": playerTracksPosition(),
+	})
+}
+
+// playerTracksPosition reports whether the configured player reports playback
+// position. Only mpv does: vlc.go and generic.go both return an empty
+// PlayResult regardless of detach.
+func playerTracksPosition() bool {
+	if cfg == nil {
+		return false
+	}
+	return strings.EqualFold(cfg.Player, "mpv")
+}

--- a/cmd/detach.go
+++ b/cmd/detach.go
@@ -42,7 +42,7 @@ var forwardedStringFlags = []struct {
 // flagJSON is read inside playStream (cmd/search.go:470), where it prints
 // stream metadata and returns *before playing*. Forwarding it would make the
 // supervised child print JSON into its log and exit without ever starting
-// playback, while the parent had already reported "status":"playing".
+// playback, while the parent had already reported "status":"started".
 var forwardedBoolFlags = []struct {
 	name string
 	val  *bool
@@ -203,13 +203,25 @@ func playDetached(cmd *cobra.Command, r playRef) error {
 			"playback exited immediately; see %s", lf.Name())
 	}
 
-	return emitJSON(map[string]any{
-		"status":          "playing",
-		"pid":             c.Process.Pid,
-		"title":           r.Title,
-		"log":             lf.Name(),
+	return emitJSON(detachPayload(c.Process.Pid, r.Title, lf.Name()))
+}
+
+// detachPayload is the success envelope for a detached play.
+//
+// The status is "started", not "playing", and the difference is not cosmetic.
+// detachLiveness is one second, while provider search and stream extraction
+// routinely take five to thirty; the common failure therefore lands well after
+// the parent has already exited 0. All this envelope can honestly claim is
+// that a player process was started — which is why "log" is part of the
+// contract: it is the only way to find out what happened next.
+func detachPayload(pid int, title, log string) map[string]any {
+	return map[string]any{
+		"status":          "started",
+		"pid":             pid,
+		"title":           title,
+		"log":             log,
 		"resume_tracking": playerTracksPosition(),
-	})
+	}
 }
 
 // playerTracksPosition reports whether the configured player reports playback

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -174,8 +173,29 @@ func TestForwardedArgsIncludesExplicitStringAndBoolFlags(t *testing.T) {
 	if !containsArg(got, "--quality", "1080") {
 		t.Fatalf("forwardedArgs(...) = %v, missing explicit --quality", got)
 	}
-	if !containsArg(got, "--no-subs") {
-		t.Fatalf("forwardedArgs(...) = %v, missing explicit --no-subs", got)
+	if !containsArg(got, "--no-subs=true") {
+		t.Fatalf("forwardedArgs(...) = %v, missing explicit --no-subs=true", got)
+	}
+}
+
+// Changed() is also true for an explicit "--flag=false": the caller did pass
+// it, they just passed false. A bare "--"+name always means true to cobra,
+// so forwarding an explicit --continue=false as a bare --continue would
+// invert it — the child would resume from history when the caller explicitly
+// asked it not to. The value must travel with the flag.
+func TestForwardedArgsPreservesExplicitFalseBool(t *testing.T) {
+	withInheritedFlags(t, "continue")
+
+	if err := playCmd.Flags().Set("continue", "false"); err != nil {
+		t.Fatalf("Set --continue=false: %v", err)
+	}
+
+	got := forwardedArgs(playCmd)
+	if !containsArg(got, "--continue=false") {
+		t.Fatalf("forwardedArgs(...) = %v, missing explicit --continue=false", got)
+	}
+	if containsArg(got, "--continue") {
+		t.Fatalf("forwardedArgs(...) = %v, forwarded a bare --continue for an explicit false (inverts it)", got)
 	}
 }
 
@@ -216,8 +236,8 @@ func TestForwardedArgsIncludesExplicitContinue(t *testing.T) {
 	}
 
 	got := forwardedArgs(playCmd)
-	if !containsArg(got, "--continue") {
-		t.Fatalf("forwardedArgs(...) = %v, missing explicit --continue", got)
+	if !containsArg(got, "--continue=true") {
+		t.Fatalf("forwardedArgs(...) = %v, missing explicit --continue=true", got)
 	}
 }
 
@@ -238,25 +258,6 @@ func TestForwardedArgsNeverForwardsJSON(t *testing.T) {
 	got := forwardedArgs(playCmd)
 	if containsArg(got, "--json") {
 		t.Fatalf("forwardedArgs(...) = %v, forwarded --json; the child would print metadata and never play", got)
-	}
-}
-
-func TestDetachLogPathIsPerPID(t *testing.T) {
-	hermeticCacheDir(t)
-
-	a, err := detachLogPath(111)
-	if err != nil {
-		t.Fatalf("detachLogPath: %v", err)
-	}
-	b, err := detachLogPath(222)
-	if err != nil {
-		t.Fatalf("detachLogPath: %v", err)
-	}
-	if a == b {
-		t.Fatalf("log paths collide: %q", a)
-	}
-	if !strings.Contains(a, "111") {
-		t.Fatalf("log path %q does not identify the pid", a)
 	}
 }
 

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -248,7 +248,7 @@ func TestForwardedArgsIncludesExplicitContinue(t *testing.T) {
 // stream metadata and returns *before playing*. Forwarding it to the
 // supervised child would make the child print JSON into its log and exit
 // without ever starting playback, while the parent had already reported
-// "status":"playing" — so omitting it is a deliberate decision, not a gap.
+// "status":"started" — so omitting it is a deliberate decision, not a gap.
 // This test pins that decision so a later "make forwarding exhaustive"
 // change does not silently turn it back into a bug.
 func TestForwardedArgsNeverForwardsJSON(t *testing.T) {
@@ -358,7 +358,7 @@ func TestSupervisedPlayDoesNotDetachAgain(t *testing.T) {
 // The player-availability precondition must run before the --detach
 // dispatch, not after: otherwise a detached invocation would fork a
 // supervisor that fails silently into its own log file, leaving the caller
-// with a misleading "status":"playing"-or-hang instead of an immediate
+// with a misleading "status":"started"-or-hang instead of an immediate
 // exit-4 report. This test drives playRun with flagDetach=true and an
 // unavailable player and asserts it never reaches playDetached: if it did,
 // os.Executable()/exec.Command would run for real (no seam exists for
@@ -388,5 +388,29 @@ func TestPlayDetachedUnavailablePlayerExitsFourBeforeSpawning(t *testing.T) {
 	}
 	if ee.code != exitPlayerUnavailable {
 		t.Fatalf("exit code = %d, want %d", ee.code, exitPlayerUnavailable)
+	}
+}
+
+// The parent waits detachLiveness (one second) before declaring success, but
+// provider search and stream extraction routinely take five to thirty
+// seconds, so the common failure lands after the parent has already exited 0.
+// Claiming "playing" at that point is a claim the parent cannot support; all
+// it knows is that a player process started. The agent is told to read "log"
+// when the user reports nothing happened, so that key is part of the contract
+// too.
+func TestDetachPayloadReportsStartedNotPlaying(t *testing.T) {
+	got := detachPayload(4242, "Some Show", "/tmp/play-x.log")
+
+	if got["status"] != "started" {
+		t.Fatalf("status = %v, want \"started\" (a one-second liveness window cannot prove playback)", got["status"])
+	}
+	if got["log"] != "/tmp/play-x.log" {
+		t.Fatalf("log = %v, want the log path; it is the agent's only way to see what happened after the parent exited", got["log"])
+	}
+	if got["pid"] != 4242 {
+		t.Fatalf("pid = %v, want 4242", got["pid"])
+	}
+	if got["title"] != "Some Show" {
+		t.Fatalf("title = %v, want Some Show", got["title"])
 	}
 }

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -1,32 +1,92 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
 
+// containsArg reports whether args contains want as a contiguous, exact
+// subsequence. Deliberately not implemented via strings.Join + Contains:
+// joining collapses argv into one string, so "play" would also match
+// "--replay" or a path component, and "--ref REF123" would match even if
+// they landed as one mangled argv entry instead of two adjacent ones.
+func containsArg(args []string, want ...string) bool {
+	for i := 0; i+len(want) <= len(args); i++ {
+		match := true
+		for j, w := range want {
+			if args[i+j] != w {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// hermeticCacheDir points os.UserCacheDir at a throwaway directory so tests
+// never touch (or depend on) the real user cache dir.
+func hermeticCacheDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("LocalAppData", dir)
+	case "darwin":
+		t.Setenv("HOME", dir)
+	default:
+		t.Setenv("XDG_CACHE_HOME", dir)
+	}
+}
+
+// withInheritedFlags forces the same persistent-flag merge cobra performs
+// before RunE during a real Execute() (see (*cobra.Command).mergePersistentFlags),
+// the same technique play_test.go's withBaseFlag uses, generalized to any
+// flag name a test needs to Set/Changed on playCmd directly rather than
+// through Execute(). Restores each flag's Changed bit and value afterward.
+func withInheritedFlags(t *testing.T, names ...string) {
+	t.Helper()
+	playCmd.InheritedFlags() // side effect: merges rootCmd's persistent flags into playCmd.Flags()
+	for _, name := range names {
+		f := playCmd.Flags().Lookup(name)
+		if f == nil {
+			t.Fatalf("playCmd.Flags().Lookup(%q) is nil after merge", name)
+		}
+		prevChanged, prevVal := f.Changed, f.Value.String()
+		t.Cleanup(func() {
+			f.Changed = prevChanged
+			_ = f.Value.Set(prevVal)
+		})
+	}
+}
+
 // The supervisor must be told to actually play, and must be marked supervised
 // so it does not recurse into spawning another supervisor.
 func TestSupervisorArgsArePlayableAndNonRecursive(t *testing.T) {
-	args := supervisorArgs("/usr/bin/lobster", "REF123", 2, 3, "")
+	args := supervisorArgs("/usr/bin/lobster", "REF123", 2, 3, nil)
 
-	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "play") {
+	if args[0] != "/usr/bin/lobster" || args[1] != "play" {
 		t.Fatalf("args %v do not invoke play", args)
 	}
-	if !strings.Contains(joined, "--ref REF123") {
+	if !containsArg(args, "--ref", "REF123") {
 		t.Fatalf("args %v do not carry the ref", args)
 	}
-	if !strings.Contains(joined, "--season 2") || !strings.Contains(joined, "--episode 3") {
+	if !containsArg(args, "--season", "2") || !containsArg(args, "--episode", "3") {
 		t.Fatalf("args %v lost season/episode", args)
 	}
-	if !strings.Contains(joined, "--supervised") {
+	if !containsArg(args, "--supervised") {
 		t.Fatalf("args %v missing --supervised; the child would spawn its own child forever", args)
 	}
-	if strings.Contains(joined, "--detach") {
+	if containsArg(args, "--detach") {
 		t.Fatalf("args %v still carry --detach; that is the recursion", args)
 	}
 }
@@ -34,36 +94,118 @@ func TestSupervisorArgsArePlayableAndNonRecursive(t *testing.T) {
 // Season and episode are meaningless for a film and must not be passed as
 // zeroes, which the play command would reject.
 func TestSupervisorArgsOmitZeroSeasonEpisode(t *testing.T) {
-	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, "")
-	joined := strings.Join(args, " ")
-	if strings.Contains(joined, "--season") || strings.Contains(joined, "--episode") {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, nil)
+	if containsArg(args, "--season") || containsArg(args, "--episode") {
 		t.Fatalf("args %v pass zero season/episode", args)
 	}
 }
 
-// When the caller passed --base explicitly on the foreground invocation, that
-// override must be propagated to the supervised child. Without this, the
-// child would fall back to the ref's own Base and silently ignore the
-// explicit override (cmd/play.go's Changed("base") logic).
-func TestSupervisorArgsPropagatesExplicitBase(t *testing.T) {
-	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, "yts")
-	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "--base yts") {
-		t.Fatalf("args %v do not propagate explicit --base", args)
+// extra is appended verbatim, exercising the mechanism forwardedArgs relies
+// on independent of any particular flag.
+func TestSupervisorArgsAppendsExtra(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 2, 3, []string{"--base", "yts"})
+	if !containsArg(args, "--base", "yts") {
+		t.Fatalf("args %v do not carry extra", args)
+	}
+	// Distinct from the zero-season/episode case: season/episode are present
+	// here alongside extra, so this is not testing the same thing twice.
+	if !containsArg(args, "--season", "2") || !containsArg(args, "--episode", "3") {
+		t.Fatalf("args %v lost season/episode alongside extra", args)
 	}
 }
 
-// When the caller did not pass --base, none should be forwarded, so the
-// child falls back to the ref's own Base as playRun already does.
-func TestSupervisorArgsOmitBaseWhenNotExplicit(t *testing.T) {
-	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, "")
-	joined := strings.Join(args, " ")
-	if strings.Contains(joined, "--base") {
-		t.Fatalf("args %v pass --base though it was not explicitly set", args)
+func TestSupervisorArgsOmitsExtraWhenNil(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, nil)
+	if containsArg(args, "--base") {
+		t.Fatalf("args %v carry --base though extra was nil", args)
+	}
+}
+
+// detachChildArgv is the actual decision point: it must read the flag's real
+// Changed() state via cmd, not just plumb a value through. An implementation
+// that hardcoded "no override" or unconditionally forwarded flagBase would
+// pass a test that only exercises supervisorArgs directly — these two tests
+// exercise detachChildArgv itself, in both directions, driving Changed()
+// through playCmd the same way a real Execute() would.
+func TestDetachChildArgvPropagatesExplicitBase(t *testing.T) {
+	withInheritedFlags(t, "base")
+	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
+	flagRef, flagSeason, flagEpisode = "REF", 0, 0
+	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
+
+	if err := playCmd.Flags().Set("base", "yts"); err != nil {
+		t.Fatalf("Set --base: %v", err)
+	}
+
+	got := detachChildArgv(playCmd, "/usr/bin/lobster")
+	if !containsArg(got, "--base", "yts") {
+		t.Fatalf("detachChildArgv(...) = %v, want explicit --base forwarded", got)
+	}
+}
+
+func TestDetachChildArgvOmitsBaseWhenNotExplicit(t *testing.T) {
+	withInheritedFlags(t, "base")
+	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
+	flagRef, flagSeason, flagEpisode = "REF", 0, 0
+	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
+	// Deliberately do not Set("base", ...): Changed must be false here.
+
+	got := detachChildArgv(playCmd, "/usr/bin/lobster")
+	if containsArg(got, "--base") {
+		t.Fatalf("detachChildArgv(...) = %v, forwarded --base though it was not explicit", got)
+	}
+}
+
+// forwardedArgs is the table-driven mechanism behind detachChildArgv. Cover
+// it at its own level: a string flag, a bool flag, and the "nothing passed"
+// case, so a change that forwards unconditionally or drops the table entirely
+// cannot pass by accident.
+func TestForwardedArgsIncludesExplicitStringAndBoolFlags(t *testing.T) {
+	withInheritedFlags(t, "quality", "no-subs")
+
+	if err := playCmd.Flags().Set("quality", "1080"); err != nil {
+		t.Fatalf("Set --quality: %v", err)
+	}
+	if err := playCmd.Flags().Set("no-subs", "true"); err != nil {
+		t.Fatalf("Set --no-subs: %v", err)
+	}
+
+	got := forwardedArgs(playCmd)
+	if !containsArg(got, "--quality", "1080") {
+		t.Fatalf("forwardedArgs(...) = %v, missing explicit --quality", got)
+	}
+	if !containsArg(got, "--no-subs") {
+		t.Fatalf("forwardedArgs(...) = %v, missing explicit --no-subs", got)
+	}
+}
+
+func TestForwardedArgsOmitsFlagsNotPassed(t *testing.T) {
+	withInheritedFlags(t, "player", "provider", "language", "audio-language", "debug", "base")
+
+	got := forwardedArgs(playCmd)
+	if len(got) != 0 {
+		t.Fatalf("forwardedArgs(...) = %v, want none: nothing was passed explicitly", got)
+	}
+}
+
+// --download is rejected earlier in playRun and must never reach detach's
+// forwarding table, explicit or not.
+func TestForwardedArgsNeverForwardsDownload(t *testing.T) {
+	for _, f := range forwardedStringFlags {
+		if f.name == "download" {
+			t.Fatalf("forwardedStringFlags carries --download; it must never be forwarded")
+		}
+	}
+	for _, f := range forwardedBoolFlags {
+		if f.name == "download" {
+			t.Fatalf("forwardedBoolFlags carries --download; it must never be forwarded")
+		}
 	}
 }
 
 func TestDetachLogPathIsPerPID(t *testing.T) {
+	hermeticCacheDir(t)
+
 	a, err := detachLogPath(111)
 	if err != nil {
 		t.Fatalf("detachLogPath: %v", err)
@@ -77,6 +219,63 @@ func TestDetachLogPathIsPerPID(t *testing.T) {
 	}
 	if !strings.Contains(a, "111") {
 		t.Fatalf("log path %q does not identify the pid", a)
+	}
+}
+
+// createDetachLog must hand back distinct files on repeated calls (no reuse
+// or truncation of a previous run's log) without needing to know any pid up
+// front.
+func TestCreateDetachLogIsUnique(t *testing.T) {
+	hermeticCacheDir(t)
+
+	f1, err := createDetachLog()
+	if err != nil {
+		t.Fatalf("createDetachLog: %v", err)
+	}
+	defer f1.Close()
+	f2, err := createDetachLog()
+	if err != nil {
+		t.Fatalf("createDetachLog: %v", err)
+	}
+	defer f2.Close()
+
+	if f1.Name() == f2.Name() {
+		t.Fatalf("createDetachLog returned the same path twice: %q", f1.Name())
+	}
+}
+
+// waitLiveness must reap the child via Wait, not merely poll its pid: an
+// unwaited child becomes a zombie on Unix (kill(pid,0) still succeeds) and
+// holds an open handle on Windows (reserving the pid) — either way a
+// pid-only check always reports "alive". These tests drive a real child
+// process (this same test binary, re-exec'd as a disposable helper via
+// LOBSTER_TEST_HELPER_EXIT_CODE — see TestMain in fallback_providers_test.go)
+// so the reap is exercised for real, not asserted by reading the source.
+func TestWaitLivenessDetectsImmediateExit(t *testing.T) {
+	c := exec.Command(os.Args[0])
+	c.Env = append(os.Environ(), "LOBSTER_TEST_HELPER_EXIT_CODE=1")
+	if err := c.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if alive := waitLiveness(c, 200*time.Millisecond); alive {
+		t.Fatal("waitLiveness reported alive for a process that already exited")
+	}
+}
+
+func TestWaitLivenessReportsAliveWhileChildStillRunning(t *testing.T) {
+	c := exec.Command(os.Args[0])
+	c.Env = append(os.Environ(),
+		"LOBSTER_TEST_HELPER_EXIT_CODE=0",
+		"LOBSTER_TEST_HELPER_SLEEP_MS=5000",
+	)
+	if err := c.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Process.Kill() })
+
+	if alive := waitLiveness(c, 100*time.Millisecond); !alive {
+		t.Fatal("waitLiveness reported dead for a process still running")
 	}
 }
 

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
@@ -53,13 +55,13 @@ func hermeticCacheDir(t *testing.T) {
 // the same technique play_test.go's withBaseFlag uses, generalized to any
 // flag name a test needs to Set/Changed on playCmd directly rather than
 // through Execute(). Restores each flag's Changed bit and value afterward.
-func withInheritedFlags(t *testing.T, names ...string) {
+func withInheritedFlags(t *testing.T, c *cobra.Command, names ...string) {
 	t.Helper()
-	playCmd.InheritedFlags() // side effect: merges rootCmd's persistent flags into playCmd.Flags()
+	c.InheritedFlags() // side effect: merges rootCmd's persistent flags into c.Flags()
 	for _, name := range names {
-		f := playCmd.Flags().Lookup(name)
+		f := c.Flags().Lookup(name)
 		if f == nil {
-			t.Fatalf("playCmd.Flags().Lookup(%q) is nil after merge", name)
+			t.Fatalf("%s.Flags().Lookup(%q) is nil after merge", c.Name(), name)
 		}
 		prevChanged, prevVal := f.Changed, f.Value.String()
 		t.Cleanup(func() {
@@ -128,7 +130,7 @@ func TestSupervisorArgsOmitsExtraWhenNil(t *testing.T) {
 // exercise detachChildArgv itself, in both directions, driving Changed()
 // through playCmd the same way a real Execute() would.
 func TestDetachChildArgvPropagatesExplicitBase(t *testing.T) {
-	withInheritedFlags(t, "base")
+	withInheritedFlags(t, playCmd, "base")
 	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
 	flagRef, flagSeason, flagEpisode = "REF", 0, 0
 	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
@@ -144,7 +146,7 @@ func TestDetachChildArgvPropagatesExplicitBase(t *testing.T) {
 }
 
 func TestDetachChildArgvOmitsBaseWhenNotExplicit(t *testing.T) {
-	withInheritedFlags(t, "base")
+	withInheritedFlags(t, playCmd, "base")
 	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
 	flagRef, flagSeason, flagEpisode = "REF", 0, 0
 	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
@@ -161,7 +163,7 @@ func TestDetachChildArgvOmitsBaseWhenNotExplicit(t *testing.T) {
 // case, so a change that forwards unconditionally or drops the table entirely
 // cannot pass by accident.
 func TestForwardedArgsIncludesExplicitStringAndBoolFlags(t *testing.T) {
-	withInheritedFlags(t, "quality", "no-subs")
+	withInheritedFlags(t, playCmd, "quality", "no-subs")
 
 	if err := playCmd.Flags().Set("quality", "1080"); err != nil {
 		t.Fatalf("Set --quality: %v", err)
@@ -185,7 +187,7 @@ func TestForwardedArgsIncludesExplicitStringAndBoolFlags(t *testing.T) {
 // invert it — the child would resume from history when the caller explicitly
 // asked it not to. The value must travel with the flag.
 func TestForwardedArgsPreservesExplicitFalseBool(t *testing.T) {
-	withInheritedFlags(t, "continue")
+	withInheritedFlags(t, playCmd, "continue")
 
 	if err := playCmd.Flags().Set("continue", "false"); err != nil {
 		t.Fatalf("Set --continue=false: %v", err)
@@ -201,7 +203,7 @@ func TestForwardedArgsPreservesExplicitFalseBool(t *testing.T) {
 }
 
 func TestForwardedArgsOmitsFlagsNotPassed(t *testing.T) {
-	withInheritedFlags(t, "player", "provider", "language", "audio-language", "debug", "base")
+	withInheritedFlags(t, playCmd, "player", "provider", "language", "audio-language", "debug", "base")
 
 	got := forwardedArgs(playCmd)
 	if len(got) != 0 {
@@ -230,7 +232,7 @@ func TestForwardedArgsNeverForwardsDownload(t *testing.T) {
 // caller explicitly asking to resume — the same bug class as the other
 // seven flags.
 func TestForwardedArgsIncludesExplicitContinue(t *testing.T) {
-	withInheritedFlags(t, "continue")
+	withInheritedFlags(t, playCmd, "continue")
 
 	if err := playCmd.Flags().Set("continue", "true"); err != nil {
 		t.Fatalf("Set --continue: %v", err)
@@ -250,7 +252,7 @@ func TestForwardedArgsIncludesExplicitContinue(t *testing.T) {
 // This test pins that decision so a later "make forwarding exhaustive"
 // change does not silently turn it back into a bug.
 func TestForwardedArgsNeverForwardsJSON(t *testing.T) {
-	withInheritedFlags(t, "json")
+	withInheritedFlags(t, playCmd, "json")
 
 	if err := playCmd.Flags().Set("json", "true"); err != nil {
 		t.Fatalf("Set --json: %v", err)

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -300,7 +300,12 @@ func TestWaitLivenessDetectsImmediateExit(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	if alive := waitLiveness(c, 200*time.Millisecond); alive {
+	// The window must outlast child *startup*, not just its exit: on a cold
+	// Windows CI runner, spawning the test binary alone can exceed 200ms, so a
+	// tight window sees a child that hasn't exited yet and correctly — but
+	// uselessly — reports it alive. Wait returns the moment the child exits,
+	// so a generous window costs nothing when the test passes.
+	if alive := waitLiveness(c, 10*time.Second); alive {
 		t.Fatal("waitLiveness reported alive for a process that already exited")
 	}
 }

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"runtime"
@@ -349,5 +350,41 @@ func TestSupervisedPlayDoesNotDetachAgain(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("supervised play did not reach playback; it re-detached instead")
+	}
+}
+
+// The player-availability precondition must run before the --detach
+// dispatch, not after: otherwise a detached invocation would fork a
+// supervisor that fails silently into its own log file, leaving the caller
+// with a misleading "status":"playing"-or-hang instead of an immediate
+// exit-4 report. This test drives playRun with flagDetach=true and an
+// unavailable player and asserts it never reaches playDetached: if it did,
+// os.Executable()/exec.Command would run for real (no seam exists for
+// playDetached itself), which would either fail loudly in a way distinct
+// from exitPlayerUnavailable or spawn a real child process — neither of
+// which this test permits.
+func TestPlayDetachedUnavailablePlayerExitsFourBeforeSpawning(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return false, "vlc" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevD, prevS := flagRef, flagDetach, flagSupervised
+	flagRef, flagDetach, flagSupervised = ref, true, false
+	t.Cleanup(func() { flagRef, flagDetach, flagSupervised = prevRef, prevD, prevS })
+
+	err = playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitPlayerUnavailable {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitPlayerUnavailable)
 	}
 }

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -203,6 +203,44 @@ func TestForwardedArgsNeverForwardsDownload(t *testing.T) {
 	}
 }
 
+// flagContinue is read inside playStream (cmd/search.go:560) to load history
+// and set the resume position. Without forwarding it, `lobster play --ref R
+// --continue --detach` would silently start from the beginning despite the
+// caller explicitly asking to resume — the same bug class as the other
+// seven flags.
+func TestForwardedArgsIncludesExplicitContinue(t *testing.T) {
+	withInheritedFlags(t, "continue")
+
+	if err := playCmd.Flags().Set("continue", "true"); err != nil {
+		t.Fatalf("Set --continue: %v", err)
+	}
+
+	got := forwardedArgs(playCmd)
+	if !containsArg(got, "--continue") {
+		t.Fatalf("forwardedArgs(...) = %v, missing explicit --continue", got)
+	}
+}
+
+// flagJSON is read inside playStream (cmd/search.go:470), where it prints
+// stream metadata and returns *before playing*. Forwarding it to the
+// supervised child would make the child print JSON into its log and exit
+// without ever starting playback, while the parent had already reported
+// "status":"playing" — so omitting it is a deliberate decision, not a gap.
+// This test pins that decision so a later "make forwarding exhaustive"
+// change does not silently turn it back into a bug.
+func TestForwardedArgsNeverForwardsJSON(t *testing.T) {
+	withInheritedFlags(t, "json")
+
+	if err := playCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("Set --json: %v", err)
+	}
+
+	got := forwardedArgs(playCmd)
+	if containsArg(got, "--json") {
+		t.Fatalf("forwardedArgs(...) = %v, forwarded --json; the child would print metadata and never play", got)
+	}
+}
+
 func TestDetachLogPathIsPerPID(t *testing.T) {
 	hermeticCacheDir(t)
 

--- a/cmd/detach_test.go
+++ b/cmd/detach_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// The supervisor must be told to actually play, and must be marked supervised
+// so it does not recurse into spawning another supervisor.
+func TestSupervisorArgsArePlayableAndNonRecursive(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF123", 2, 3, "")
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "play") {
+		t.Fatalf("args %v do not invoke play", args)
+	}
+	if !strings.Contains(joined, "--ref REF123") {
+		t.Fatalf("args %v do not carry the ref", args)
+	}
+	if !strings.Contains(joined, "--season 2") || !strings.Contains(joined, "--episode 3") {
+		t.Fatalf("args %v lost season/episode", args)
+	}
+	if !strings.Contains(joined, "--supervised") {
+		t.Fatalf("args %v missing --supervised; the child would spawn its own child forever", args)
+	}
+	if strings.Contains(joined, "--detach") {
+		t.Fatalf("args %v still carry --detach; that is the recursion", args)
+	}
+}
+
+// Season and episode are meaningless for a film and must not be passed as
+// zeroes, which the play command would reject.
+func TestSupervisorArgsOmitZeroSeasonEpisode(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, "")
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--season") || strings.Contains(joined, "--episode") {
+		t.Fatalf("args %v pass zero season/episode", args)
+	}
+}
+
+// When the caller passed --base explicitly on the foreground invocation, that
+// override must be propagated to the supervised child. Without this, the
+// child would fall back to the ref's own Base and silently ignore the
+// explicit override (cmd/play.go's Changed("base") logic).
+func TestSupervisorArgsPropagatesExplicitBase(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, "yts")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--base yts") {
+		t.Fatalf("args %v do not propagate explicit --base", args)
+	}
+}
+
+// When the caller did not pass --base, none should be forwarded, so the
+// child falls back to the ref's own Base as playRun already does.
+func TestSupervisorArgsOmitBaseWhenNotExplicit(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0, "")
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--base") {
+		t.Fatalf("args %v pass --base though it was not explicitly set", args)
+	}
+}
+
+func TestDetachLogPathIsPerPID(t *testing.T) {
+	a, err := detachLogPath(111)
+	if err != nil {
+		t.Fatalf("detachLogPath: %v", err)
+	}
+	b, err := detachLogPath(222)
+	if err != nil {
+		t.Fatalf("detachLogPath: %v", err)
+	}
+	if a == b {
+		t.Fatalf("log paths collide: %q", a)
+	}
+	if !strings.Contains(a, "111") {
+		t.Fatalf("log path %q does not identify the pid", a)
+	}
+}
+
+// A supervised process must play, not spawn another supervisor. Without this
+// guard --detach forks forever.
+func TestSupervisedPlayDoesNotDetachAgain(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	called := false
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevD, prevS := flagRef, flagDetach, flagSupervised
+	flagRef, flagDetach, flagSupervised = ref, true, true
+	t.Cleanup(func() { flagRef, flagDetach, flagSupervised = prevRef, prevD, prevS })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if !called {
+		t.Fatal("supervised play did not reach playback; it re-detached instead")
+	}
+}

--- a/cmd/detach_unix.go
+++ b/cmd/detach_unix.go
@@ -2,23 +2,10 @@
 
 package cmd
 
-import (
-	"os"
-	"syscall"
-)
+import "syscall"
 
 // detachSpawnAttr puts the supervisor in its own process group so it survives
 // the agent's shell exiting.
 func detachSpawnAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setpgid: true}
-}
-
-// processAlive reports whether the pid is still running. Signal 0 performs the
-// permission and existence checks without delivering anything.
-func processAlive(pid int) bool {
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return p.Signal(syscall.Signal(0)) == nil
 }

--- a/cmd/detach_unix.go
+++ b/cmd/detach_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+// detachSpawnAttr puts the supervisor in its own process group so it survives
+// the agent's shell exiting.
+func detachSpawnAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// processAlive reports whether the pid is still running. Signal 0 performs the
+// permission and existence checks without delivering anything.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}

--- a/cmd/detach_windows.go
+++ b/cmd/detach_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+// detachedProcess is Win32's DETACHED_PROCESS creation flag. Go's syscall
+// package exports CREATE_NEW_PROCESS_GROUP but not this one, so it is spelled
+// out here rather than left as a bare literal at the call site.
+const detachedProcess = 0x00000008
+
+// detachSpawnAttr detaches the supervisor from the console so it survives the
+// agent's shell exiting. Setpgid does not exist on Windows.
+func detachSpawnAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess,
+	}
+}
+
+// processAlive reports whether the pid is still running. On Windows
+// os.FindProcess fails outright for a dead pid, which is the check.
+func processAlive(pid int) bool {
+	_, err := os.FindProcess(pid)
+	return err == nil
+}

--- a/cmd/detach_windows.go
+++ b/cmd/detach_windows.go
@@ -2,10 +2,7 @@
 
 package cmd
 
-import (
-	"os"
-	"syscall"
-)
+import "syscall"
 
 // detachedProcess is Win32's DETACHED_PROCESS creation flag. Go's syscall
 // package exports CREATE_NEW_PROCESS_GROUP but not this one, so it is spelled
@@ -18,11 +15,4 @@ func detachSpawnAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess,
 	}
-}
-
-// processAlive reports whether the pid is still running. On Windows
-// os.FindProcess fails outright for a dead pid, which is the check.
-func processAlive(pid int) bool {
-	_, err := os.FindProcess(pid)
-	return err == nil
 }

--- a/cmd/episodes.go
+++ b/cmd/episodes.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"context"
+	"sync"
+
 	"github.com/spf13/cobra"
 
 	"lobster/internal/media"
@@ -91,6 +94,12 @@ func episodesRun(cmd *cobra.Command, args []string) error {
 // supply stubs instead of providers that reach the network.
 var agentFallbackProviders = fallbackProviders
 
+// episodesFallbackTimeout bounds the whole fallback season scan. It matches
+// multiSearchTimeout, which bounds find's fan-out over the same chain — the two
+// commands wait on the same providers and should give up at the same point.
+// A var, not a const, so tests can shrink it and still be deterministic.
+var episodesFallbackTimeout = multiSearchTimeout
+
 // seasonSource returns the provider that can actually enumerate this ref's
 // seasons, the ID to ask it about, that season list, and the primary's error
 // if it had one.
@@ -100,7 +109,8 @@ var agentFallbackProviders = fallbackProviders
 // find searches the primary *and* the fallback chain (gatherSearchResults
 // broadens whenever the primary returns fewer than three results) while
 // stamping the configured base on every ref it prints — playRef.Base is a
-// starting point, not an attribution (cmd/ref.go). A ref whose ID came from a
+// config-time choice of primary, a starting point rather than an attribution,
+// and cmd/ref.go explains why no honest per-row one exists. A ref whose ID came from a
 // fallback provider therefore reaches the primary as a foreign ID, and the
 // primary answers "no seasons" or errors.
 //
@@ -110,10 +120,22 @@ var agentFallbackProviders = fallbackProviders
 // `episodes --ref` reported "no seasons found" for a show `play --ref` then
 // played without complaint. The two commands must agree on what one ref means.
 //
-// The re-search is by title and ranked by resolver.Candidates, so the ref's
-// ID/Title/Year all count — the same ranking the resolver uses, and the reason
-// a ref carries more than an ID. A fallback is only accepted when it returns a
-// non-empty season list; an empty one means it does not really have this show.
+// The re-search is by title, ranked by resolver.Candidates so the ref's
+// ID/Title/Year all count — the reason a ref carries more than an ID — and then
+// admitted only if resolver.Matches says the candidate is the same work.
+// Ranking alone is not a gate: candidatesFor applies no score threshold, so
+// without Matches the first fallback that returns any seasons for any show
+// wins, and the envelope echoes the ref's own title over it. The caller could
+// not detect the swap. A candidate that matches but returns an empty season
+// list is skipped too — it does not really have this show.
+//
+// The chain is scanned in parallel under a deadline, the same shape find uses
+// (multiProviderSearch), because a serial scan is the wrong shape for a command
+// whose premise is that an agent is never left waiting: eleven providers, each
+// a Search plus up to MaxCandidates GetSeasons calls against a 30s HTTP client
+// timeout, is minutes of silence on a degraded chain. Provider order still
+// decides the winner, so the answer does not depend on which provider was
+// quickest.
 func seasonSource(primary provider.Provider, r playRef) (provider.Provider, string, []media.Season, error) {
 	seasons, err := primary.GetSeasons(r.ID)
 	if err == nil && len(seasons) > 0 {
@@ -127,20 +149,84 @@ func seasonSource(primary provider.Provider, r playRef) (provider.Provider, stri
 		Year:      r.Year,
 		MediaType: media.TV,
 	}
-	for _, fb := range agentFallbackProviders(primary) {
-		results, searchErr := fb.Search(r.Title)
-		if searchErr != nil {
-			debugf("episodes: fallback %T search failed: %v", fb, searchErr)
-			continue
-		}
-		for _, c := range resolver.Candidates(results, req) {
-			fbSeasons, seasonsErr := fb.GetSeasons(c.ID)
-			if seasonsErr != nil || len(fbSeasons) == 0 {
-				continue
-			}
-			debugf("episodes: %T answers for %q (ID %s)", fb, c.Title, c.ID)
-			return fb, c.ID, fbSeasons, nil
+
+	ctx, cancel := context.WithTimeout(context.Background(), episodesFallbackTimeout)
+	defer cancel()
+
+	fallbacks := agentFallbackProviders(primary)
+	// Indexed by provider so the result is provider order, not arrival order.
+	hits := make([]*seasonHit, len(fallbacks))
+	var wg sync.WaitGroup
+	for i, fb := range fallbacks {
+		wg.Add(1)
+		go func(idx int, p provider.Provider) {
+			defer wg.Done()
+			hits[idx] = probeSeasons(ctx, p, req)
+		}(i, fb)
+	}
+	// Every worker returns at the deadline even when a provider call is still
+	// blocked: the calls are wrapped in the same select-on-ctx pattern
+	// searchWithContext uses, so this Wait is bounded by the context.
+	wg.Wait()
+
+	for _, h := range hits {
+		if h != nil {
+			debugf("episodes: %T answers for %q (ID %s)", h.provider, h.title, h.id)
+			return h.provider, h.id, h.seasons, nil
 		}
 	}
 	return primary, r.ID, nil, err
+}
+
+// seasonHit is one fallback provider's answer for a ref.
+type seasonHit struct {
+	provider provider.Provider
+	id       string
+	title    string
+	seasons  []media.Season
+}
+
+// probeSeasons asks one fallback provider whether it has req's work and can
+// enumerate its seasons. It returns nil for "no", including when the context
+// expires mid-call.
+func probeSeasons(ctx context.Context, p provider.Provider, req resolver.Request) *seasonHit {
+	results, err := searchWithContext(ctx, p, req.Title)
+	if err != nil {
+		debugf("episodes: fallback %T search failed: %v", p, err)
+		return nil
+	}
+	for _, c := range resolver.Candidates(results, req) {
+		if !resolver.Matches(c, req) {
+			debugf("episodes: fallback %T offered %q, which is not %q", p, c.Title, req.Title)
+			continue
+		}
+		seasons, err := seasonsWithContext(ctx, p, c.ID)
+		if err != nil || len(seasons) == 0 {
+			continue
+		}
+		return &seasonHit{provider: p, id: c.ID, title: c.Title, seasons: seasons}
+	}
+	return nil
+}
+
+// seasonsWithContext runs GetSeasons, abandoning the result if the context
+// expires. provider.Provider takes no context, so — exactly as in
+// searchWithContext — the inner goroutine runs to completion and its result is
+// discarded; it ends when the underlying HTTP call does.
+func seasonsWithContext(ctx context.Context, p provider.Provider, id string) ([]media.Season, error) {
+	type result struct {
+		seasons []media.Season
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		s, err := p.GetSeasons(id)
+		ch <- result{s, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case r := <-ch:
+		return r.seasons, r.err
+	}
 }

--- a/cmd/episodes.go
+++ b/cmd/episodes.go
@@ -19,13 +19,12 @@ var episodesCmd = &cobra.Command{
 
 Takes a ref emitted by "lobster find". With --season it lists that season's
 episodes; without it, the first season's.`,
-	Args:          cobra.NoArgs,
-	RunE:          episodesRun,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Args: cobra.NoArgs,
+	RunE: episodesRun,
 }
 
 func init() {
+	markAgentCommand(episodesCmd)
 	episodesCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
 	episodesCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (default: first)")
 }

--- a/cmd/episodes.go
+++ b/cmd/episodes.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"lobster/internal/media"
+)
+
+var (
+	flagRef     string
+	flagSeason  int
+	flagEpisode int
+)
+
+var episodesCmd = &cobra.Command{
+	Use:   "episodes --ref <REF>",
+	Short: "List seasons and episodes for a TV ref as JSON (no prompts)",
+	Long: `List the episodes of a show without prompting.
+
+Takes a ref emitted by "lobster find". With --season it lists that season's
+episodes; without it, the first season's.`,
+	Args:          cobra.NoArgs,
+	RunE:          episodesRun,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	episodesCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
+	episodesCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (default: first)")
+}
+
+func episodesRun(cmd *cobra.Command, args []string) error {
+	r, err := decodeRef(flagRef)
+	if err != nil {
+		return emitErr("bad_ref", 1, "%v", err)
+	}
+	if r.Type != media.TV.String() {
+		return emitErr("not_a_series", 1, "%q is a %s, which has no episodes", r.Title, r.Type)
+	}
+
+	p := agentProvider()
+	seasons, err := p.GetSeasons(r.ID)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "getting seasons: %v", err)
+	}
+	if len(seasons) == 0 {
+		return emitErr("no_results", exitNoResults, "no seasons found for %q", r.Title)
+	}
+
+	sel := seasons[0]
+	if flagSeason > 0 {
+		found := false
+		for _, s := range seasons {
+			if s.Number == flagSeason {
+				sel, found = s, true
+				break
+			}
+		}
+		if !found {
+			return emitErr("no_results", exitNoResults, "season %d not found for %q", flagSeason, r.Title)
+		}
+	}
+
+	eps, err := p.GetEpisodes(r.ID, sel.ID)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "getting episodes: %v", err)
+	}
+
+	seasonNums := make([]int, 0, len(seasons))
+	for _, s := range seasons {
+		seasonNums = append(seasonNums, s.Number)
+	}
+	out := make([]map[string]any, 0, len(eps))
+	for _, e := range eps {
+		out = append(out, map[string]any{"number": e.Number, "title": e.Title})
+	}
+
+	return emitJSON(map[string]any{
+		"title":    r.Title,
+		"seasons":  seasonNums,
+		"season":   sel.Number,
+		"episodes": out,
+	})
+}

--- a/cmd/episodes.go
+++ b/cmd/episodes.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"lobster/internal/media"
+	"lobster/internal/provider"
+	"lobster/internal/resolver"
 )
 
 var (
@@ -40,12 +42,12 @@ func episodesRun(cmd *cobra.Command, args []string) error {
 
 	applyRefBase(cmd, r)
 
-	p := agentProvider()
-	seasons, err := p.GetSeasons(r.ID)
-	if err != nil {
-		return emitErr("providers_failed", exitProvidersFailed, "getting seasons: %v", err)
-	}
+	primary := agentProvider()
+	p, id, seasons, primaryErr := seasonSource(primary, r)
 	if len(seasons) == 0 {
+		if primaryErr != nil {
+			return emitErr("providers_failed", exitProvidersFailed, "getting seasons: %v", primaryErr)
+		}
 		return emitErr("no_results", exitNoResults, "no seasons found for %q", r.Title)
 	}
 
@@ -63,7 +65,7 @@ func episodesRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	eps, err := p.GetEpisodes(r.ID, sel.ID)
+	eps, err := p.GetEpisodes(id, sel.ID)
 	if err != nil {
 		return emitErr("providers_failed", exitProvidersFailed, "getting episodes: %v", err)
 	}
@@ -83,4 +85,62 @@ func episodesRun(cmd *cobra.Command, args []string) error {
 		"season":   sel.Number,
 		"episodes": out,
 	})
+}
+
+// agentFallbackProviders is the fallback chain, as a package var so tests can
+// supply stubs instead of providers that reach the network.
+var agentFallbackProviders = fallbackProviders
+
+// seasonSource returns the provider that can actually enumerate this ref's
+// seasons, the ID to ask it about, that season list, and the primary's error
+// if it had one.
+//
+// The primary is asked first and almost always answers. It fails for one
+// specific, non-rare reason: a ref's ID need not belong to the primary at all.
+// find searches the primary *and* the fallback chain (gatherSearchResults
+// broadens whenever the primary returns fewer than three results) while
+// stamping the configured base on every ref it prints — playRef.Base is a
+// starting point, not an attribution (cmd/ref.go). A ref whose ID came from a
+// fallback provider therefore reaches the primary as a foreign ID, and the
+// primary answers "no seasons" or errors.
+//
+// play already survives that: resolveAndPlay has a branch for exactly this
+// condition (cmd/search.go, `if err != nil || len(seasons) == 0`) that
+// re-searches by title across the whole chain. episodes did not, so `find` →
+// `episodes --ref` reported "no seasons found" for a show `play --ref` then
+// played without complaint. The two commands must agree on what one ref means.
+//
+// The re-search is by title and ranked by resolver.Candidates, so the ref's
+// ID/Title/Year all count — the same ranking the resolver uses, and the reason
+// a ref carries more than an ID. A fallback is only accepted when it returns a
+// non-empty season list; an empty one means it does not really have this show.
+func seasonSource(primary provider.Provider, r playRef) (provider.Provider, string, []media.Season, error) {
+	seasons, err := primary.GetSeasons(r.ID)
+	if err == nil && len(seasons) > 0 {
+		return primary, r.ID, seasons, nil
+	}
+	debugf("episodes: primary could not enumerate %q (err=%v, seasons=%d); re-searching the fallback chain by title", r.ID, err, len(seasons))
+
+	req := resolver.Request{
+		ID:        r.ID,
+		Title:     r.Title,
+		Year:      r.Year,
+		MediaType: media.TV,
+	}
+	for _, fb := range agentFallbackProviders(primary) {
+		results, searchErr := fb.Search(r.Title)
+		if searchErr != nil {
+			debugf("episodes: fallback %T search failed: %v", fb, searchErr)
+			continue
+		}
+		for _, c := range resolver.Candidates(results, req) {
+			fbSeasons, seasonsErr := fb.GetSeasons(c.ID)
+			if seasonsErr != nil || len(fbSeasons) == 0 {
+				continue
+			}
+			debugf("episodes: %T answers for %q (ID %s)", fb, c.Title, c.ID)
+			return fb, c.ID, fbSeasons, nil
+		}
+	}
+	return primary, r.ID, nil, err
 }

--- a/cmd/episodes.go
+++ b/cmd/episodes.go
@@ -38,6 +38,8 @@ func episodesRun(cmd *cobra.Command, args []string) error {
 		return emitErr("not_a_series", 1, "%q is a %s, which has no episodes", r.Title, r.Type)
 	}
 
+	applyRefBase(cmd, r)
+
 	p := agentProvider()
 	seasons, err := p.GetSeasons(r.ID)
 	if err != nil {

--- a/cmd/episodes_test.go
+++ b/cmd/episodes_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// An agent cannot guess episode numbers, so it needs a listing — and that
+// listing must not prompt.
+func TestEpisodesListsWithoutPrompting(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		return &stubProvider{
+			seasons:  []media.Season{{ID: "s1", Number: 1}, {ID: "s2", Number: 2}},
+			episodes: []media.Episode{{ID: "e1", Number: 1, Title: "Pilot"}},
+		}
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	ref, err := encodeRef(playRef{ID: "tv/show-1", Title: "Some Show", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	prevSeason := flagSeason
+	flagSeason = 1
+	t.Cleanup(func() { flagSeason = prevSeason })
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+
+	var got struct {
+		Schema   int `json:"schema"`
+		Episodes []struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		} `json:"episodes"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if len(got.Episodes) != 1 || got.Episodes[0].Number != 1 || got.Episodes[0].Title != "Pilot" {
+		t.Fatalf("episodes = %+v", got.Episodes)
+	}
+}
+
+// Asking for episodes of a film is a caller mistake worth naming clearly.
+func TestEpisodesRejectsMovieRef(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "A Film", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := episodesRun(episodesCmd, nil); err == nil {
+		t.Fatal("episodesRun accepted a movie ref, want an error")
+	}
+}

--- a/cmd/episodes_test.go
+++ b/cmd/episodes_test.go
@@ -169,6 +169,16 @@ func TestEpisodesUnknownSeasonExitsTwo(t *testing.T) {
 	}
 }
 
+// withNoFallbackProviders empties the fallback chain for the duration of the
+// test. Required wherever the primary cannot enumerate seasons: seasonSource
+// then re-searches the chain, and the real chain reaches the network.
+func withNoFallbackProviders(t *testing.T) {
+	t.Helper()
+	prev := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider { return nil }
+	t.Cleanup(func() { agentFallbackProviders = prev })
+}
+
 // A provider that errors is exit 3, so the agent runs doctor rather than
 // suggesting a different season number.
 func TestEpisodesProviderErrorExitsThree(t *testing.T) {
@@ -178,6 +188,7 @@ func TestEpisodesProviderErrorExitsThree(t *testing.T) {
 	p := twoSeasonStub()
 	p.seasonsErr = errors.New("upstream 503")
 	withStubProvider(t, p)
+	withNoFallbackProviders(t)
 	withEpisodesFlags(t, tvRef(t, ""), 1)
 
 	err := episodesRun(episodesCmd, nil)
@@ -328,5 +339,82 @@ func TestPlayAndEpisodesAgreeOnRefBase(t *testing.T) {
 	}
 	if seen["play"] != "flixhq.ws" {
 		t.Fatalf("both commands used base %q, want the ref's flixhq.ws", seen["play"])
+	}
+}
+
+// find searches the fallback chain as well as the primary (gatherSearchResults)
+// but stamps the primary's base on every ref, so a ref's ID can belong to a
+// provider that is not the one episodes will ask. Handing a foreign ID to the
+// primary yields no seasons — and episodes reported "no seasons found" for a
+// show play resolves and plays without trouble, because resolveAndPlay
+// re-searches by title across the chain (cmd/search.go). episodes must do the
+// same or the two commands disagree about what one ref means.
+func TestEpisodesFallsBackWhenPrimaryCannotEnumerate(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	// The primary does not index this ID: no error, just nothing.
+	withStubProvider(t, &stubProvider{})
+
+	fb := twoSeasonStub()
+	fb.results = []media.SearchResult{
+		{ID: "fb/some-show", Title: "Some Show", Type: media.TV},
+	}
+	prevFB := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider {
+		return []provider.Provider{fb}
+	}
+	t.Cleanup(func() { agentFallbackProviders = prevFB })
+
+	withEpisodesFlags(t, tvRef(t, ""), 2)
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+
+	var got struct {
+		Seasons  []int `json:"seasons"`
+		Season   int   `json:"season"`
+		Episodes []struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		} `json:"episodes"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if len(got.Seasons) != 2 {
+		t.Fatalf("seasons = %v, want the fallback provider's two", got.Seasons)
+	}
+	if got.Season != 2 || len(got.Episodes) != 2 || got.Episodes[0].Title != "Return" {
+		t.Fatalf("season = %d, episodes = %+v; want the fallback's season 2", got.Season, got.Episodes)
+	}
+}
+
+// The fallback must be looked up under the ref's own title, and it must not
+// silently accept a provider that answers about a different show.
+func TestEpisodesFallbackIgnoresUnrelatedFallbackResults(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	withStubProvider(t, &stubProvider{})
+
+	fb := twoSeasonStub()
+	fb.results = nil // the fallback does not have this title at all
+	prevFB := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider {
+		return []provider.Provider{fb}
+	}
+	t.Cleanup(func() { agentFallbackProviders = prevFB })
+
+	withEpisodesFlags(t, tvRef(t, ""), 1)
+
+	err := episodesRun(episodesCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("episodesRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
 	}
 }

--- a/cmd/episodes_test.go
+++ b/cmd/episodes_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
+	"lobster/internal/config"
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
@@ -72,5 +74,259 @@ func TestEpisodesRejectsMovieRef(t *testing.T) {
 
 	if err := episodesRun(episodesCmd, nil); err == nil {
 		t.Fatal("episodesRun accepted a movie ref, want an error")
+	}
+}
+
+// tvRef is a TV ref carrying an optional originating base.
+func tvRef(t *testing.T, base string) string {
+	t.Helper()
+	ref, err := encodeRef(playRef{ID: "tv/show-1", Title: "Some Show", Type: "tv", Base: base})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	return ref
+}
+
+// twoSeasonStub answers with two seasons whose episode lists differ, so a
+// command that ignores the requested season is distinguishable from one that
+// honours it.
+func twoSeasonStub() *stubProvider {
+	return &stubProvider{
+		seasons: []media.Season{{ID: "s1", Number: 1}, {ID: "s2", Number: 2}},
+		episodesBySeason: map[string][]media.Episode{
+			"s1": {{ID: "e1", Number: 1, Title: "Pilot"}},
+			"s2": {{ID: "e2", Number: 1, Title: "Return"}, {ID: "e3", Number: 2, Title: "Fallout"}},
+		},
+	}
+}
+
+// withEpisodesFlags sets --ref/--season for the duration of the test.
+func withEpisodesFlags(t *testing.T, ref string, season int) {
+	t.Helper()
+	prevRef, prevSeason := flagRef, flagSeason
+	flagRef, flagSeason = ref, season
+	t.Cleanup(func() { flagRef, flagSeason = prevRef, prevSeason })
+}
+
+// withStubProvider installs p as the provider the agent commands build.
+func withStubProvider(t *testing.T, p *stubProvider) {
+	t.Helper()
+	prev := agentProvider
+	agentProvider = func() provider.Provider { return p }
+	t.Cleanup(func() { agentProvider = prev })
+}
+
+// --season must select that season's episodes, not season 1's. Covered only
+// now that stubProvider.GetEpisodes honours its seasonID.
+func TestEpisodesSelectsRequestedSeason(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	p := twoSeasonStub()
+	withStubProvider(t, p)
+	withEpisodesFlags(t, tvRef(t, ""), 2)
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+	if p.lastSeasonID != "s2" {
+		t.Fatalf("GetEpisodes was asked for season %q, want s2", p.lastSeasonID)
+	}
+
+	var got struct {
+		Season   int `json:"season"`
+		Episodes []struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		} `json:"episodes"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if got.Season != 2 {
+		t.Fatalf("season = %d, want 2", got.Season)
+	}
+	if len(got.Episodes) != 2 || got.Episodes[0].Title != "Return" {
+		t.Fatalf("episodes = %+v, want season 2's list", got.Episodes)
+	}
+}
+
+// A season the show does not have is "no such thing", not "sources down".
+func TestEpisodesUnknownSeasonExitsTwo(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	withStubProvider(t, twoSeasonStub())
+	withEpisodesFlags(t, tvRef(t, ""), 5)
+
+	err := episodesRun(episodesCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("episodesRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+}
+
+// A provider that errors is exit 3, so the agent runs doctor rather than
+// suggesting a different season number.
+func TestEpisodesProviderErrorExitsThree(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	p := twoSeasonStub()
+	p.seasonsErr = errors.New("upstream 503")
+	withStubProvider(t, p)
+	withEpisodesFlags(t, tvRef(t, ""), 1)
+
+	err := episodesRun(episodesCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("episodesRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitProvidersFailed {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+}
+
+// The episode listing can fail on its own, after seasons resolved fine.
+func TestEpisodesEpisodeFetchErrorExitsThree(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	p := twoSeasonStub()
+	p.episodesErr = errors.New("upstream 503")
+	withStubProvider(t, p)
+	withEpisodesFlags(t, tvRef(t, ""), 1)
+
+	err := episodesRun(episodesCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("episodesRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitProvidersFailed {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+}
+
+// A ref carries the base it was found under. play honours it; episodes must
+// too, or a `find --base flixhq.ws` ref lists fine under play and fails under
+// episodes with "no seasons found" because a MovieBox provider was handed a
+// FlixHQ ID.
+func TestEpisodesHonorsRefBaseWhenNotOverridden(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+	withInheritedFlags(t, episodesCmd, "base")
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "moviebox"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	var seenBase string
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		seenBase = cfg.Base
+		return twoSeasonStub()
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	withEpisodesFlags(t, tvRef(t, "flixhq.ws"), 1)
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+	if seenBase != "flixhq.ws" {
+		t.Fatalf("cfg.Base seen by agentProvider = %q, want flixhq.ws (the ref's base)", seenBase)
+	}
+}
+
+// An explicit --base is a deliberate override and must beat the ref's base,
+// exactly as it does for play.
+func TestEpisodesExplicitBaseFlagOverridesRef(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+	withInheritedFlags(t, episodesCmd, "base")
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "moviebox"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	if err := episodesCmd.Flags().Set("base", "moviebox"); err != nil {
+		t.Fatalf("Set --base: %v", err)
+	}
+
+	var seenBase string
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		seenBase = cfg.Base
+		return twoSeasonStub()
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	withEpisodesFlags(t, tvRef(t, "flixhq.ws"), 1)
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+	if seenBase != "moviebox" {
+		t.Fatalf("cfg.Base seen by agentProvider = %q, want moviebox (the explicit --base)", seenBase)
+	}
+}
+
+// The two commands must agree on what a single ref means. If they disagree,
+// the agent's own workflow breaks in the middle: episodes lists nothing for a
+// ref that play then happily plays.
+func TestPlayAndEpisodesAgreeOnRefBase(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+	withInheritedFlags(t, playCmd, "base")
+	withInheritedFlags(t, episodesCmd, "base")
+
+	ref := tvRef(t, "flixhq.ws")
+
+	seen := map[string]string{}
+	record := func(name string) func() provider.Provider {
+		return func() provider.Provider {
+			seen[name] = cfg.Base
+			return twoSeasonStub()
+		}
+	}
+
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error { return nil }
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	prevProv := agentProvider
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevCfg := cfg
+	t.Cleanup(func() { cfg = prevCfg })
+
+	cfg = &config.Config{Base: "moviebox"}
+	withEpisodesFlags(t, ref, 1)
+	agentProvider = record("episodes")
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+
+	cfg = &config.Config{Base: "moviebox"}
+	prevEpisode := flagEpisode
+	flagEpisode = 1
+	t.Cleanup(func() { flagEpisode = prevEpisode })
+	agentProvider = record("play")
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+
+	if seen["episodes"] != seen["play"] {
+		t.Fatalf("episodes resolved against base %q but play used %q; the same ref must mean the same thing", seen["episodes"], seen["play"])
+	}
+	if seen["play"] != "flixhq.ws" {
+		t.Fatalf("both commands used base %q, want the ref's flixhq.ws", seen["play"])
 	}
 }

--- a/cmd/episodes_test.go
+++ b/cmd/episodes_test.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"lobster/internal/config"
 	"lobster/internal/media"
@@ -393,6 +395,43 @@ func TestEpisodesFallsBackWhenPrimaryCannotEnumerate(t *testing.T) {
 
 // The fallback must be looked up under the ref's own title, and it must not
 // silently accept a provider that answers about a different show.
+//
+// resolver.Candidates ranks but does not threshold — a score-0 result is still
+// returned — so "the first candidate whose GetSeasons is non-empty" accepts a
+// provider that answered about something else entirely. The failure is silent
+// and undetectable by the caller: the envelope echoes the ref's own title, so
+// the agent sees "Some Show" with a different show's seasons and episodes.
+// Listing the wrong work without failing loudly is the exact failure the ref
+// design exists to prevent.
+func TestEpisodesFallbackRefusesADifferentShow(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	withStubProvider(t, &stubProvider{})
+
+	fb := twoSeasonStub()
+	fb.results = []media.SearchResult{
+		{ID: "fb/totally-different", Title: "Completely Different Show", Year: "1999", Type: media.TV},
+	}
+	prevFB := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider {
+		return []provider.Provider{fb}
+	}
+	t.Cleanup(func() { agentFallbackProviders = prevFB })
+
+	withEpisodesFlags(t, tvRef(t, ""), 1)
+
+	err := episodesRun(episodesCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("episodesRun returned %T (%v) for an unrelated fallback match, want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+}
+
+// A fallback that simply does not carry the title at all is exit 2 too.
 func TestEpisodesFallbackIgnoresUnrelatedFallbackResults(t *testing.T) {
 	hostileEnv(t)
 	captureAgentOut(t)
@@ -416,5 +455,90 @@ func TestEpisodesFallbackIgnoresUnrelatedFallbackResults(t *testing.T) {
 	}
 	if ee.code != exitNoResults {
 		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+}
+
+// blockingProvider is a fallback that hangs in Search until its channel is
+// closed. provider.Provider takes no context, so this is what a wedged
+// upstream looks like from inside lobster: a call that simply does not return.
+type blockingProvider struct {
+	*stubProvider
+	block chan struct{}
+}
+
+func (b *blockingProvider) Search(string) ([]media.SearchResult, error) {
+	<-b.block
+	return nil, nil
+}
+
+// newBlockingProvider returns a provider wedged in Search, released either by
+// the test's cleanup or after grace — whichever comes first. The grace release
+// is what keeps the test an assertion failure rather than a hang if the scan is
+// ever unbounded again.
+func newBlockingProvider(t *testing.T, grace time.Duration) *blockingProvider {
+	t.Helper()
+	b := &blockingProvider{stubProvider: &stubProvider{}, block: make(chan struct{})}
+	var once sync.Once
+	release := func() { once.Do(func() { close(b.block) }) }
+	timer := time.AfterFunc(grace, release)
+	t.Cleanup(func() {
+		timer.Stop()
+		release()
+	})
+	return b
+}
+
+// The fallback scan must be bounded. It fans out over the whole chain — up to
+// eleven providers, each a Search plus several GetSeasons calls against a 30s
+// HTTP client timeout — and episodes is one of the commands whose entire
+// premise is that an agent is never left waiting. find bounds the same fan-out
+// at multiSearchTimeout (cmd/multisearch.go); this must too, or one wedged
+// provider turns a one-call command into minutes of silence.
+func TestEpisodesFallbackScanIsBounded(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevTimeout := episodesFallbackTimeout
+	episodesFallbackTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { episodesFallbackTimeout = prevTimeout })
+
+	withStubProvider(t, &stubProvider{})
+
+	// Wedged provider first in chain order, so a scan that waits for it in turn
+	// cannot reach the healthy one until it gives up.
+	blocked := newBlockingProvider(t, 3*time.Second)
+	healthy := twoSeasonStub()
+	healthy.results = []media.SearchResult{
+		{ID: "fb/some-show", Title: "Some Show", Type: media.TV},
+	}
+	prevFB := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider {
+		return []provider.Provider{blocked, healthy}
+	}
+	t.Cleanup(func() { agentFallbackProviders = prevFB })
+
+	withEpisodesFlags(t, tvRef(t, ""), 1)
+
+	start := time.Now()
+	err := episodesRun(episodesCmd, nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("episodesRun took %v with one wedged provider; the scan is not bounded by episodesFallbackTimeout (%v)", elapsed, episodesFallbackTimeout)
+	}
+
+	var got struct {
+		Episodes []struct {
+			Title string `json:"title"`
+		} `json:"episodes"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if len(got.Episodes) != 1 || got.Episodes[0].Title != "Pilot" {
+		t.Fatalf("episodes = %+v, want the healthy fallback's season 1", got.Episodes)
 	}
 }

--- a/cmd/episodes_type_test.go
+++ b/cmd/episodes_type_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// seasonSpyProvider records every ID GetSeasons was asked about, so a test can
+// assert on the call that should never have been made rather than only on the
+// output it happened to produce.
+type seasonSpyProvider struct {
+	stubProvider
+
+	mu       sync.Mutex
+	askedIDs []string
+}
+
+func (s *seasonSpyProvider) GetSeasons(id string) ([]media.Season, error) {
+	s.mu.Lock()
+	s.askedIDs = append(s.askedIDs, id)
+	s.mu.Unlock()
+	return s.stubProvider.GetSeasons(id)
+}
+
+func (s *seasonSpyProvider) asked() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.askedIDs...)
+}
+
+// A TV ref must never be satisfied by a provider that only holds a same-titled
+// film. resolver.Matches ignored media type, and resolver.Candidates falls
+// back to the other type when nothing of the requested type is present
+// (dedupeByType returns otherType when sameType is empty) — so the film was
+// admitted and probeSeasons called GetSeasons on a movie ID. A provider that
+// answers that with anything at all then had its "seasons" printed under the
+// show's title, exit 0, with nothing for the caller to detect.
+//
+// "Spider-Man" is the honest input: the 2002 film and the 1994 animated series
+// share a title exactly, so every title-based check in Matches passes and only
+// the type distinguishes them.
+func TestEpisodesRefusesAFallbackHoldingOnlyASameTitledMovie(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	// The primary cannot enumerate this ref — the foreign-ID case seasonSource
+	// exists for — so the fallback chain is re-searched by title.
+	primary := &stubProvider{seasonsErr: errors.New("unknown id")}
+	withStubProvider(t, primary)
+
+	// The only fallback holds the *film*, and would happily return seasons for
+	// it if asked. Asking at all is the bug.
+	film := &seasonSpyProvider{stubProvider: stubProvider{
+		results: []media.SearchResult{
+			{ID: "movie/557", Title: "Spider-Man", Year: "2002", Type: media.Movie},
+		},
+		seasons:  []media.Season{{ID: "s1", Number: 1}},
+		episodes: []media.Episode{{ID: "e1", Number: 1, Title: "Not an episode of anything"}},
+	}}
+	prevFallbacks := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider {
+		return []provider.Provider{film}
+	}
+	t.Cleanup(func() { agentFallbackProviders = prevFallbacks })
+
+	ref, err := encodeRef(playRef{ID: "tv/888", Title: "Spider-Man", Year: "1994", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	withEpisodesFlags(t, ref, 1)
+
+	runErr := episodesRun(episodesCmd, nil)
+
+	if asked := film.asked(); len(asked) > 0 {
+		t.Fatalf("GetSeasons was called on %v — a film's ID, for a TV ref", asked)
+	}
+
+	var ee *exitError
+	if !errors.As(runErr, &ee) {
+		t.Fatalf("episodesRun returned %T (%v), want a non-zero exit rather than a film's seasons", runErr, runErr)
+	}
+}
+
+// The gate must not cost the fallback its purpose. This is the same shape as
+// the test above with one field changed — the fallback's result is a TV series
+// — and it has to keep working, because the season/episode fix that preceded
+// this one made exactly this path unreachable.
+func TestEpisodesStillAcceptsAFallbackHoldingTheSeries(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	primary := &stubProvider{seasonsErr: errors.New("unknown id")}
+	withStubProvider(t, primary)
+
+	series := &seasonSpyProvider{stubProvider: stubProvider{
+		results: []media.SearchResult{
+			{ID: "fb/spider-man-1994", Title: "Spider-Man", Year: "1994", Type: media.TV},
+		},
+		seasons:  []media.Season{{ID: "s1", Number: 1}},
+		episodes: []media.Episode{{ID: "e1", Number: 1, Title: "Night of the Lizard"}},
+	}}
+	prevFallbacks := agentFallbackProviders
+	agentFallbackProviders = func(provider.Provider) []provider.Provider {
+		return []provider.Provider{series}
+	}
+	t.Cleanup(func() { agentFallbackProviders = prevFallbacks })
+
+	ref, err := encodeRef(playRef{ID: "tv/888", Title: "Spider-Man", Year: "1994", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	withEpisodesFlags(t, ref, 1)
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v (envelope: %s)", err, buf.String())
+	}
+	if asked := series.asked(); len(asked) != 1 || asked[0] != "fb/spider-man-1994" {
+		t.Fatalf("GetSeasons asked about %v, want [fb/spider-man-1994]", asked)
+	}
+	if got := buf.String(); !strings.Contains(got, "Night of the Lizard") {
+		t.Fatalf("envelope did not carry the fallback's episodes: %s", got)
+	}
+}

--- a/cmd/fallback_providers_test.go
+++ b/cmd/fallback_providers_test.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"lobster/internal/config"
 	"lobster/internal/provider"
@@ -29,6 +32,26 @@ func hasProvider[T provider.Provider](ps []provider.Provider) bool {
 }
 
 func TestMain(m *testing.M) {
+	// waitLiveness (detach_test.go) needs a real child process whose exit it
+	// can observe, without launching a real media player or depending on a
+	// shell being on PATH (this test binary also has to build and run on
+	// windows-latest CI). The trick: re-exec this same test binary with this
+	// env var set, and short-circuit straight to os.Exit before the testing
+	// package ever gets involved, so it behaves as a plain, portable,
+	// disposable helper process rather than another test run.
+	if code := os.Getenv("LOBSTER_TEST_HELPER_EXIT_CODE"); code != "" {
+		if ms := os.Getenv("LOBSTER_TEST_HELPER_SLEEP_MS"); ms != "" {
+			if n, err := strconv.Atoi(ms); err == nil {
+				time.Sleep(time.Duration(n) * time.Millisecond)
+			}
+		}
+		n, err := strconv.Atoi(code)
+		if err != nil {
+			n = 1
+		}
+		os.Exit(n)
+	}
+
 	// Stub flixhqDomain to prevent live network probes in tests.
 	// Tests that need a healthy or dead result override this with t.Cleanup restore.
 	prev := flixhqDomain

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -29,10 +29,8 @@ var findCmd = &cobra.Command{
 Unlike the interactive commands, find never opens fzf and never waits for
 input, so it is safe to call from a script or an agent. Each result carries an
 opaque "ref" which is the handle to pass to "lobster play --ref".`,
-	Args:          cobra.MinimumNArgs(1),
-	RunE:          findRun,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Args: cobra.MinimumNArgs(1),
+	RunE: findRun,
 }
 
 func findRun(cmd *cobra.Command, args []string) error {
@@ -95,6 +93,7 @@ func findRun(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
+	markAgentCommand(findCmd)
 	findCmd.Flags().StringVar(&flagFindType, "type", "", "Filter results: movie | tv")
 	findCmd.Flags().IntVar(&flagFindLimit, "limit", 0, "Maximum results to print (0 = no limit)")
 }

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -17,6 +17,10 @@ var (
 // fixed results instead of reaching the network.
 var agentSearch = gatherSearchResults
 
+// agentProvider builds the primary provider. A package var so tests can supply
+// a stub instead of one that reaches the network.
+var agentProvider = newProvider
+
 var findCmd = &cobra.Command{
 	Use:   "find <query>",
 	Short: "Search for a movie or TV show and print JSON (no prompts)",
@@ -34,7 +38,7 @@ opaque "ref" which is the handle to pass to "lobster play --ref".`,
 func findRun(cmd *cobra.Command, args []string) error {
 	query := strings.Join(args, " ")
 
-	p := newProvider()
+	p := agentProvider()
 	results, err := agentSearch(p, fallbackSearchProviders(p), query)
 	if err != nil {
 		return emitErr("providers_failed", exitProvidersFailed, "search failed: %v", err)

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -21,6 +21,28 @@ var agentSearch = gatherSearchResults
 // a stub instead of one that reaches the network.
 var agentProvider = newProvider
 
+// parseFindType resolves --type. It reports whether filtering applies at all
+// (an empty --type means "no filter") and rejects anything else.
+//
+// Comparison is case-insensitive: "TV" and "Movie" are what a human — or an
+// agent echoing the user — naturally writes, and case is not a mistake worth
+// failing on. An unrecognised word is: the old code treated every value that
+// was not exactly "tv" as "movie", so `--type series` silently returned only
+// films and reported success, which the caller has no way to notice.
+func parseFindType(s string) (want media.MediaType, filter bool, err error) {
+	switch strings.ToLower(s) {
+	case "":
+		return media.Movie, false, nil
+	case "movie":
+		return media.Movie, true, nil
+	case "tv":
+		return media.TV, true, nil
+	default:
+		return media.Movie, false, emitErr("usage", exitUsage,
+			"unrecognised --type %q (valid: movie, tv; case-insensitive)", s)
+	}
+}
+
 var findCmd = &cobra.Command{
 	Use:   "find <query>",
 	Short: "Search for a movie or TV show and print JSON (no prompts)",
@@ -36,17 +58,21 @@ opaque "ref" which is the handle to pass to "lobster play --ref".`,
 func findRun(cmd *cobra.Command, args []string) error {
 	query := strings.Join(args, " ")
 
+	// Validated before the search so an unusable filter costs no network
+	// round trip, and so the error is unambiguous rather than arriving as an
+	// empty result set.
+	want, filter, err := parseFindType(flagFindType)
+	if err != nil {
+		return err
+	}
+
 	p := agentProvider()
 	results, err := agentSearch(p, fallbackSearchProviders(p), query)
 	if err != nil {
 		return emitErr("providers_failed", exitProvidersFailed, "search failed: %v", err)
 	}
 
-	if flagFindType != "" {
-		want := media.Movie
-		if flagFindType == "tv" {
-			want = media.TV
-		}
+	if filter {
 		filtered := results[:0:0]
 		for _, r := range results {
 			if r.Type == want {
@@ -64,6 +90,10 @@ func findRun(cmd *cobra.Command, args []string) error {
 		results = results[:flagFindLimit]
 	}
 
+	// The configured base, stamped on every result — including ones the
+	// fallback chain supplied, whose IDs came from a different provider. See
+	// playRef.Base (cmd/ref.go): the stamp is a starting point for resolution,
+	// not an attribution.
 	base := ""
 	if cfg != nil {
 		base = cfg.Base
@@ -94,6 +124,6 @@ func findRun(cmd *cobra.Command, args []string) error {
 
 func init() {
 	markAgentCommand(findCmd)
-	findCmd.Flags().StringVar(&flagFindType, "type", "", "Filter results: movie | tv")
+	findCmd.Flags().StringVar(&flagFindType, "type", "", "Filter results: movie | tv (case-insensitive)")
 	findCmd.Flags().IntVar(&flagFindLimit, "limit", 0, "Maximum results to print (0 = no limit)")
 }

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"lobster/internal/media"
+)
+
+var (
+	flagFindType  string
+	flagFindLimit int
+)
+
+// agentSearch is the search entry point, as a package var so tests can supply
+// fixed results instead of reaching the network.
+var agentSearch = gatherSearchResults
+
+var findCmd = &cobra.Command{
+	Use:   "find <query>",
+	Short: "Search for a movie or TV show and print JSON (no prompts)",
+	Long: `Search and print matching titles as JSON on stdout.
+
+Unlike the interactive commands, find never opens fzf and never waits for
+input, so it is safe to call from a script or an agent. Each result carries an
+opaque "ref" which is the handle to pass to "lobster play --ref".`,
+	Args:          cobra.MinimumNArgs(1),
+	RunE:          findRun,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func findRun(cmd *cobra.Command, args []string) error {
+	query := strings.Join(args, " ")
+
+	p := newProvider()
+	results, err := agentSearch(p, fallbackSearchProviders(p), query)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "search failed: %v", err)
+	}
+
+	if flagFindType != "" {
+		want := media.Movie
+		if flagFindType == "tv" {
+			want = media.TV
+		}
+		filtered := results[:0:0]
+		for _, r := range results {
+			if r.Type == want {
+				filtered = append(filtered, r)
+			}
+		}
+		results = filtered
+	}
+
+	if len(results) == 0 {
+		return emitErr("no_results", exitNoResults, "nothing matched %q", query)
+	}
+
+	if flagFindLimit > 0 && len(results) > flagFindLimit {
+		results = results[:flagFindLimit]
+	}
+
+	base := ""
+	if cfg != nil {
+		base = cfg.Base
+	}
+
+	out := make([]map[string]any, 0, len(results))
+	for i, r := range results {
+		ref, err := encodeRef(playRef{
+			ID:    r.ID,
+			Title: r.Title,
+			Year:  r.Year,
+			Type:  r.Type.String(),
+			Base:  base,
+		})
+		if err != nil {
+			return emitErr("internal", 1, "encoding ref: %v", err)
+		}
+		out = append(out, map[string]any{
+			"idx":   i,
+			"ref":   ref,
+			"title": r.Title,
+			"year":  r.Year,
+			"type":  r.Type.String(),
+		})
+	}
+	return emitJSON(map[string]any{"results": out})
+}
+
+func init() {
+	findCmd.Flags().StringVar(&flagFindType, "type", "", "Filter results: movie | tv")
+	findCmd.Flags().IntVar(&flagFindLimit, "limit", 0, "Maximum results to print (0 = no limit)")
+}

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -69,6 +70,13 @@ func findRun(cmd *cobra.Command, args []string) error {
 	p := agentProvider()
 	results, err := agentSearch(p, fallbackSearchProviders(p), query)
 	if err != nil {
+		// gatherSearchResults reports "nothing matched" as an error, not as an
+		// empty slice, so without this branch every typo exited 3 and sent the
+		// agent to `lobster doctor` over a misspelling. errors.Is, not a
+		// message match: the text is a display string and may be reworded.
+		if errors.Is(err, errNoResults) {
+			return emitErr("no_results", exitNoResults, "nothing matched %q", query)
+		}
 		return emitErr("providers_failed", exitProvidersFailed, "search failed: %v", err)
 	}
 
@@ -82,6 +90,8 @@ func findRun(cmd *cobra.Command, args []string) error {
 		results = filtered
 	}
 
+	// Reachable only via --type now: a search that found nothing arrives as
+	// errNoResults above, never as an empty slice.
 	if len(results) == 0 {
 		return emitErr("no_results", exitNoResults, "nothing matched %q", query)
 	}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -145,3 +145,103 @@ func TestFindLimitTruncates(t *testing.T) {
 		t.Fatalf("got %d results, want 2 (limit)", len(got.Results))
 	}
 }
+
+// withFindStub installs a fixed two-result search (one film, one series) and
+// the --type flag for the duration of the test.
+func withFindStub(t *testing.T, typ string) {
+	t.Helper()
+	hostileEnv(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevSearch := agentSearch
+	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
+		return []media.SearchResult{
+			{ID: "movie/a", Title: "A Film", Type: media.Movie},
+			{ID: "tv/b", Title: "A Series", Type: media.TV},
+		}, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	prevType := flagFindType
+	flagFindType = typ
+	t.Cleanup(func() { flagFindType = prevType })
+}
+
+// --type was compared to the literal "tv" and everything else fell through to
+// "movie", so `--type series` or `--type show` silently filtered to films and
+// reported success — the agent has no way to notice. Name the mistake.
+func TestFindRejectsUnknownType(t *testing.T) {
+	withFindStub(t, "series")
+	buf := captureAgentOut(t)
+
+	err := findRun(findCmd, []string{"x"})
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("findRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitUsage {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitUsage)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if _, ok := got["results"]; ok {
+		t.Fatalf("an unrecognised --type still produced results: %q", buf.String())
+	}
+}
+
+// "TV" and "Movie" are what a human (or an agent echoing the user) naturally
+// writes; case is not a mistake worth failing on.
+func TestFindTypeIsCaseInsensitive(t *testing.T) {
+	for _, typ := range []string{"TV", "Tv", "tv"} {
+		t.Run(typ, func(t *testing.T) {
+			withFindStub(t, typ)
+			buf := captureAgentOut(t)
+
+			if err := findRun(findCmd, []string{"x"}); err != nil {
+				t.Fatalf("findRun: %v", err)
+			}
+			var got struct {
+				Results []struct {
+					Title string `json:"title"`
+					Type  string `json:"type"`
+				} `json:"results"`
+			}
+			if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+				t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+			}
+			if len(got.Results) != 1 || got.Results[0].Type != "tv" {
+				t.Fatalf("results = %+v, want only the series", got.Results)
+			}
+		})
+	}
+}
+
+// The movie side of the same filter must keep working, including mixed case.
+func TestFindTypeMovieFilters(t *testing.T) {
+	withFindStub(t, "Movie")
+	buf := captureAgentOut(t)
+
+	if err := findRun(findCmd, []string{"x"}); err != nil {
+		t.Fatalf("findRun: %v", err)
+	}
+	var got struct {
+		Results []struct {
+			Type string `json:"type"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if len(got.Results) != 1 || got.Results[0].Type != "movie" {
+		t.Fatalf("results = %+v, want only the film", got.Results)
+	}
+}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"lobster/internal/config"
@@ -77,32 +79,204 @@ func TestFindEmitsResultsWithoutPrompting(t *testing.T) {
 }
 
 // No results is a distinct, recoverable outcome and must not be conflated with
-// "every provider is down".
-func TestFindNoResultsExitsTwo(t *testing.T) {
+// "every provider is down": exit 2 tells the agent to suggest a spelling, exit
+// 3 tells it to run `lobster doctor`.
+//
+// The earlier version of this test stubbed agentSearch to return (nil, nil) —
+// a state gatherSearchResults never produces, since it turns an empty merge
+// into an error. It therefore exercised a branch findRun could not reach in
+// production and passed while the real binary exited 3 on every typo. Each
+// case below is a shape the real gatherSearchResults can actually return;
+// TestGatherSearchResultsErrorShapes pins that claim against the real one.
+func TestFindMapsSearchOutcomesToExitCodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []media.SearchResult
+		err      error
+		findType string
+		wantCode int
+		wantErr  string
+	}{
+		{
+			name:     "nothing matched",
+			err:      fmt.Errorf("%w for %q", errNoResults, "zzzznotathing"),
+			wantCode: exitNoResults,
+			wantErr:  "no_results",
+		},
+		{
+			name:     "nothing matched, wrapped again by a caller",
+			err:      fmt.Errorf("search failed: %w", fmt.Errorf("%w for %q", errNoResults, "zzzznotathing")),
+			wantCode: exitNoResults,
+			wantErr:  "no_results",
+		},
+		{
+			name:     "every provider unreachable",
+			err:      fmt.Errorf("%w (searching %q)", errProvidersFailed, "zzzznotathing"),
+			wantCode: exitProvidersFailed,
+			wantErr:  "providers_failed",
+		},
+		{
+			name:     "an unclassified error is still a provider failure",
+			err:      errors.New("dial tcp: connection refused"),
+			wantCode: exitProvidersFailed,
+			wantErr:  "providers_failed",
+		},
+		{
+			// The one way findRun still reaches len(results) == 0: a search
+			// that succeeded, filtered to nothing by --type. Driven through
+			// the real filter with a real non-empty result set — stubbing
+			// (nil, nil) here would repeat the mistake this test was written
+			// to correct, since gatherSearchResults cannot return that.
+			name: "a successful search that --type filters to empty",
+			results: []media.SearchResult{
+				{ID: "movie/a", Title: "A Film", Type: media.Movie},
+			},
+			findType: "tv",
+			wantCode: exitNoResults,
+			wantErr:  "no_results",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostileEnv(t)
+			buf := captureAgentOut(t)
+
+			prevCfg := cfg
+			cfg = &config.Config{Base: "flixhq.ws"}
+			t.Cleanup(func() { cfg = prevCfg })
+
+			prevProv := agentProvider
+			agentProvider = func() provider.Provider { return &stubProvider{} }
+			t.Cleanup(func() { agentProvider = prevProv })
+
+			prevSearch := agentSearch
+			agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
+				return tt.results, tt.err
+			}
+			t.Cleanup(func() { agentSearch = prevSearch })
+
+			prevType := flagFindType
+			flagFindType = tt.findType
+			t.Cleanup(func() { flagFindType = prevType })
+
+			err := findRun(findCmd, []string{"zzzznotathing"})
+			var ee *exitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("findRun returned %T (%v), want *exitError", err, err)
+			}
+			if ee.code != tt.wantCode {
+				t.Fatalf("exit code = %d, want %d (envelope: %s)", ee.code, tt.wantCode, buf.String())
+			}
+			if !strings.Contains(buf.String(), `"code": "`+tt.wantErr+`"`) {
+				t.Fatalf("envelope = %s, want code %q", buf.String(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// The stub above is only honest if the real gatherSearchResults really does
+// return these two sentinels, and really does tell the two states apart. This
+// exercises the real function against stub providers.
+func TestGatherSearchResultsErrorShapes(t *testing.T) {
+	boom := errors.New("dial tcp: connection refused")
+	// How a real provider reports an empty catalog hit: an *error* wrapping
+	// provider.ErrNoResults, not an empty slice. Observed from the live
+	// binary — FlixHQWS, VaPlayer, TBCPL, VidNest, Soap2Day, AniPub and
+	// KimCartoon all answer a nonsense query this way.
+	empty := fmt.Errorf("%w for %q", provider.ErrNoResults, "zzzznotathing")
+
+	tests := []struct {
+		name      string
+		primary   *stubProvider
+		fallbacks []provider.Provider
+		wantIs    error
+	}{
+		{
+			name:    "every provider answered, none had the title",
+			primary: &stubProvider{},
+			fallbacks: []provider.Provider{
+				&stubProvider{}, &stubProvider{},
+			},
+			wantIs: errNoResults,
+		},
+		{
+			name:      "primary answered emptily with no fallbacks at all",
+			primary:   &stubProvider{},
+			fallbacks: nil,
+			wantIs:    errNoResults,
+		},
+		{
+			name:    "primary failed but a fallback answered emptily",
+			primary: &stubProvider{searchErr: boom},
+			fallbacks: []provider.Provider{
+				&stubProvider{searchErr: boom}, &stubProvider{},
+			},
+			wantIs: errNoResults,
+		},
+		{
+			// The live shape: a typo, every provider up. This is the case the
+			// binary got wrong — it exited 3 and told the agent to run doctor.
+			name:    "every provider reports an empty catalog by erroring",
+			primary: &stubProvider{searchErr: empty},
+			fallbacks: []provider.Provider{
+				&stubProvider{searchErr: empty}, &stubProvider{searchErr: empty},
+			},
+			wantIs: errNoResults,
+		},
+		{
+			name:      "one provider is genuinely down, the rest report empty",
+			primary:   &stubProvider{searchErr: boom},
+			fallbacks: []provider.Provider{&stubProvider{searchErr: empty}},
+			wantIs:    errNoResults,
+		},
+		{
+			name:      "every provider failed",
+			primary:   &stubProvider{searchErr: boom},
+			fallbacks: []provider.Provider{&stubProvider{searchErr: boom}},
+			wantIs:    errProvidersFailed,
+		},
+		{
+			name:      "primary failed and there is nothing to fall back to",
+			primary:   &stubProvider{searchErr: boom},
+			fallbacks: nil,
+			wantIs:    errProvidersFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostileEnv(t)
+
+			results, err := gatherSearchResults(tt.primary, tt.fallbacks, "zzzznotathing")
+			if results != nil {
+				t.Fatalf("results = %v, want nil", results)
+			}
+			if !errors.Is(err, tt.wantIs) {
+				t.Fatalf("gatherSearchResults error = %v, want errors.Is(..., %v)", err, tt.wantIs)
+			}
+			// The query must survive the wrap: the interactive path prints
+			// this error verbatim.
+			if !strings.Contains(err.Error(), `"zzzznotathing"`) {
+				t.Fatalf("error %q does not name the query", err)
+			}
+		})
+	}
+}
+
+// A search that does find something must not be dressed up as either failure.
+func TestGatherSearchResultsSucceeds(t *testing.T) {
 	hostileEnv(t)
-	captureAgentOut(t)
 
-	prevCfg := cfg
-	cfg = &config.Config{Base: "flixhq.ws"}
-	t.Cleanup(func() { cfg = prevCfg })
-
-	prevProv := agentProvider
-	agentProvider = func() provider.Provider { return &stubProvider{} }
-	t.Cleanup(func() { agentProvider = prevProv })
-
-	prevSearch := agentSearch
-	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
-		return nil, nil
+	primary := &stubProvider{results: []media.SearchResult{
+		{ID: "movie/1", Title: "The Matrix", Year: "1999", Type: media.Movie},
+	}}
+	results, err := gatherSearchResults(primary, nil, "the matrix")
+	if err != nil {
+		t.Fatalf("gatherSearchResults: %v", err)
 	}
-	t.Cleanup(func() { agentSearch = prevSearch })
-
-	err := findRun(findCmd, []string{"zzzznotathing"})
-	var ee *exitError
-	if !errors.As(err, &ee) {
-		t.Fatalf("findRun returned %T (%v), want *exitError", err, err)
-	}
-	if ee.code != exitNoResults {
-		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	if len(results) != 1 || results[0].Title != "The Matrix" {
+		t.Fatalf("results = %+v, want the one stub row", results)
 	}
 }
 

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -20,6 +20,10 @@ func TestFindEmitsResultsWithoutPrompting(t *testing.T) {
 	cfg = &config.Config{Base: "flixhq.ws"}
 	t.Cleanup(func() { cfg = prevCfg })
 
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
 	prevSearch := agentSearch
 	agentSearch = func(primary provider.Provider, fallbacks []provider.Provider, query string) ([]media.SearchResult, error) {
 		return []media.SearchResult{
@@ -82,6 +86,10 @@ func TestFindNoResultsExitsTwo(t *testing.T) {
 	cfg = &config.Config{Base: "flixhq.ws"}
 	t.Cleanup(func() { cfg = prevCfg })
 
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
 	prevSearch := agentSearch
 	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
 		return nil, nil
@@ -105,6 +113,10 @@ func TestFindLimitTruncates(t *testing.T) {
 	prevCfg := cfg
 	cfg = &config.Config{Base: "flixhq.ws"}
 	t.Cleanup(func() { cfg = prevCfg })
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
 
 	prevSearch := agentSearch
 	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// find must complete without ever prompting. This is the whole point of the
+// command: an agent that hits fzf hangs until it is killed.
+func TestFindEmitsResultsWithoutPrompting(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevSearch := agentSearch
+	agentSearch = func(primary provider.Provider, fallbacks []provider.Provider, query string) ([]media.SearchResult, error) {
+		return []media.SearchResult{
+			{ID: "movie/watch-the-matrix-19724", Title: "The Matrix", Year: "1999", Type: media.Movie},
+			{ID: "movie/watch-the-matrix-reloaded-19725", Title: "The Matrix Reloaded", Year: "2003", Type: media.Movie},
+		}, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	if err := findRun(findCmd, []string{"the matrix"}); err != nil {
+		t.Fatalf("findRun: %v", err)
+	}
+
+	var got struct {
+		Schema  int `json:"schema"`
+		Results []struct {
+			Idx   int    `json:"idx"`
+			Ref   string `json:"ref"`
+			Title string `json:"title"`
+			Year  string `json:"year"`
+			Type  string `json:"type"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(got.Results))
+	}
+	if got.Results[0].Title != "The Matrix" || got.Results[0].Year != "1999" {
+		t.Fatalf("first result = %+v", got.Results[0])
+	}
+	if got.Results[0].Type != "movie" {
+		t.Fatalf("type = %q, want movie", got.Results[0].Type)
+	}
+
+	// The ref must decode back to the same selection, including the base.
+	ref, err := decodeRef(got.Results[0].Ref)
+	if err != nil {
+		t.Fatalf("emitted ref does not decode: %v", err)
+	}
+	if ref.ID != "movie/watch-the-matrix-19724" || ref.Title != "The Matrix" {
+		t.Fatalf("ref = %+v", ref)
+	}
+	if ref.Base != "flixhq.ws" {
+		t.Fatalf("ref.Base = %q, want flixhq.ws", ref.Base)
+	}
+}
+
+// No results is a distinct, recoverable outcome and must not be conflated with
+// "every provider is down".
+func TestFindNoResultsExitsTwo(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevSearch := agentSearch
+	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	err := findRun(findCmd, []string{"zzzznotathing"})
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("findRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+}
+
+func TestFindLimitTruncates(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevSearch := agentSearch
+	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
+		return []media.SearchResult{
+			{ID: "a", Title: "A", Type: media.Movie},
+			{ID: "b", Title: "B", Type: media.Movie},
+			{ID: "c", Title: "C", Type: media.Movie},
+		}, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	prevLimit := flagFindLimit
+	flagFindLimit = 2
+	t.Cleanup(func() { flagFindLimit = prevLimit })
+
+	if err := findRun(findCmd, []string{"x"}); err != nil {
+		t.Fatalf("findRun: %v", err)
+	}
+	var got struct {
+		Results []struct{} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("got %d results, want 2 (limit)", len(got.Results))
+	}
+}

--- a/cmd/gathersearch_test.go
+++ b/cmd/gathersearch_test.go
@@ -19,10 +19,10 @@ func (s gatherStubProvider) Search(string) ([]media.SearchResult, error) { retur
 func (s gatherStubProvider) GetDetails(string) (*media.ContentDetail, error) {
 	return &media.ContentDetail{}, nil
 }
-func (s gatherStubProvider) GetSeasons(string) ([]media.Season, error)         { return nil, nil }
+func (s gatherStubProvider) GetSeasons(string) ([]media.Season, error)           { return nil, nil }
 func (s gatherStubProvider) GetEpisodes(string, string) ([]media.Episode, error) { return nil, nil }
-func (s gatherStubProvider) GetServers(string, string) ([]media.Server, error) { return nil, nil }
-func (s gatherStubProvider) GetEmbedURL(string) (string, error)                { return "", nil }
+func (s gatherStubProvider) GetServers(string, string) ([]media.Server, error)   { return nil, nil }
+func (s gatherStubProvider) GetEmbedURL(string) (string, error)                  { return "", nil }
 func (s gatherStubProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
 	return nil, nil
 }

--- a/cmd/gathersearch_test.go
+++ b/cmd/gathersearch_test.go
@@ -8,29 +8,29 @@ import (
 	"lobster/internal/provider"
 )
 
-// stubProvider is a minimal Provider whose Search returns canned results/error.
-type stubProvider struct {
+// gatherStubProvider is a minimal Provider whose Search returns canned results/error.
+type gatherStubProvider struct {
 	name    string
 	results []media.SearchResult
 	err     error
 }
 
-func (s stubProvider) Search(string) ([]media.SearchResult, error) { return s.results, s.err }
-func (s stubProvider) GetDetails(string) (*media.ContentDetail, error) {
+func (s gatherStubProvider) Search(string) ([]media.SearchResult, error) { return s.results, s.err }
+func (s gatherStubProvider) GetDetails(string) (*media.ContentDetail, error) {
 	return &media.ContentDetail{}, nil
 }
-func (s stubProvider) GetSeasons(string) ([]media.Season, error)         { return nil, nil }
-func (s stubProvider) GetEpisodes(string, string) ([]media.Episode, error) { return nil, nil }
-func (s stubProvider) GetServers(string, string) ([]media.Server, error) { return nil, nil }
-func (s stubProvider) GetEmbedURL(string) (string, error)                { return "", nil }
-func (s stubProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
+func (s gatherStubProvider) GetSeasons(string) ([]media.Season, error)         { return nil, nil }
+func (s gatherStubProvider) GetEpisodes(string, string) ([]media.Episode, error) { return nil, nil }
+func (s gatherStubProvider) GetServers(string, string) ([]media.Server, error) { return nil, nil }
+func (s gatherStubProvider) GetEmbedURL(string) (string, error)                { return "", nil }
+func (s gatherStubProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
 	return nil, nil
 }
-func (s stubProvider) Recent(media.MediaType) ([]media.SearchResult, error) { return nil, nil }
+func (s gatherStubProvider) Recent(media.MediaType) ([]media.SearchResult, error) { return nil, nil }
 
 func TestGatherSearchResultsFallsBackWhenPrimaryErrors(t *testing.T) {
-	primary := stubProvider{name: "primary", err: fmt.Errorf("no results found")}
-	fb := stubProvider{name: "fb", results: []media.SearchResult{
+	primary := gatherStubProvider{name: "primary", err: fmt.Errorf("no results found")}
+	fb := gatherStubProvider{name: "fb", results: []media.SearchResult{
 		{ID: "kam", Title: "KAMUI: He's Behind You", Type: media.TV},
 	}}
 
@@ -44,8 +44,8 @@ func TestGatherSearchResultsFallsBackWhenPrimaryErrors(t *testing.T) {
 }
 
 func TestGatherSearchResultsErrorsWhenNothingFound(t *testing.T) {
-	primary := stubProvider{err: fmt.Errorf("no results")}
-	fb := stubProvider{err: fmt.Errorf("no results")}
+	primary := gatherStubProvider{err: fmt.Errorf("no results")}
+	fb := gatherStubProvider{err: fmt.Errorf("no results")}
 	if _, err := gatherSearchResults(primary, []provider.Provider{fb}, "zzz"); err == nil {
 		t.Fatal("expected error when no provider has results")
 	}
@@ -54,7 +54,7 @@ func TestGatherSearchResultsErrorsWhenNothingFound(t *testing.T) {
 // flakyProvider succeeds on the first Search and fails on every one after,
 // mimicking a provider that rate-limits or drops a connection.
 type flakyProvider struct {
-	stubProvider
+	gatherStubProvider
 	calls int
 }
 
@@ -70,10 +70,10 @@ func (f *flakyProvider) Search(q string) ([]media.SearchResult, error) {
 // Re-querying the primary and replacing the originals on a transient failure
 // silently dropped the only results the user was going to see.
 func TestGatherSearchResultsKeepsInitialPrimaryResults(t *testing.T) {
-	primary := &flakyProvider{stubProvider: stubProvider{results: []media.SearchResult{
+	primary := &flakyProvider{gatherStubProvider: gatherStubProvider{results: []media.SearchResult{
 		{ID: "movie/557", Title: "Spider-Man", Type: media.Movie, Year: "2002"},
 	}}}
-	fb := stubProvider{results: []media.SearchResult{
+	fb := gatherStubProvider{results: []media.SearchResult{
 		{ID: "movie/558", Title: "Spider-Man 2", Type: media.Movie, Year: "2004"},
 	}}
 

--- a/cmd/multisearch.go
+++ b/cmd/multisearch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,15 +15,40 @@ import (
 
 const multiSearchTimeout = 5 * time.Second
 
+// An empty search has two causes that call for opposite advice, so
+// gatherSearchResults reports which one happened and callers branch on it with
+// errors.Is rather than matching the message text.
+//
+// errNoResults means every provider that was asked answered, and none of them
+// indexes this title — usually a typo, so `find` exits 2 and the agent should
+// suggest a spelling. errProvidersFailed means nothing answered at all, so
+// `find` exits 3 and the agent should run `lobster doctor`. Conflating them is
+// not cosmetic: exit 3 on a typo sends an agent to diagnose provider health
+// over a misspelling, which is what the binary did until this split existed.
+var (
+	errNoResults       = errors.New("no results found")
+	errProvidersFailed = errors.New("no provider could be reached")
+)
+
 // gatherSearchResults runs the primary provider's search, then broadens to the
 // fallback providers whenever the primary errors or returns few results — so a
 // title the primary catalog lacks (e.g. anime, which only the TMDB/AllAnime/
-// AniPub providers index) is still discoverable. It only errors when no
-// provider yields anything.
+// AniPub providers index) is still discoverable.
+//
+// It errors only when no provider yields anything, with errNoResults or
+// errProvidersFailed wrapped in so the caller can tell the two apart. Both
+// messages name the query, because the interactive path (playFlow) prints the
+// error verbatim.
 func gatherSearchResults(primary provider.Provider, fallbacks []provider.Provider, query string) ([]media.SearchResult, error) {
 	stop := ui.StartSpinner(fmt.Sprintf("Searching for %q...", query))
 	results, err := primary.Search(query)
 	stop()
+	// A provider that answered with nothing still counts as reached: it is
+	// evidence the title does not exist, which a failed call is not. Most
+	// providers signal "nothing matched" with an error rather than an empty
+	// slice, so `err == nil` alone would classify every real typo as an
+	// outage — see provider.ErrNoResults.
+	reached := err == nil || errors.Is(err, provider.ErrNoResults)
 	if err != nil {
 		debugf("primary search (%T) failed: %v; broadening to fallback providers", primary, err)
 		results = nil
@@ -35,15 +61,19 @@ func gatherSearchResults(primary provider.Provider, fallbacks []provider.Provide
 	if len(results) < 3 {
 		debugf("primary returned %d results, searching fallback providers...", len(results))
 		stop = ui.StartSpinner("Searching more providers...")
-		merged := multiProviderSearch(results, fallbacks, query)
+		merged, fallbackReached := multiProviderSearch(results, fallbacks, query)
 		stop()
+		reached = reached || fallbackReached
 		if len(merged) > 0 {
 			results = merged
 		}
 	}
 
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		if !reached {
+			return nil, fmt.Errorf("%w (searching %q)", errProvidersFailed, query)
+		}
+		return nil, fmt.Errorf("%w for %q", errNoResults, query)
 	}
 	return results, nil
 }
@@ -53,13 +83,19 @@ func gatherSearchResults(primary provider.Provider, fallbacks []provider.Provide
 // primary is deliberately not re-queried: a thin-but-successful first search
 // followed by a transient second failure used to discard the only results the
 // user would have seen.
-func multiProviderSearch(primaryResults []media.SearchResult, fallbacks []provider.Provider, query string) []media.SearchResult {
+//
+// The second return reports whether at least one fallback actually answered —
+// with or without results. gatherSearchResults needs it to tell "no provider
+// indexes this title" from "no provider is up", and an empty merged slice
+// cannot distinguish the two on its own.
+func multiProviderSearch(primaryResults []media.SearchResult, fallbacks []provider.Provider, query string) ([]media.SearchResult, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), multiSearchTimeout)
 	defer cancel()
 
 	var mu sync.Mutex
 	// Pre-allocate slice for fallback results to maintain order.
 	fallbackResults := make([][]media.SearchResult, len(fallbacks))
+	reached := false
 
 	var wg sync.WaitGroup
 	for i, fb := range fallbacks {
@@ -69,17 +105,24 @@ func multiProviderSearch(primaryResults []media.SearchResult, fallbacks []provid
 			results, err := searchWithContext(ctx, p, query)
 			if err != nil {
 				debugf("multi-search fallback (%T) failed: %v", p, err)
+				// Answered, just emptily — still evidence about the title.
+				if errors.Is(err, provider.ErrNoResults) {
+					mu.Lock()
+					reached = true
+					mu.Unlock()
+				}
 				return
 			}
 			mu.Lock()
 			fallbackResults[idx] = results
+			reached = true
 			mu.Unlock()
 		}(i, fb)
 	}
 
 	wg.Wait()
 
-	return deduplicateResults(primaryResults, fallbackResults)
+	return deduplicateResults(primaryResults, fallbackResults), reached
 }
 
 // searchWithContext runs a provider search, aborting if the context expires.

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -4,12 +4,33 @@ import (
 	"github.com/spf13/cobra"
 
 	"lobster/internal/media"
+	"lobster/internal/player"
 	"lobster/internal/provider"
 )
 
 // agentResolveAndPlay is the playback entry point, as a package var so tests
 // can observe what selection reaches it without launching a player.
 var agentResolveAndPlay = resolveAndPlay
+
+// agentPlayerCheck reports whether the configured player binary is available,
+// and its display name for the error message. A package var, seamed the same
+// way as agentProvider and agentResolveAndPlay, so tests can force either
+// outcome without depending on what is actually installed on the machine
+// running the test.
+//
+// Without this precondition, a missing player binary reaches resolveAndPlay,
+// which returns a plain error from player.NotFoundError; playRun's catch-all
+// then maps it to "providers_failed" (exit 3), telling the agent the
+// providers are down when the real problem is that mpv (or whichever player
+// is configured) is not installed. Checking availability up front lets it
+// report exit 4 with the right message instead.
+var agentPlayerCheck = func() (available bool, name string) {
+	if cfg == nil {
+		return true, ""
+	}
+	p := player.New(cfg.Player, cfg.AudioLanguage)
+	return p.Available(), p.Name()
+}
 
 var playCmd = &cobra.Command{
 	Use:   "play --ref <REF>",
@@ -55,6 +76,13 @@ func playRun(cmd *cobra.Command, args []string) error {
 	// it is not supported here.
 	if flagDownload != "" {
 		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
+	}
+
+	// Checked before the --detach dispatch so a detached invocation reports
+	// exit 4 to the caller immediately, rather than forking a supervisor that
+	// fails into a log file the agent has no reason to read.
+	if available, name := agentPlayerCheck(); !available {
+		return emitErr("player_unavailable", exitPlayerUnavailable, "%s is not installed or not on PATH", name)
 	}
 
 	if flagDetach && !flagSupervised {

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -59,6 +59,25 @@ func init() {
 	_ = playCmd.Flags().MarkHidden("supervised")
 }
 
+// applyRefBase honors the ref's originating base unless the caller explicitly
+// passed --base on this invocation. An ID found under `--base yts` is
+// meaningless under another base (playRef doc comment, cmd/ref.go) — without
+// this, a `find --base yts` result would silently resolve against whatever
+// base is currently configured, losing the ID's exact-match bonus and letting
+// a different provider's copy be served. An explicit --base is a deliberate
+// override and must win.
+//
+// Shared by play and episodes rather than living in playRun: while only play
+// applied it, a ref from `find --base flixhq.ws` played fine but listed
+// nothing under episodes, because a MovieBox provider was handed a FlixHQ ID
+// and reported "no seasons found". The two commands must agree on what one ref
+// means.
+func applyRefBase(cmd *cobra.Command, r playRef) {
+	if r.Base != "" && cfg != nil && !cmd.Flags().Changed("base") {
+		cfg.Base = r.Base
+	}
+}
+
 func playRun(cmd *cobra.Command, args []string) error {
 	r, err := decodeRef(flagRef)
 	if err != nil {
@@ -88,16 +107,7 @@ func playRun(cmd *cobra.Command, args []string) error {
 		return playDetached(cmd, r)
 	}
 
-	// Honor the ref's originating base unless the caller explicitly passed
-	// --base on this invocation. An ID found under `--base yts` is meaningless
-	// under another base (playRef doc comment, cmd/ref.go) — without this, a
-	// `find --base yts` result would silently resolve against whatever base is
-	// currently configured, losing the ID's exact-match bonus and letting a
-	// different provider's copy be served. An explicit --base is a deliberate
-	// override and must win.
-	if r.Base != "" && cfg != nil && !cmd.Flags().Changed("base") {
-		cfg.Base = r.Base
-	}
+	applyRefBase(cmd, r)
 
 	var p provider.Provider = agentProvider()
 	if err := agentResolveAndPlay(p, sel, flagSeason, flagEpisode); err != nil {

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -16,9 +16,11 @@ var playCmd = &cobra.Command{
 	Short: "Play a ref returned by lobster find (no prompts)",
 	Long: `Play the exact title a ref identifies, without prompting.
 
-The ref pins the selection — title, year, type and originating base. It does
-not pin the stream: resolution still runs through the fallback chain at play
-time, so if the original source is down another provider's copy may be served.
+The ref pins the selection — title, year, type and originating base. The
+base is used as the resolution base unless --base is passed explicitly on
+this invocation, which overrides it. Neither pins the stream: resolution
+still runs through the fallback chain at play time, so if the original
+source is down another provider's copy may be served.
 
 For a series, both --season and --episode are required; without them playback
 would fall through to the interactive picker and hang.`,
@@ -50,6 +52,17 @@ func playRun(cmd *cobra.Command, args []string) error {
 	// it is not supported here.
 	if flagDownload != "" {
 		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
+	}
+
+	// Honor the ref's originating base unless the caller explicitly passed
+	// --base on this invocation. An ID found under `--base yts` is meaningless
+	// under another base (playRef doc comment, cmd/ref.go) — without this, a
+	// `find --base yts` result would silently resolve against whatever base is
+	// currently configured, losing the ID's exact-match bonus and letting a
+	// different provider's copy be served. An explicit --base is a deliberate
+	// override and must win.
+	if r.Base != "" && cfg != nil && !cmd.Flags().Changed("base") {
+		cfg.Base = r.Base
 	}
 
 	var p provider.Provider = agentProvider()

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -85,8 +85,10 @@ func applyRefBase(cmd *cobra.Command, r playRef) {
 	}
 }
 
-// validateSeasonEpisode confirms the requested season and episode actually
-// exist on p before any playback is dispatched.
+// validateSeasonEpisode rejects a requested season or episode that the primary
+// provider positively reports does not exist, before any playback is
+// dispatched. It is a veto on a known-bad request, not a precondition for
+// playback: when it cannot tell, it says nothing.
 //
 // resolveAndPlay (cmd/search.go) initialises its seasonIdx/episodeIdx to 0 and
 // only overwrites them on an exact Number match, so a request for a season or
@@ -95,16 +97,33 @@ func applyRefBase(cmd *cobra.Command, r playRef) {
 // reported success. `episodes` already answers exit 2 for exactly that input,
 // so the two commands contradicted each other about whether a season exists.
 //
-// The distinction between the two failure modes is the point: a season that
-// does not exist is exitNoResults (2) — pick a different number — while a
-// provider that cannot answer is exitProvidersFailed (3) — run doctor. Mapping
-// the second onto the first would tell the agent to fix the user's input when
-// the sources are down.
+// It rejects one thing only: a season or episode genuinely absent from a list
+// the primary provider successfully returned. Everything else — an error, or
+// an empty list — means "cannot validate", and must fall through untouched.
+//
+// That distinction is load-bearing, not defensive coding. resolveAndPlay has a
+// purpose-built branch for an unenumerable show (cmd/search.go:237, `if err !=
+// nil || len(seasons) == 0`) that resolves by title/year/season/episode across
+// the whole fallback chain and plays. Because this gate runs first, turning a
+// GetSeasons failure into a verdict here makes that branch unreachable from
+// `play --ref`. And it is not a rare state: gatherSearchResults broadens to the
+// fallback providers whenever the primary returns fewer than three results,
+// while find stamps the primary's base on every result — so any ref whose ID
+// actually came from a fallback provider lands here, which is exactly when the
+// primary is degraded. A watchable show would report "every provider is down".
+//
+// So there is no exitProvidersFailed in this function. A primary that cannot
+// answer is not this function's verdict to give: resolveAndPlay tries the
+// fallbacks and reports exit 3 itself if they fail too, which is both later and
+// better informed.
 func validateSeasonEpisode(p provider.Provider, r playRef, season, episode int) error {
 	seasons, err := p.GetSeasons(r.ID)
-	if err != nil {
-		return emitErr("providers_failed", exitProvidersFailed, "getting seasons for %q: %v", r.Title, err)
+	if err != nil || len(seasons) == 0 {
+		// Same condition resolveAndPlay branches on. Let it do its job.
+		debugf("play: cannot validate season/episode against primary (err=%v, seasons=%d); deferring to the resolver", err, len(seasons))
+		return nil
 	}
+
 	seasonID := ""
 	found := false
 	for _, s := range seasons {
@@ -114,13 +133,17 @@ func validateSeasonEpisode(p provider.Provider, r playRef, season, episode int) 
 		}
 	}
 	if !found {
+		// A real, non-empty season list that lacks this number. This is the
+		// silent-S1E1 bug: resolveAndPlay would leave seasonIdx at 0 and play
+		// season one while reporting success.
 		return emitErr("no_results", exitNoResults,
 			"season %d not found for %q (list them with 'lobster episodes --ref ...')", season, r.Title)
 	}
 
 	eps, err := p.GetEpisodes(r.ID, seasonID)
-	if err != nil {
-		return emitErr("providers_failed", exitProvidersFailed, "getting episodes for %q: %v", r.Title, err)
+	if err != nil || len(eps) == 0 {
+		debugf("play: cannot validate episode against primary (err=%v, episodes=%d); deferring to the resolver", err, len(eps))
+		return nil
 	}
 	for _, e := range eps {
 		if e.Number == episode {

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -34,6 +34,9 @@ func init() {
 	playCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
 	playCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (required for TV)")
 	playCmd.Flags().IntVar(&flagEpisode, "episode", 0, "Episode number (required for TV)")
+	playCmd.Flags().BoolVar(&flagDetach, "detach", false, "Start playback in the background and return immediately")
+	playCmd.Flags().BoolVar(&flagSupervised, "supervised", false, "Internal: marks the background supervisor process")
+	_ = playCmd.Flags().MarkHidden("supervised")
 }
 
 func playRun(cmd *cobra.Command, args []string) error {
@@ -52,6 +55,10 @@ func playRun(cmd *cobra.Command, args []string) error {
 	// it is not supported here.
 	if flagDownload != "" {
 		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
+	}
+
+	if flagDetach && !flagSupervised {
+		return playDetached(cmd, r)
 	}
 
 	// Honor the ref's originating base unless the caller explicitly passed

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -44,7 +44,14 @@ still runs through the fallback chain at play time, so if the original
 source is down another provider's copy may be served.
 
 For a series, both --season and --episode are required; without them playback
-would fall through to the interactive picker and hang.`,
+would fall through to the interactive picker and hang.
+
+Only --detach honours the "stdout is JSON and nothing else" contract. Attached,
+the player inherits this process's stdout — that is deliberate, so a human
+running "lobster play --ref" still sees mpv's own output — but it means the
+player's progress lines are interleaved with the JSON envelope. A caller
+parsing stdout must pass --detach, which redirects the player's output to a log
+file and reports that log's path in the envelope.`,
 	Args: cobra.NoArgs,
 	RunE: playRun,
 }

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -78,6 +78,52 @@ func applyRefBase(cmd *cobra.Command, r playRef) {
 	}
 }
 
+// validateSeasonEpisode confirms the requested season and episode actually
+// exist on p before any playback is dispatched.
+//
+// resolveAndPlay (cmd/search.go) initialises its seasonIdx/episodeIdx to 0 and
+// only overwrites them on an exact Number match, so a request for a season or
+// episode the show does not have fell through to index 0: `play --ref <show>
+// --season 5 --episode 12` against a three-season show played S1E1 and
+// reported success. `episodes` already answers exit 2 for exactly that input,
+// so the two commands contradicted each other about whether a season exists.
+//
+// The distinction between the two failure modes is the point: a season that
+// does not exist is exitNoResults (2) — pick a different number — while a
+// provider that cannot answer is exitProvidersFailed (3) — run doctor. Mapping
+// the second onto the first would tell the agent to fix the user's input when
+// the sources are down.
+func validateSeasonEpisode(p provider.Provider, r playRef, season, episode int) error {
+	seasons, err := p.GetSeasons(r.ID)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "getting seasons for %q: %v", r.Title, err)
+	}
+	seasonID := ""
+	found := false
+	for _, s := range seasons {
+		if s.Number == season {
+			seasonID, found = s.ID, true
+			break
+		}
+	}
+	if !found {
+		return emitErr("no_results", exitNoResults,
+			"season %d not found for %q (list them with 'lobster episodes --ref ...')", season, r.Title)
+	}
+
+	eps, err := p.GetEpisodes(r.ID, seasonID)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "getting episodes for %q: %v", r.Title, err)
+	}
+	for _, e := range eps {
+		if e.Number == episode {
+			return nil
+		}
+	}
+	return emitErr("no_results", exitNoResults,
+		"season %d of %q has no episode %d", season, r.Title, episode)
+}
+
 func playRun(cmd *cobra.Command, args []string) error {
 	r, err := decodeRef(flagRef)
 	if err != nil {
@@ -103,13 +149,27 @@ func playRun(cmd *cobra.Command, args []string) error {
 		return emitErr("player_unavailable", exitPlayerUnavailable, "%s is not installed or not on PATH", name)
 	}
 
+	// Both the base and the season/episode check must precede the --detach
+	// dispatch: the base decides which provider is asked, and a rejection
+	// after the fork would be written into a log the caller has no reason to
+	// read while the parent had already reported success.
+	applyRefBase(cmd, r)
+
+	var p provider.Provider
+	if sel.Type == media.TV {
+		p = agentProvider()
+		if err := validateSeasonEpisode(p, r, flagSeason, flagEpisode); err != nil {
+			return err
+		}
+	}
+
 	if flagDetach && !flagSupervised {
 		return playDetached(cmd, r)
 	}
 
-	applyRefBase(cmd, r)
-
-	var p provider.Provider = agentProvider()
+	if p == nil {
+		p = agentProvider()
+	}
 	if err := agentResolveAndPlay(p, sel, flagSeason, flagEpisode); err != nil {
 		return emitErr("providers_failed", exitProvidersFailed, "%v", err)
 	}

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// agentResolveAndPlay is the playback entry point, as a package var so tests
+// can observe what selection reaches it without launching a player.
+var agentResolveAndPlay = resolveAndPlay
+
+var playCmd = &cobra.Command{
+	Use:   "play --ref <REF>",
+	Short: "Play a ref returned by lobster find (no prompts)",
+	Long: `Play the exact title a ref identifies, without prompting.
+
+The ref pins the selection — title, year, type and originating base. It does
+not pin the stream: resolution still runs through the fallback chain at play
+time, so if the original source is down another provider's copy may be served.
+
+For a series, both --season and --episode are required; without them playback
+would fall through to the interactive picker and hang.`,
+	Args:          cobra.NoArgs,
+	RunE:          playRun,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	playCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
+	playCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (required for TV)")
+	playCmd.Flags().IntVar(&flagEpisode, "episode", 0, "Episode number (required for TV)")
+}
+
+func playRun(cmd *cobra.Command, args []string) error {
+	r, err := decodeRef(flagRef)
+	if err != nil {
+		return emitErr("bad_ref", 1, "%v", err)
+	}
+
+	sel := r.searchResult()
+	if sel.Type == media.TV && (flagSeason <= 0 || flagEpisode <= 0) {
+		return emitErr("season_episode_required", 1,
+			"%q is a series: pass --season and --episode (list them with 'lobster episodes --ref ...')", r.Title)
+	}
+
+	// Downloading walks a different, interactive path (batch range prompts), so
+	// it is not supported here.
+	if flagDownload != "" {
+		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
+	}
+
+	var p provider.Provider = agentProvider()
+	if err := agentResolveAndPlay(p, sel, flagSeason, flagEpisode); err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "%v", err)
+	}
+
+	return emitJSON(map[string]any{
+		"status": "finished",
+		"title":  r.Title,
+	})
+}

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -45,13 +45,12 @@ source is down another provider's copy may be served.
 
 For a series, both --season and --episode are required; without them playback
 would fall through to the interactive picker and hang.`,
-	Args:          cobra.NoArgs,
-	RunE:          playRun,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Args: cobra.NoArgs,
+	RunE: playRun,
 }
 
 func init() {
+	markAgentCommand(playCmd)
 	playCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
 	playCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (required for TV)")
 	playCmd.Flags().IntVar(&flagEpisode, "episode", 0, "Episode number (required for TV)")

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -440,41 +440,55 @@ func TestPlayValidSeasonEpisodeReachesPlayback(t *testing.T) {
 	}
 }
 
-// A provider that cannot answer is exit 3 ("sources are down"), never exit 2
-// ("no such season") — the advice attached to each is different.
-func TestPlaySeasonLookupProviderErrorExitsThree(t *testing.T) {
+// A primary provider that cannot enumerate seasons must NOT be turned into a
+// verdict. resolveAndPlay has a purpose-built branch for exactly this state
+// (cmd/search.go:237, `if err != nil || len(seasons) == 0`) that resolves by
+// title/year/season/episode across the whole fallback chain and plays. A ref
+// whose ID actually came from a fallback provider still carries the primary's
+// base (find stamps cfg.Base on every result), so this is the normal case
+// whenever the primary is degraded — which is this repo's normal state.
+// Validating here must not make that branch unreachable.
+func TestPlaySeasonLookupErrorFallsThroughToResolver(t *testing.T) {
 	p := twoSeasonStub()
-	p.seasonsErr = errors.New("upstream 503")
+	p.seasonsErr = errors.New("unexpected status 404")
 	dispatched := playHarness(t, p, showRef(t), 2, 1)
 
-	err := playRun(playCmd, nil)
-	var ee *exitError
-	if !errors.As(err, &ee) {
-		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun returned %v; a primary that cannot answer must fall through to the resolver's fallback branch, not become a verdict", err)
 	}
-	if ee.code != exitProvidersFailed {
-		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
-	}
-	if *dispatched {
-		t.Fatal("playback was dispatched though the season lookup failed")
+	if !*dispatched {
+		t.Fatal("playback was not dispatched; the resolver's fallback-stream branch is unreachable")
 	}
 }
 
-func TestPlayEpisodeLookupProviderErrorExitsThree(t *testing.T) {
-	p := twoSeasonStub()
-	p.episodesErr = errors.New("upstream 503")
+// The empty list is the same state as the error: cmd/search.go:237 treats
+// `err != nil || len(seasons) == 0` identically, and the old code funnelled
+// the empty case into !found and answered exit 2 — "no such season" for a show
+// whose seasons simply were not enumerable.
+func TestPlayEmptySeasonListFallsThroughToResolver(t *testing.T) {
+	p := &stubProvider{} // GetSeasons returns nil, nil
 	dispatched := playHarness(t, p, showRef(t), 2, 1)
 
-	err := playRun(playCmd, nil)
-	var ee *exitError
-	if !errors.As(err, &ee) {
-		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun returned %v; an empty season list means \"cannot validate\", not \"no such season\"", err)
 	}
-	if ee.code != exitProvidersFailed {
-		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	if !*dispatched {
+		t.Fatal("playback was not dispatched for an unenumerable show")
 	}
-	if *dispatched {
-		t.Fatal("playback was dispatched though the episode lookup failed")
+}
+
+// Same reasoning one level down: an error fetching episodes means the primary
+// cannot answer, so let the resolver decide rather than pre-empting it.
+func TestPlayEpisodeLookupErrorFallsThroughToResolver(t *testing.T) {
+	p := twoSeasonStub()
+	p.episodesErr = errors.New("unexpected status 404")
+	dispatched := playHarness(t, p, showRef(t), 2, 1)
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun returned %v; a failed episode lookup must fall through to the resolver", err)
+	}
+	if !*dispatched {
+		t.Fatal("playback was not dispatched though only the primary's episode lookup failed")
 	}
 }
 

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -200,9 +200,8 @@ func TestPlayAvailablePlayerReachesPlayback(t *testing.T) {
 // withBaseFlag forces the same persistent-flag merge cobra performs before
 // RunE during a real Execute() (see (*cobra.Command).mergePersistentFlags),
 // so that cmd.Flags().Changed("base") reflects reality even though these
-// tests call playRun directly rather than going through Execute(). It
-// returns the shared *pflag.Flag so a test can drive "was --base passed on
-// this invocation" the same way cobra would, and restores its state after.
+// tests call playRun directly rather than going through Execute(), and
+// restores the flag's value and Changed bit afterwards.
 func withBaseFlag(t *testing.T) {
 	t.Helper()
 	withInheritedFlags(t, playCmd, "base")
@@ -341,5 +340,183 @@ func TestPlayLeavesConfigBaseUntouchedWhenRefBaseEmpty(t *testing.T) {
 	}
 	if seenBase != "flixhq.ws" {
 		t.Fatalf("cfg.Base seen by agentProvider = %q, want flixhq.ws (untouched)", seenBase)
+	}
+}
+
+// playHarness wires the seams every season/episode validation test needs: an
+// available player, a stub provider, a recording (non-launching) playback
+// entry point, and the play flags. It returns a pointer to the "did playback
+// run" flag so a test can assert dispatch happened or did not.
+func playHarness(t *testing.T, p *stubProvider, ref string, season, episode int) *bool {
+	t.Helper()
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return p }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	dispatched := false
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		dispatched = true
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
+	flagRef, flagSeason, flagEpisode = ref, season, episode
+	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
+
+	return &dispatched
+}
+
+// showRef builds a TV ref for the validation tests.
+func showRef(t *testing.T) string {
+	t.Helper()
+	ref, err := encodeRef(playRef{ID: "tv/show-1", Title: "Some Show", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	return ref
+}
+
+// resolveAndPlay initialises seasonIdx/episodeIdx to 0 and only overwrites
+// them on an exact Number match, so a season the show does not have silently
+// played S1E1 and reported success. episodes already answers exit 2 for the
+// same input; the two commands must not disagree about whether a season
+// exists.
+func TestPlayUnknownSeasonExitsTwo(t *testing.T) {
+	dispatched := playHarness(t, twoSeasonStub(), showRef(t), 5, 12)
+
+	err := playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+	if *dispatched {
+		t.Fatal("playback was dispatched for a season the show does not have (this is the S1E1 bug)")
+	}
+}
+
+// The same hole exists one level down: a valid season with a non-existent
+// episode played that season's first episode.
+func TestPlayUnknownEpisodeExitsTwo(t *testing.T) {
+	dispatched := playHarness(t, twoSeasonStub(), showRef(t), 2, 12)
+
+	err := playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+	if *dispatched {
+		t.Fatal("playback was dispatched for an episode the season does not have")
+	}
+}
+
+// Validation must not reject what does exist.
+func TestPlayValidSeasonEpisodeReachesPlayback(t *testing.T) {
+	p := twoSeasonStub()
+	dispatched := playHarness(t, p, showRef(t), 2, 2)
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if !*dispatched {
+		t.Fatal("a season and episode that both exist did not reach playback")
+	}
+	if p.lastSeasonID != "s2" {
+		t.Fatalf("validation looked up season %q, want s2", p.lastSeasonID)
+	}
+}
+
+// A provider that cannot answer is exit 3 ("sources are down"), never exit 2
+// ("no such season") — the advice attached to each is different.
+func TestPlaySeasonLookupProviderErrorExitsThree(t *testing.T) {
+	p := twoSeasonStub()
+	p.seasonsErr = errors.New("upstream 503")
+	dispatched := playHarness(t, p, showRef(t), 2, 1)
+
+	err := playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitProvidersFailed {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+	if *dispatched {
+		t.Fatal("playback was dispatched though the season lookup failed")
+	}
+}
+
+func TestPlayEpisodeLookupProviderErrorExitsThree(t *testing.T) {
+	p := twoSeasonStub()
+	p.episodesErr = errors.New("upstream 503")
+	dispatched := playHarness(t, p, showRef(t), 2, 1)
+
+	err := playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitProvidersFailed {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+	if *dispatched {
+		t.Fatal("playback was dispatched though the episode lookup failed")
+	}
+}
+
+// A film has no seasons. Validation must not run for it — a provider whose
+// GetSeasons errors would otherwise turn every movie play into exit 3.
+func TestPlayMovieSkipsSeasonValidation(t *testing.T) {
+	p := &stubProvider{seasonsErr: errors.New("GetSeasons must not be called for a film")}
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "A Film", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	dispatched := playHarness(t, p, ref, 0, 0)
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if !*dispatched {
+		t.Fatal("a movie ref did not reach playback")
+	}
+}
+
+// Validation must happen before the --detach dispatch. Otherwise the parent
+// forks a supervisor, waits one second, and reports success while the child
+// exits 2 into a log the caller has no reason to read. If it did reach
+// playDetached, os.Executable()/exec.Command would run for real (no seam
+// exists) and spawn a process this test does not permit.
+func TestPlayDetachedRejectsUnknownSeasonBeforeSpawning(t *testing.T) {
+	dispatched := playHarness(t, twoSeasonStub(), showRef(t), 5, 1)
+
+	prevD, prevS := flagDetach, flagSupervised
+	flagDetach, flagSupervised = true, false
+	t.Cleanup(func() { flagDetach, flagSupervised = prevD, prevS })
+
+	err := playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+	if *dispatched {
+		t.Fatal("playback was dispatched despite an unknown season")
 	}
 }

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// A TV ref without both season and episode would fall through to the
+// interactive season picker, which hangs. Refuse it with a clear message
+// instead.
+func TestPlayRejectsTVWithoutSeasonAndEpisode(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	ref, err := encodeRef(playRef{ID: "tv/show", Title: "Some Show", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
+	flagRef, flagSeason, flagEpisode = ref, 0, 0
+	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
+
+	if err := playRun(playCmd, nil); err == nil {
+		t.Fatal("playRun accepted a TV ref with no season/episode, want an error")
+	}
+}
+
+// The ref's title and year must reach the playback path. If they are dropped,
+// the resolver searches for "" and ranking collapses — which plays the wrong
+// film rather than failing.
+func TestPlayPassesFullSelectionThrough(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	var got media.SearchResult
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(p provider.Provider, sel media.SearchResult, season, episode int) error {
+		got = sel
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{
+		ID: "movie/watch-the-matrix-19724", Title: "The Matrix", Year: "1999", Type: "movie",
+	})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if got.Title != "The Matrix" {
+		t.Fatalf("Title = %q, want The Matrix", got.Title)
+	}
+	if got.Year != "1999" {
+		t.Fatalf("Year = %q, want 1999 (the resolver ranks on it)", got.Year)
+	}
+	if got.ID != "movie/watch-the-matrix-19724" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+	if got.Type != media.Movie {
+		t.Fatalf("Type = %v, want Movie", got.Type)
+	}
+}
+
+// A total resolution failure is exit 3, so the agent knows to run doctor
+// rather than suggest a spelling fix.
+func TestPlayResolutionFailureExitsThree(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		return fmt.Errorf("all providers failed")
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	err = playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitProvidersFailed {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+}

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -205,13 +205,7 @@ func TestPlayAvailablePlayerReachesPlayback(t *testing.T) {
 // this invocation" the same way cobra would, and restores its state after.
 func withBaseFlag(t *testing.T) {
 	t.Helper()
-	playCmd.InheritedFlags() // side effect: merges rootCmd's persistent flags into playCmd.Flags()
-	f := playCmd.Flags().Lookup("base")
-	if f == nil {
-		t.Fatal("playCmd.Flags().Lookup(\"base\") is nil after merge; --base is not visible through the subcommand")
-	}
-	prevChanged, prevBase := f.Changed, flagBase
-	t.Cleanup(func() { f.Changed, flagBase = prevChanged, prevBase })
+	withInheritedFlags(t, playCmd, "base")
 }
 
 // A ref found under `--base yts` is meaningless resolved against another

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"lobster/internal/config"
 	"lobster/internal/media"
 	"lobster/internal/provider"
 )
@@ -106,5 +107,146 @@ func TestPlayResolutionFailureExitsThree(t *testing.T) {
 	}
 	if ee.code != exitProvidersFailed {
 		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+}
+
+// withBaseFlag forces the same persistent-flag merge cobra performs before
+// RunE during a real Execute() (see (*cobra.Command).mergePersistentFlags),
+// so that cmd.Flags().Changed("base") reflects reality even though these
+// tests call playRun directly rather than going through Execute(). It
+// returns the shared *pflag.Flag so a test can drive "was --base passed on
+// this invocation" the same way cobra would, and restores its state after.
+func withBaseFlag(t *testing.T) {
+	t.Helper()
+	playCmd.InheritedFlags() // side effect: merges rootCmd's persistent flags into playCmd.Flags()
+	f := playCmd.Flags().Lookup("base")
+	if f == nil {
+		t.Fatal("playCmd.Flags().Lookup(\"base\") is nil after merge; --base is not visible through the subcommand")
+	}
+	prevChanged, prevBase := f.Changed, flagBase
+	t.Cleanup(func() { f.Changed, flagBase = prevChanged, prevBase })
+}
+
+// A ref found under `--base yts` is meaningless resolved against another
+// base: the ID's exact-match bonus is provider-specific. play must apply the
+// ref's Base when the user did not explicitly override it on this
+// invocation.
+func TestPlayHonorsRefBaseWhenNotOverridden(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+	withBaseFlag(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	var seenBase string
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		seenBase = cfg.Base
+		return &stubProvider{}
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error { return nil }
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "yts/1", Title: "X", Type: "movie", Base: "yts"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if seenBase != "yts" {
+		t.Fatalf("cfg.Base seen by agentProvider = %q, want yts (the ref's base)", seenBase)
+	}
+}
+
+// An explicit --base on the command line is a deliberate user override and
+// must win over the ref's stored base.
+func TestPlayExplicitBaseFlagOverridesRef(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+	withBaseFlag(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	if err := playCmd.Flags().Set("base", "moviebox"); err != nil {
+		t.Fatalf("Set --base: %v", err)
+	}
+	cfg.Base = "moviebox" // mirrors loadConfig applying the explicit flag
+
+	var seenBase string
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		seenBase = cfg.Base
+		return &stubProvider{}
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error { return nil }
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "yts/1", Title: "X", Type: "movie", Base: "yts"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if seenBase != "moviebox" {
+		t.Fatalf("cfg.Base seen by agentProvider = %q, want moviebox (the explicit --base)", seenBase)
+	}
+}
+
+// A ref with no stored Base (e.g. an older ref, or one built without cfg) must
+// leave cfg.Base exactly as configured.
+func TestPlayLeavesConfigBaseUntouchedWhenRefBaseEmpty(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+	withBaseFlag(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	var seenBase string
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		seenBase = cfg.Base
+		return &stubProvider{}
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error { return nil }
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"}) // no Base
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if seenBase != "flixhq.ws" {
+		t.Fatalf("cfg.Base seen by agentProvider = %q, want flixhq.ws (untouched)", seenBase)
 	}
 }

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -534,3 +534,40 @@ func TestPlayDetachedRejectsUnknownSeasonBeforeSpawning(t *testing.T) {
 		t.Fatal("playback was dispatched despite an unknown season")
 	}
 }
+
+// The decode-time type check, seen from the command: a series ref whose Type
+// was lost must never reach playback. Without it the ref reads as a movie,
+// season/episode are not required, and resolveAndPlay is handed season 0.
+func TestPlayRejectsRefWithUnknownType(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	played := false
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		played = true
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	withStubProvider(t, twoSeasonStub())
+
+	ref, err := encodeRef(playRef{ID: "tv/show-1", Title: "Some Show", Type: ""})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevSeason, prevEpisode := flagRef, flagSeason, flagEpisode
+	flagRef, flagSeason, flagEpisode = ref, 0, 0
+	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevSeason, prevEpisode })
+
+	if err := playRun(playCmd, nil); err == nil {
+		t.Fatal("playRun accepted a ref with no type, want a bad_ref error")
+	}
+	if played {
+		t.Fatal("resolveAndPlay was reached with an untyped ref")
+	}
+}

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -110,6 +110,93 @@ func TestPlayResolutionFailureExitsThree(t *testing.T) {
 	}
 }
 
+// An unavailable configured player must exit 4 (player_unavailable), not 3
+// (providers_failed): the two call for completely different advice ("install
+// mpv" vs. "try again later"). Before the fix, playRun's catch-all mapped
+// every resolveAndPlay error, including player.NotFoundError, to exit 3.
+func TestPlayUnavailablePlayerExitsFour(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	called := false
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return false, "mpv" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	err = playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitPlayerUnavailable {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitPlayerUnavailable)
+	}
+	if called {
+		t.Fatal("playback was dispatched despite the player being reported unavailable")
+	}
+}
+
+// The precondition check must not reject the happy path: an available player
+// still reaches playback normally.
+func TestPlayAvailablePlayerReachesPlayback(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Player: "mpv"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "mpv" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	called := false
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if !called {
+		t.Fatal("playback was not dispatched though the player was reported available")
+	}
+}
+
 // withBaseFlag forces the same persistent-flag merge cobra performs before
 // RunE during a real Execute() (see (*cobra.Command).mergePersistentFlags),
 // so that cmd.Flags().Changed("base") reflects reality even though these
@@ -139,6 +226,10 @@ func TestPlayHonorsRefBaseWhenNotOverridden(t *testing.T) {
 	prevCfg := cfg
 	cfg = &config.Config{Base: "flixhq.ws"}
 	t.Cleanup(func() { cfg = prevCfg })
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
 
 	var seenBase string
 	prevProv := agentProvider
@@ -178,6 +269,10 @@ func TestPlayExplicitBaseFlagOverridesRef(t *testing.T) {
 	prevCfg := cfg
 	cfg = &config.Config{Base: "flixhq.ws"}
 	t.Cleanup(func() { cfg = prevCfg })
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
 
 	if err := playCmd.Flags().Set("base", "moviebox"); err != nil {
 		t.Fatalf("Set --base: %v", err)
@@ -222,6 +317,10 @@ func TestPlayLeavesConfigBaseUntouchedWhenRefBaseEmpty(t *testing.T) {
 	prevCfg := cfg
 	cfg = &config.Config{Base: "flixhq.ws"}
 	t.Cleanup(func() { cfg = prevCfg })
+
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
 
 	var seenBase string
 	prevProv := agentProvider

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -26,9 +26,14 @@ import (
 // It is a hint, not a guarantee. find searches the primary provider *and* the
 // fallback chain (gatherSearchResults), and stamps cfg.Base on every result it
 // prints, so a result that actually came from a fallback provider carries the
-// primary's base. Nothing downstream depends on the stamp being exact:
-// resolution re-searches by title through the whole chain regardless, and the
-// base only decides where it starts.
+// primary's base. It cannot be made exact either: most fallback providers are
+// not addressable as a --base value at all (newProvider, cmd/provider.go).
+//
+// So nothing downstream may assume the ID resolves against the base, and
+// nothing does. play re-searches by title through the whole chain
+// (resolveAndPlay, cmd/search.go) and episodes does the same via seasonSource
+// (cmd/episodes.go) when the base's provider cannot enumerate the ID. The base
+// only decides where that search starts.
 type playRef struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
@@ -63,13 +68,25 @@ func decodeRef(s string) (playRef, error) {
 	if r.ID == "" || r.Title == "" {
 		return playRef{}, fmt.Errorf("ref is missing id or title")
 	}
+	// Type decides whether play requires --season/--episode, and searchResult
+	// maps everything that is not "tv" onto media.Movie. So an empty or
+	// misspelled type does not fail: a series reads as a film, the
+	// season/episode gate in playRun does not fire, and resolveAndPlay is
+	// entered with season 0 — the interactive-picker path these commands exist
+	// to avoid. Only the two canonical MediaType.String() values are accepted,
+	// and exactly as encodeRef writes them: a ref is machine-produced and
+	// opaque, so "TV" is a corrupted token, not a human typing.
+	if r.Type != media.Movie.String() && r.Type != media.TV.String() {
+		return playRef{}, fmt.Errorf("ref has unknown type %q (want %q or %q)",
+			r.Type, media.Movie.String(), media.TV.String())
+	}
 	return r, nil
 }
 
 // searchResult converts a ref back into the value the playback path expects.
 func (r playRef) searchResult() media.SearchResult {
 	t := media.Movie
-	if r.Type == "tv" {
+	if r.Type == media.TV.String() {
 		t = media.TV
 	}
 	return media.SearchResult{

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"lobster/internal/media"
+)
+
+// playRef is everything needed to replay a selection the user confirmed.
+//
+// An ID alone is not enough. media.SearchResult.ID is provider-specific
+// (internal/media/types.go), and the resolver re-searches by title on every
+// fallback provider — resolveWithProvider calls p.Search(req.Title), and its
+// doc comment states that IDs are not portable across providers. Without Title
+// and Year the provider is asked to Search("") and ranking collapses, which
+// does not fail loudly: it plays the wrong film.
+//
+// Base is carried because the primary provider is flag/config-selected, and an
+// ID found under --base yts is meaningless under the default base.
+type playRef struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Year  string `json:"year,omitempty"`
+	Type  string `json:"type"`
+	Base  string `json:"base,omitempty"`
+}
+
+// encodeRef renders a ref as a base64url token. Opaque by contract, but plain
+// base64 so it can be decoded by hand during support.
+func encodeRef(r playRef) (string, error) {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", fmt.Errorf("encoding ref: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// decodeRef parses a token produced by encodeRef.
+func decodeRef(s string) (playRef, error) {
+	if s == "" {
+		return playRef{}, fmt.Errorf("empty ref")
+	}
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return playRef{}, fmt.Errorf("ref is not valid base64url: %w", err)
+	}
+	var r playRef
+	if err := json.Unmarshal(b, &r); err != nil {
+		return playRef{}, fmt.Errorf("ref is not valid JSON: %w", err)
+	}
+	if r.ID == "" || r.Title == "" {
+		return playRef{}, fmt.Errorf("ref is missing id or title")
+	}
+	return r, nil
+}
+
+// searchResult converts a ref back into the value the playback path expects.
+func (r playRef) searchResult() media.SearchResult {
+	t := media.Movie
+	if r.Type == "tv" {
+		t = media.TV
+	}
+	return media.SearchResult{
+		ID:    r.ID,
+		Title: r.Title,
+		Year:  r.Year,
+		Type:  t,
+	}
+}

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -26,8 +26,12 @@ import (
 // It is a hint, not a guarantee. find searches the primary provider *and* the
 // fallback chain (gatherSearchResults), and stamps cfg.Base on every result it
 // prints, so a result that actually came from a fallback provider carries the
-// primary's base. It cannot be made exact either: most fallback providers are
-// not addressable as a --base value at all (newProvider, cmd/provider.go).
+// primary's base. Making it exact would not help. A base is a config-time
+// choice of *primary* provider, not a per-row attribution, and by the time
+// find prints a row that row may not come from one provider at all:
+// deduplicateResults (cmd/multisearch.go) merges duplicates across providers,
+// keeping the first arrival's ID while filling its metadata gaps from the
+// others. There is no single honest base to stamp on the merged row.
 //
 // So nothing downstream may assume the ID resolves against the base, and
 // nothing does. play re-searches by title through the whole chain

--- a/cmd/ref.go
+++ b/cmd/ref.go
@@ -17,8 +17,18 @@ import (
 // and Year the provider is asked to Search("") and ranking collapses, which
 // does not fail loudly: it plays the wrong film.
 //
-// Base is carried because the primary provider is flag/config-selected, and an
-// ID found under --base yts is meaningless under the default base.
+// Base records the base that was *configured* when the ref was produced, not
+// necessarily the provider that supplied the ID. It is carried because the
+// primary provider is flag/config-selected, and an ID found under --base yts
+// is meaningless under the default base — so replaying the same base is a much
+// better starting point than whatever happens to be configured later.
+//
+// It is a hint, not a guarantee. find searches the primary provider *and* the
+// fallback chain (gatherSearchResults), and stamps cfg.Base on every result it
+// prints, so a result that actually came from a fallback provider carries the
+// primary's base. Nothing downstream depends on the stamp being exact:
+// resolution re-searches by title through the whole chain regardless, and the
+// base only decides where it starts.
 type playRef struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`

--- a/cmd/ref_test.go
+++ b/cmd/ref_test.go
@@ -63,3 +63,34 @@ func TestRefSearchResultMapsType(t *testing.T) {
 		t.Fatalf("movie mapped to %v, want media.Movie", got)
 	}
 }
+
+// A ref whose Type is empty or unrecognised must be rejected at decode time.
+//
+// searchResult() maps everything that is not "tv" onto media.Movie, so a
+// truncated or hand-edited ref for a series arrives at playRun looking like a
+// film: the "--season and --episode are required" gate does not fire, and the
+// selection is handed to resolveAndPlay with season 0, which is precisely the
+// path that falls through to the interactive picker this whole command set
+// exists to avoid. Failing loudly on the token is the only place the mistake
+// is still cheap.
+func TestDecodeRefRejectsUnknownType(t *testing.T) {
+	for _, typ := range []string{"", "series", "TV", "Movie", "film"} {
+		tok, err := encodeRef(playRef{ID: "x", Title: "T", Type: typ})
+		if err != nil {
+			t.Fatalf("encodeRef(%q): %v", typ, err)
+		}
+		if _, err := decodeRef(tok); err == nil {
+			t.Errorf("decodeRef accepted type %q, want an error", typ)
+		}
+	}
+	// The two canonical values must still round-trip.
+	for _, typ := range []string{media.Movie.String(), media.TV.String()} {
+		tok, err := encodeRef(playRef{ID: "x", Title: "T", Type: typ})
+		if err != nil {
+			t.Fatalf("encodeRef(%q): %v", typ, err)
+		}
+		if _, err := decodeRef(tok); err != nil {
+			t.Errorf("decodeRef rejected canonical type %q: %v", typ, err)
+		}
+	}
+}

--- a/cmd/ref_test.go
+++ b/cmd/ref_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// A ref must survive the round trip intact. It is the only handle the agent
+// has on a selection the user confirmed, so any field loss means playing
+// something other than what was agreed.
+func TestRefRoundTrip(t *testing.T) {
+	want := playRef{
+		ID:    "movie/watch-the-matrix-19724",
+		Title: "The Matrix",
+		Year:  "1999",
+		Type:  "movie",
+		Base:  "flixhq.ws",
+	}
+	tok, err := encodeRef(want)
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	got, err := decodeRef(tok)
+	if err != nil {
+		t.Fatalf("decodeRef: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip lost data:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// A hand-mangled ref must produce a clean error, not a panic.
+func TestDecodeRefRejectsGarbage(t *testing.T) {
+	for _, in := range []string{"", "!!!not-base64!!!", "YWJj"} { // "abc" is valid b64, invalid JSON
+		if _, err := decodeRef(in); err == nil {
+			t.Fatalf("decodeRef(%q) succeeded, want an error", in)
+		}
+	}
+}
+
+// Year is a string throughout media.SearchResult and is frequently empty;
+// the ref must preserve that rather than inventing a zero year.
+func TestRefPreservesEmptyYear(t *testing.T) {
+	tok, err := encodeRef(playRef{ID: "x", Title: "T", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	got, err := decodeRef(tok)
+	if err != nil {
+		t.Fatalf("decodeRef: %v", err)
+	}
+	if got.Year != "" {
+		t.Fatalf("Year = %q, want empty", got.Year)
+	}
+}
+
+func TestRefSearchResultMapsType(t *testing.T) {
+	if got := (playRef{Type: "tv"}).searchResult().Type; got != media.TV {
+		t.Fatalf("tv mapped to %v, want media.TV", got)
+	}
+	if got := (playRef{Type: "movie"}).searchResult().Type; got != media.Movie {
+		t.Fatalf("movie mapped to %v, want media.Movie", got)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -45,6 +46,12 @@ Search for movies and TV shows, stream them with mpv/vlc, or download with ffmpe
 // Execute runs the root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		// Agent commands have already written a JSON error envelope to stdout
+		// and carry their own exit code; printing again would corrupt it.
+		var ee *exitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.code)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
 
 	rootCmd.AddCommand(doctorCmd)
+	rootCmd.AddCommand(findCmd)
 	rootCmd.AddCommand(historyCmd)
 	rootCmd.AddCommand(trendingCmd)
 	rootCmd.AddCommand(recentCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ func init() {
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(findCmd)
 	rootCmd.AddCommand(episodesCmd)
+	rootCmd.AddCommand(playCmd)
 	rootCmd.AddCommand(historyCmd)
 	rootCmd.AddCommand(trendingCmd)
 	rootCmd.AddCommand(recentCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,8 +79,24 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
-// loadConfig loads and merges configuration: defaults < config file < CLI flags.
+// loadConfig is the root's PersistentPreRunE, so it runs for the interactive
+// commands and the agent commands alike. The two need different failure
+// reporting: an interactive user gets cobra's "Error: ..." on stderr, while an
+// agent command must produce the JSON envelope its caller parses
+// unconditionally — and, because SilenceErrors is set there, a bare error
+// would otherwise vanish entirely.
 func loadConfig(cmd *cobra.Command, args []string) error {
+	if err := applyConfig(); err != nil {
+		if isAgentCommand(cmd) {
+			return emitErr("config_invalid", exitUsage, "%v", err)
+		}
+		return err
+	}
+	return nil
+}
+
+// applyConfig loads and merges configuration: defaults < config file < CLI flags.
+func applyConfig() error {
 	var err error
 	cfg, err = config.Load()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ func init() {
 
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(findCmd)
+	rootCmd.AddCommand(episodesCmd)
 	rootCmd.AddCommand(historyCmd)
 	rootCmd.AddCommand(trendingCmd)
 	rootCmd.AddCommand(recentCmd)

--- a/docs/superpowers/plans/2026-09-03-agent-play-skill.md
+++ b/docs/superpowers/plans/2026-09-03-agent-play-skill.md
@@ -800,6 +800,16 @@ func findRun(cmd *cobra.Command, args []string) error {
 }
 ```
 
+Note on `Base`, added after review: this block stamps the *configured* base on
+every result, including ones the fallback chain supplied, whose IDs belong to a
+different provider. That stamp is a starting point for resolution, not an
+attribution, and it cannot be made exact — most fallback providers are not
+addressable as a `--base` value at all (`newProvider`, `cmd/provider.go`). What
+matters is that no consumer of a ref may assume its ID resolves against the
+primary: `play` re-searches by title through the whole chain (`resolveAndPlay`,
+`cmd/search.go`) and `episodes` does the same via `seasonSource`
+(`cmd/episodes.go`) when the primary cannot enumerate the ref's ID. See Task 4.
+
 Note the import block above deliberately omits `lobster/internal/provider`:
 `newProvider()` and `fallbackSearchProviders()` are used through type
 inference, so the package is never named in this file. Importing it would fail

--- a/docs/superpowers/plans/2026-09-03-agent-play-skill.md
+++ b/docs/superpowers/plans/2026-09-03-agent-play-skill.md
@@ -1626,11 +1626,16 @@ package cmd
 
 import "syscall"
 
+// detachedProcess is Win32's DETACHED_PROCESS creation flag. Go's syscall
+// package exports CREATE_NEW_PROCESS_GROUP but not this one, so it is spelled
+// out here rather than left as a bare literal at the call site.
+const detachedProcess = 0x00000008
+
 // detachSpawnAttr detaches the supervisor from the console so it survives the
 // agent's shell exiting. Setpgid does not exist on Windows.
 func detachSpawnAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | 0x00000008, // DETACHED_PROCESS
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess,
 	}
 }
 ```

--- a/docs/superpowers/plans/2026-09-03-agent-play-skill.md
+++ b/docs/superpowers/plans/2026-09-03-agent-play-skill.md
@@ -803,9 +803,12 @@ func findRun(cmd *cobra.Command, args []string) error {
 Note on `Base`, added after review: this block stamps the *configured* base on
 every result, including ones the fallback chain supplied, whose IDs belong to a
 different provider. That stamp is a starting point for resolution, not an
-attribution, and it cannot be made exact — most fallback providers are not
-addressable as a `--base` value at all (`newProvider`, `cmd/provider.go`). What
-matters is that no consumer of a ref may assume its ID resolves against the
+attribution. Making it exact would not help: a base is a config-time choice of
+*primary* provider, and by the time this loop runs a row may not come from a
+single provider at all — `deduplicateResults` (`cmd/multisearch.go`) merges
+duplicates across providers, keeping the first arrival's ID and filling its
+metadata gaps from the others, so there is no one honest base to stamp on the
+merged row. What matters is that no consumer of a ref may assume its ID resolves against the
 primary: `play` re-searches by title through the whole chain (`resolveAndPlay`,
 `cmd/search.go`) and `episodes` does the same via `seasonSource`
 (`cmd/episodes.go`) when the primary cannot enumerate the ref's ID. See Task 4.

--- a/docs/superpowers/plans/2026-09-03-agent-play-skill.md
+++ b/docs/superpowers/plans/2026-09-03-agent-play-skill.md
@@ -186,12 +186,16 @@ func (e *exitError) Error() string { return e.err.Error() }
 func (e *exitError) Unwrap() error { return e.err }
 
 // emitJSON writes one payload to stdout with the schema marker attached.
+//
+// The schema is set after the payload is copied, not before: a caller passing
+// a key named "schema" must not be able to override it, or the contract holds
+// only by convention.
 func emitJSON(payload map[string]any) error {
 	out := make(map[string]any, len(payload)+1)
-	out["schema"] = agentSchema
 	for k, v := range payload {
 		out[k] = v
 	}
+	out["schema"] = agentSchema
 	enc := json.NewEncoder(agentOut)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)

--- a/docs/superpowers/plans/2026-09-03-agent-play-skill.md
+++ b/docs/superpowers/plans/2026-09-03-agent-play-skill.md
@@ -1,0 +1,2091 @@
+# Agent-Driven Playback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a non-interactive CLI surface (`find`, `episodes`, `play`) plus a `lobster-play` agent skill, so a user can ask their coding agent to find and play a movie or TV episode.
+
+**Architecture:** Three new Cobra subcommands emit JSON on stdout and never touch `fzf`. Selections round-trip through an opaque base64url `--ref` token carrying id/title/year/type/base, because provider IDs are not portable and the resolver re-searches by title. `play --detach` re-executes lobster as a background supervisor so the HLS proxy, torrent server and subtitle temp dir outlive the foreground process.
+
+**Tech Stack:** Go 1.25, Cobra, standard library only for the new code (`encoding/json`, `encoding/base64`, `os/exec`, `syscall`).
+
+## Global Constraints
+
+- Build with `CGO_ENABLED=0`. Go toolchain lives at `/usr/local/go/bin`.
+- Before every commit: `CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...` must all pass.
+- Do **not** add `Co-Authored-By` trailers to commits.
+- Tests must make **no live network calls**. Follow the `TestMain` stubbing pattern in `cmd/fallback_providers_test.go`.
+- CI runs ubuntu-latest, windows-latest and macos-latest (`.github/workflows/ci.yml`). Any `syscall.SysProcAttr` use must be behind build tags, following the existing `ipc_windows.go` / `fzf_path_windows.go` pattern.
+- `schema` value is `1` in every JSON payload.
+- Do not modify existing command behaviour. `lobster`, `lobster <query>`, `trending`, `recent`, `history` and `doctor` must work exactly as they do today.
+- Work happens in the worktree `/tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill` on branch `feat/agent-play-skill`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| ---- | -------------- |
+| `cmd/agentjson.go` | JSON envelope writer, `exitError` type, exit-code mapping |
+| `cmd/agentjson_test.go` | Envelope shape, error envelope, exit codes |
+| `cmd/ref.go` | `ref` struct, encode/decode, conversion to `media.SearchResult` |
+| `cmd/ref_test.go` | Round-trip, malformed input |
+| `cmd/agenthelp_test.go` | Shared test helpers: hostile environment, stub provider |
+| `cmd/find.go` | `lobster find` |
+| `cmd/find_test.go` | find behaviour under hostile environment |
+| `cmd/episodes.go` | `lobster episodes` |
+| `cmd/episodes_test.go` | episodes behaviour |
+| `cmd/play.go` | `lobster play` (attached path) + `newPlayer` seam wiring |
+| `cmd/play_test.go` | play validation, exit codes |
+| `cmd/detach.go` | Supervisor arg construction, liveness wait, log path |
+| `cmd/detach_unix.go` | `Setpgid` spawn attrs (build tag `!windows`) |
+| `cmd/detach_windows.go` | `CREATE_NEW_PROCESS_GROUP|DETACHED_PROCESS` spawn attrs |
+| `cmd/detach_test.go` | Arg construction and liveness logic |
+| `skills/lobster-play/SKILL.md` | The agent skill |
+| `README.md` | Install instructions for the skill (modify) |
+
+**Key reuse:** `resolveAndPlay(p, selected, season, episode)` at `cmd/search.go:223` is already non-interactive for movies, and for TV when `season > 0 && episode > 0` and `flagDownload == ""`. The four blocking calls (`cmd/search.go:279,290,351,364`) are all in `else` branches. `play` calls it directly rather than reimplementing playback.
+
+---
+
+### Task 1: JSON envelope and exit codes
+
+**Files:**
+- Create: `cmd/agentjson.go`
+- Create: `cmd/agentjson_test.go`
+- Modify: `cmd/root.go:44-48` (`Execute`)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces:
+  - `func emitJSON(payload map[string]any) error`
+  - `func emitErr(code string, exit int, format string, a ...any) error` — writes the error envelope to stdout and returns `*exitError`
+  - `type exitError struct { code int; err error }` with `Error() string` and `Unwrap() error`
+  - Constants `exitNoResults = 2`, `exitProvidersFailed = 3`, `exitPlayerUnavailable = 4`
+  - `var agentOut io.Writer = os.Stdout` (test seam)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/agentjson_test.go`:
+
+```go
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// captureAgentOut redirects the agent JSON writer to a buffer for the test.
+func captureAgentOut(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := agentOut
+	agentOut = &buf
+	t.Cleanup(func() { agentOut = prev })
+	return &buf
+}
+
+func TestEmitJSONCarriesSchema(t *testing.T) {
+	buf := captureAgentOut(t)
+	if err := emitJSON(map[string]any{"results": []any{}}); err != nil {
+		t.Fatalf("emitJSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got["schema"] != float64(1) {
+		t.Fatalf("schema = %v, want 1", got["schema"])
+	}
+}
+
+// Errors must be machine-readable on stdout too, so an agent can parse
+// unconditionally instead of guessing whether a run produced JSON.
+func TestEmitErrWritesEnvelopeAndCarriesExitCode(t *testing.T) {
+	buf := captureAgentOut(t)
+	err := emitErr("no_results", exitNoResults, "nothing matched %q", "the matirx")
+
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("emitErr returned %T, want *exitError", err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+
+	var got struct {
+		Schema int `json:"schema"`
+		Error  struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("error output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if got.Error.Code != "no_results" {
+		t.Fatalf("code = %q, want no_results", got.Error.Code)
+	}
+	if got.Error.Message != `nothing matched "the matirx"` {
+		t.Fatalf("message = %q", got.Error.Message)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestEmit' -v`
+
+Expected: FAIL to build — `undefined: agentOut`, `undefined: emitJSON`, `undefined: emitErr`, `undefined: exitError`, `undefined: exitNoResults`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/agentjson.go`:
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// agentSchema versions the machine-readable contract. A skill written against a
+// different lobster can detect the mismatch instead of silently misparsing.
+const agentSchema = 1
+
+// Exit codes for the agent-facing commands. 2 and 3 are deliberately distinct:
+// "no such title" and "the title exists but every source is down" call for
+// completely different advice, and on this repo the latter is the common one.
+const (
+	exitNoResults         = 2
+	exitProvidersFailed   = 3
+	exitPlayerUnavailable = 4
+)
+
+// agentOut is where JSON payloads go. A package var so tests can capture them
+// without touching the real stdout.
+var agentOut io.Writer = os.Stdout
+
+// exitError carries a process exit code up to Execute. The JSON envelope has
+// already been written by the time this is returned, so Execute must not print
+// it again.
+type exitError struct {
+	code int
+	err  error
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+func (e *exitError) Unwrap() error { return e.err }
+
+// emitJSON writes one payload to stdout with the schema marker attached.
+func emitJSON(payload map[string]any) error {
+	out := make(map[string]any, len(payload)+1)
+	out["schema"] = agentSchema
+	for k, v := range payload {
+		out[k] = v
+	}
+	enc := json.NewEncoder(agentOut)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// emitErr writes the error envelope and returns an *exitError carrying the
+// process exit code.
+func emitErr(code string, exit int, format string, a ...any) error {
+	msg := fmt.Sprintf(format, a...)
+	_ = emitJSON(map[string]any{
+		"error": map[string]any{"code": code, "message": msg},
+	})
+	return &exitError{code: exit, err: fmt.Errorf("%s: %s", code, msg)}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestEmit' -v`
+
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Wire the exit code into Execute**
+
+Replace `Execute` in `cmd/root.go:44-48` with:
+
+```go
+// Execute runs the root command.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		// Agent commands have already written a JSON error envelope to stdout
+		// and carry their own exit code; printing again would corrupt it.
+		var ee *exitError
+		if errors.As(err, &ee) {
+			os.Exit(ee.code)
+		}
+		os.Exit(1)
+	}
+}
+```
+
+Add `"errors"` to the import block in `cmd/root.go`.
+
+Note: `SilenceErrors`/`SilenceUsage` are **not** set on the root command — that would change how errors look for existing human commands. They are set per-subcommand in Tasks 3-5.
+
+- [ ] **Step 6: Verify the whole suite still passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...`
+
+Expected: all packages ok, no failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/agentjson.go cmd/agentjson_test.go cmd/root.go
+git commit -m "feat(agent): JSON envelope and exit codes for machine-readable output
+
+Errors go to stdout as JSON too, so an agent can parse unconditionally
+rather than guessing whether a run produced JSON. Exit codes 2 and 3 are
+distinct because 'no such title' and 'every source is down' need
+different advice, and the latter is the common case on this repo.
+
+Execute now honours an exitError's code. SilenceErrors is deliberately
+not set on the root command; it is set per-subcommand so existing human
+commands keep their current error output."
+```
+
+---
+
+### Task 2: The `ref` replay token
+
+**Files:**
+- Create: `cmd/ref.go`
+- Create: `cmd/ref_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 (`emitErr`, `exitNoResults`)
+- Produces:
+  - `type playRef struct { ID, Title, Year, Type, Base string }`
+  - `func encodeRef(r playRef) (string, error)`
+  - `func decodeRef(s string) (playRef, error)`
+  - `func (r playRef) searchResult() media.SearchResult`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/ref_test.go`:
+
+```go
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// A ref must survive the round trip intact. It is the only handle the agent
+// has on a selection the user confirmed, so any field loss means playing
+// something other than what was agreed.
+func TestRefRoundTrip(t *testing.T) {
+	want := playRef{
+		ID:    "movie/watch-the-matrix-19724",
+		Title: "The Matrix",
+		Year:  "1999",
+		Type:  "movie",
+		Base:  "flixhq.ws",
+	}
+	tok, err := encodeRef(want)
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	got, err := decodeRef(tok)
+	if err != nil {
+		t.Fatalf("decodeRef: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round trip lost data:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// A hand-mangled ref must produce a clean error, not a panic.
+func TestDecodeRefRejectsGarbage(t *testing.T) {
+	for _, in := range []string{"", "!!!not-base64!!!", "YWJj"} { // "abc" is valid b64, invalid JSON
+		if _, err := decodeRef(in); err == nil {
+			t.Fatalf("decodeRef(%q) succeeded, want an error", in)
+		}
+	}
+}
+
+// Year is a string throughout media.SearchResult and is frequently empty;
+// the ref must preserve that rather than inventing a zero year.
+func TestRefPreservesEmptyYear(t *testing.T) {
+	tok, err := encodeRef(playRef{ID: "x", Title: "T", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	got, err := decodeRef(tok)
+	if err != nil {
+		t.Fatalf("decodeRef: %v", err)
+	}
+	if got.Year != "" {
+		t.Fatalf("Year = %q, want empty", got.Year)
+	}
+}
+
+func TestRefSearchResultMapsType(t *testing.T) {
+	if got := (playRef{Type: "tv"}).searchResult().Type; got != media.TV {
+		t.Fatalf("tv mapped to %v, want media.TV", got)
+	}
+	if got := (playRef{Type: "movie"}).searchResult().Type; got != media.Movie {
+		t.Fatalf("movie mapped to %v, want media.Movie", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestRef|TestDecodeRef' -v`
+
+Expected: FAIL to build — `undefined: playRef`, `undefined: encodeRef`, `undefined: decodeRef`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/ref.go`:
+
+```go
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"lobster/internal/media"
+)
+
+// playRef is everything needed to replay a selection the user confirmed.
+//
+// An ID alone is not enough. media.SearchResult.ID is provider-specific
+// (internal/media/types.go), and the resolver re-searches by title on every
+// fallback provider — resolveWithProvider calls p.Search(req.Title), and its
+// doc comment states that IDs are not portable across providers. Without Title
+// and Year the provider is asked to Search("") and ranking collapses, which
+// does not fail loudly: it plays the wrong film.
+//
+// Base is carried because the primary provider is flag/config-selected, and an
+// ID found under --base yts is meaningless under the default base.
+type playRef struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Year  string `json:"year,omitempty"`
+	Type  string `json:"type"`
+	Base  string `json:"base,omitempty"`
+}
+
+// encodeRef renders a ref as a base64url token. Opaque by contract, but plain
+// base64 so it can be decoded by hand during support.
+func encodeRef(r playRef) (string, error) {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", fmt.Errorf("encoding ref: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// decodeRef parses a token produced by encodeRef.
+func decodeRef(s string) (playRef, error) {
+	if s == "" {
+		return playRef{}, fmt.Errorf("empty ref")
+	}
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return playRef{}, fmt.Errorf("ref is not valid base64url: %w", err)
+	}
+	var r playRef
+	if err := json.Unmarshal(b, &r); err != nil {
+		return playRef{}, fmt.Errorf("ref is not valid JSON: %w", err)
+	}
+	if r.ID == "" || r.Title == "" {
+		return playRef{}, fmt.Errorf("ref is missing id or title")
+	}
+	return r, nil
+}
+
+// searchResult converts a ref back into the value the playback path expects.
+func (r playRef) searchResult() media.SearchResult {
+	t := media.Movie
+	if r.Type == "tv" {
+		t = media.TV
+	}
+	return media.SearchResult{
+		ID:    r.ID,
+		Title: r.Title,
+		Year:  r.Year,
+		Type:  t,
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestRef|TestDecodeRef' -v`
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/ref.go cmd/ref_test.go
+git commit -m "feat(agent): opaque ref token for replaying a confirmed selection
+
+An ID alone cannot replay a selection. Provider IDs are not portable
+(internal/media/types.go:25) and the resolver re-searches by title
+(internal/resolver/probe.go:84), so a bare ID leaves Title and Year empty
+and ranking collapses to Search(\"\") — which plays the wrong film rather
+than failing.
+
+The ref carries id, title, year, type and base. Base matters because an
+ID found under --base yts is meaningless under the default base."
+```
+
+---
+
+### Task 3: Shared test helpers and `lobster find`
+
+**Files:**
+- Create: `cmd/agenthelp_test.go`
+- Create: `cmd/find.go`
+- Create: `cmd/find_test.go`
+- Modify: `cmd/root.go` (register `findCmd` in `init`)
+
+**Interfaces:**
+- Consumes: Task 1 (`emitJSON`, `emitErr`, `exitNoResults`), Task 2 (`encodeRef`, `playRef`)
+- Produces:
+  - `var findCmd *cobra.Command`
+  - `func hostileEnv(t *testing.T)` — test helper: closed stdin + an `fzf` shim on PATH that fails the test if executed
+  - `type stubProvider struct { results []media.SearchResult; seasons []media.Season; episodes []media.Episode }` implementing `provider.Provider`
+  - `var agentSearch = gatherSearchResults` — test seam
+
+- [ ] **Step 1: Write the shared test helpers**
+
+Create `cmd/agenthelp_test.go`:
+
+```go
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// hostileEnv makes any attempt to prompt the user fail the test rather than
+// hang it. Injecting ui.Select alone is not enough: ui.Input execs fzf
+// directly, ui.SelectWithTimeout reads os.Stdin raw before reaching Select,
+// and tui.StartApp is Bubble Tea rather than fzf. Closing stdin and shimming
+// fzf on PATH catches all of those, including any added later.
+func hostileEnv(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shim relies on a POSIX shell; the guarantee is covered on unix CI")
+	}
+
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "fzf")
+	script := "#!/bin/sh\necho 'fzf was invoked by a non-interactive command' >&2\nexit 97\n"
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fzf shim: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	w.Close() // reads return EOF immediately instead of blocking
+	prev := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = prev
+		r.Close()
+	})
+}
+
+// stubProvider is a provider.Provider that answers from fixed data and never
+// touches the network.
+type stubProvider struct {
+	results  []media.SearchResult
+	seasons  []media.Season
+	episodes []media.Episode
+	searchErr error
+}
+
+func (s *stubProvider) Search(string) ([]media.SearchResult, error) {
+	return s.results, s.searchErr
+}
+func (s *stubProvider) GetDetails(string) (*media.ContentDetail, error) {
+	return &media.ContentDetail{}, nil
+}
+func (s *stubProvider) GetSeasons(string) ([]media.Season, error) { return s.seasons, nil }
+func (s *stubProvider) GetEpisodes(string, string) ([]media.Episode, error) {
+	return s.episodes, nil
+}
+func (s *stubProvider) GetServers(string, string) ([]media.Server, error) {
+	return []media.Server{{ID: "srv1", Name: "stub"}}, nil
+}
+func (s *stubProvider) GetEmbedURL(string) (string, error) { return "https://example.invalid/e", nil }
+func (s *stubProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
+	return s.results, nil
+}
+func (s *stubProvider) Recent(media.MediaType) ([]media.SearchResult, error) {
+	return s.results, nil
+}
+```
+
+- [ ] **Step 2: Write the failing test for find**
+
+Create `cmd/find_test.go`:
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// find must complete without ever prompting. This is the whole point of the
+// command: an agent that hits fzf hangs until it is killed.
+func TestFindEmitsResultsWithoutPrompting(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevSearch := agentSearch
+	agentSearch = func(primary provider.Provider, fallbacks []provider.Provider, query string) ([]media.SearchResult, error) {
+		return []media.SearchResult{
+			{ID: "movie/watch-the-matrix-19724", Title: "The Matrix", Year: "1999", Type: media.Movie},
+			{ID: "movie/watch-the-matrix-reloaded-19725", Title: "The Matrix Reloaded", Year: "2003", Type: media.Movie},
+		}, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	if err := findRun(findCmd, []string{"the matrix"}); err != nil {
+		t.Fatalf("findRun: %v", err)
+	}
+
+	var got struct {
+		Schema  int `json:"schema"`
+		Results []struct {
+			Idx   int    `json:"idx"`
+			Ref   string `json:"ref"`
+			Title string `json:"title"`
+			Year  string `json:"year"`
+			Type  string `json:"type"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, buf.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("got %d results, want 2", len(got.Results))
+	}
+	if got.Results[0].Title != "The Matrix" || got.Results[0].Year != "1999" {
+		t.Fatalf("first result = %+v", got.Results[0])
+	}
+	if got.Results[0].Type != "movie" {
+		t.Fatalf("type = %q, want movie", got.Results[0].Type)
+	}
+
+	// The ref must decode back to the same selection, including the base.
+	ref, err := decodeRef(got.Results[0].Ref)
+	if err != nil {
+		t.Fatalf("emitted ref does not decode: %v", err)
+	}
+	if ref.ID != "movie/watch-the-matrix-19724" || ref.Title != "The Matrix" {
+		t.Fatalf("ref = %+v", ref)
+	}
+	if ref.Base != "flixhq.ws" {
+		t.Fatalf("ref.Base = %q, want flixhq.ws", ref.Base)
+	}
+}
+
+// No results is a distinct, recoverable outcome and must not be conflated with
+// "every provider is down".
+func TestFindNoResultsExitsTwo(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevSearch := agentSearch
+	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	err := findRun(findCmd, []string{"zzzznotathing"})
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("findRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitNoResults {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitNoResults)
+	}
+}
+
+func TestFindLimitTruncates(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevCfg := cfg
+	cfg = &config.Config{Base: "flixhq.ws"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevSearch := agentSearch
+	agentSearch = func(provider.Provider, []provider.Provider, string) ([]media.SearchResult, error) {
+		return []media.SearchResult{
+			{ID: "a", Title: "A", Type: media.Movie},
+			{ID: "b", Title: "B", Type: media.Movie},
+			{ID: "c", Title: "C", Type: media.Movie},
+		}, nil
+	}
+	t.Cleanup(func() { agentSearch = prevSearch })
+
+	prevLimit := flagFindLimit
+	flagFindLimit = 2
+	t.Cleanup(func() { flagFindLimit = prevLimit })
+
+	if err := findRun(findCmd, []string{"x"}); err != nil {
+		t.Fatalf("findRun: %v", err)
+	}
+	var got struct {
+		Results []struct{} `json:"results"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if len(got.Results) != 2 {
+		t.Fatalf("got %d results, want 2 (limit)", len(got.Results))
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestFind' -v`
+
+Expected: FAIL to build — `undefined: findCmd`, `undefined: findRun`, `undefined: agentSearch`, `undefined: flagFindLimit`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `cmd/find.go`:
+
+```go
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"lobster/internal/media"
+)
+
+var (
+	flagFindType  string
+	flagFindLimit int
+)
+
+// agentSearch is the search entry point, as a package var so tests can supply
+// fixed results instead of reaching the network.
+var agentSearch = gatherSearchResults
+
+var findCmd = &cobra.Command{
+	Use:   "find <query>",
+	Short: "Search for a movie or TV show and print JSON (no prompts)",
+	Long: `Search and print matching titles as JSON on stdout.
+
+Unlike the interactive commands, find never opens fzf and never waits for
+input, so it is safe to call from a script or an agent. Each result carries an
+opaque "ref" which is the handle to pass to "lobster play --ref".`,
+	Args:          cobra.MinimumNArgs(1),
+	RunE:          findRun,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func findRun(cmd *cobra.Command, args []string) error {
+	query := strings.Join(args, " ")
+
+	p := newProvider()
+	results, err := agentSearch(p, fallbackSearchProviders(p), query)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "search failed: %v", err)
+	}
+
+	if flagFindType != "" {
+		want := media.Movie
+		if flagFindType == "tv" {
+			want = media.TV
+		}
+		filtered := results[:0:0]
+		for _, r := range results {
+			if r.Type == want {
+				filtered = append(filtered, r)
+			}
+		}
+		results = filtered
+	}
+
+	if len(results) == 0 {
+		return emitErr("no_results", exitNoResults, "nothing matched %q", query)
+	}
+
+	if flagFindLimit > 0 && len(results) > flagFindLimit {
+		results = results[:flagFindLimit]
+	}
+
+	base := ""
+	if cfg != nil {
+		base = cfg.Base
+	}
+
+	out := make([]map[string]any, 0, len(results))
+	for i, r := range results {
+		ref, err := encodeRef(playRef{
+			ID:    r.ID,
+			Title: r.Title,
+			Year:  r.Year,
+			Type:  r.Type.String(),
+			Base:  base,
+		})
+		if err != nil {
+			return emitErr("internal", 1, "encoding ref: %v", err)
+		}
+		out = append(out, map[string]any{
+			"idx":   i,
+			"ref":   ref,
+			"title": r.Title,
+			"year":  r.Year,
+			"type":  r.Type.String(),
+		})
+	}
+	return emitJSON(map[string]any{"results": out})
+}
+```
+
+Note the import block above deliberately omits `lobster/internal/provider`:
+`newProvider()` and `fallbackSearchProviders()` are used through type
+inference, so the package is never named in this file. Importing it would fail
+`go vet`.
+
+- [ ] **Step 5: Register the command**
+
+In `cmd/root.go` `init()`, add after `rootCmd.AddCommand(doctorCmd)`:
+
+```go
+	rootCmd.AddCommand(findCmd)
+```
+
+And in `cmd/find.go`, add an `init()`:
+
+```go
+func init() {
+	findCmd.Flags().StringVar(&flagFindType, "type", "", "Filter results: movie | tv")
+	findCmd.Flags().IntVar(&flagFindLimit, "limit", 0, "Maximum results to print (0 = no limit)")
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestFind' -v`
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Verify the whole suite**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...`
+
+Expected: all ok.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/agenthelp_test.go cmd/find.go cmd/find_test.go cmd/root.go
+git commit -m "feat(agent): add lobster find, a search that never prompts
+
+Emits candidates as JSON with an opaque ref per result. No results exits
+2, distinct from providers-down which exits 3.
+
+Tests run under a hostile environment: stdin closed and an fzf shim on
+PATH that fails the test if executed. Injecting ui.Select alone would not
+be enough, because ui.Input execs fzf directly, ui.SelectWithTimeout
+reads stdin raw before reaching Select, and the no-arg path is Bubble Tea
+rather than fzf."
+```
+
+---
+
+### Task 4: `lobster episodes`
+
+**Files:**
+- Create: `cmd/episodes.go`
+- Create: `cmd/episodes_test.go`
+- Modify: `cmd/root.go` (register `episodesCmd`)
+
+**Interfaces:**
+- Consumes: Task 1, Task 2 (`decodeRef`), Task 3 (`hostileEnv`, `stubProvider`)
+- Produces:
+  - `var episodesCmd *cobra.Command`
+  - `var agentProvider = newProvider` — test seam so episodes/play can be given a stub
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/episodes_test.go`:
+
+```go
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// An agent cannot guess episode numbers, so it needs a listing — and that
+// listing must not prompt.
+func TestEpisodesListsWithoutPrompting(t *testing.T) {
+	hostileEnv(t)
+	buf := captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		return &stubProvider{
+			seasons:  []media.Season{{ID: "s1", Number: 1}, {ID: "s2", Number: 2}},
+			episodes: []media.Episode{{ID: "e1", Number: 1, Title: "Pilot"}},
+		}
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	ref, err := encodeRef(playRef{ID: "tv/show-1", Title: "Some Show", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	prevSeason := flagSeason
+	flagSeason = 1
+	t.Cleanup(func() { flagSeason = prevSeason })
+
+	if err := episodesRun(episodesCmd, nil); err != nil {
+		t.Fatalf("episodesRun: %v", err)
+	}
+
+	var got struct {
+		Schema   int `json:"schema"`
+		Episodes []struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		} `json:"episodes"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v (%q)", err, buf.String())
+	}
+	if got.Schema != 1 {
+		t.Fatalf("schema = %d, want 1", got.Schema)
+	}
+	if len(got.Episodes) != 1 || got.Episodes[0].Number != 1 || got.Episodes[0].Title != "Pilot" {
+		t.Fatalf("episodes = %+v", got.Episodes)
+	}
+}
+
+// Asking for episodes of a film is a caller mistake worth naming clearly.
+func TestEpisodesRejectsMovieRef(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "A Film", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := episodesRun(episodesCmd, nil); err == nil {
+		t.Fatal("episodesRun accepted a movie ref, want an error")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestEpisodes' -v`
+
+Expected: FAIL to build — `undefined: episodesCmd`, `undefined: episodesRun`, `undefined: agentProvider`, `undefined: flagRef`, `undefined: flagSeason`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/episodes.go`:
+
+```go
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"lobster/internal/media"
+)
+
+var (
+	flagRef     string
+	flagSeason  int
+	flagEpisode int
+)
+
+// agentProvider builds the primary provider. A package var so tests can supply
+// a stub instead of one that reaches the network.
+var agentProvider = newProvider
+
+var episodesCmd = &cobra.Command{
+	Use:   "episodes --ref <REF>",
+	Short: "List seasons and episodes for a TV ref as JSON (no prompts)",
+	Long: `List the episodes of a show without prompting.
+
+Takes a ref emitted by "lobster find". With --season it lists that season's
+episodes; without it, the first season's.`,
+	Args:          cobra.NoArgs,
+	RunE:          episodesRun,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	episodesCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
+	episodesCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (default: first)")
+}
+
+func episodesRun(cmd *cobra.Command, args []string) error {
+	r, err := decodeRef(flagRef)
+	if err != nil {
+		return emitErr("bad_ref", 1, "%v", err)
+	}
+	if r.Type != media.TV.String() {
+		return emitErr("not_a_series", 1, "%q is a %s, which has no episodes", r.Title, r.Type)
+	}
+
+	p := agentProvider()
+	seasons, err := p.GetSeasons(r.ID)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "getting seasons: %v", err)
+	}
+	if len(seasons) == 0 {
+		return emitErr("no_results", exitNoResults, "no seasons found for %q", r.Title)
+	}
+
+	sel := seasons[0]
+	if flagSeason > 0 {
+		found := false
+		for _, s := range seasons {
+			if s.Number == flagSeason {
+				sel, found = s, true
+				break
+			}
+		}
+		if !found {
+			return emitErr("no_results", exitNoResults, "season %d not found for %q", flagSeason, r.Title)
+		}
+	}
+
+	eps, err := p.GetEpisodes(r.ID, sel.ID)
+	if err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "getting episodes: %v", err)
+	}
+
+	seasonNums := make([]int, 0, len(seasons))
+	for _, s := range seasons {
+		seasonNums = append(seasonNums, s.Number)
+	}
+	out := make([]map[string]any, 0, len(eps))
+	for _, e := range eps {
+		out = append(out, map[string]any{"number": e.Number, "title": e.Title})
+	}
+
+	return emitJSON(map[string]any{
+		"title":    r.Title,
+		"seasons":  seasonNums,
+		"season":   sel.Number,
+		"episodes": out,
+	})
+}
+```
+
+As in `find.go`, the import block deliberately omits
+`lobster/internal/provider`: `agentProvider()` is used through type inference
+and the package is never named here.
+
+- [ ] **Step 4: Register the command**
+
+In `cmd/root.go` `init()`, add:
+
+```go
+	rootCmd.AddCommand(episodesCmd)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestEpisodes' -v`
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Verify the whole suite and commit**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...`
+
+```bash
+git add cmd/episodes.go cmd/episodes_test.go cmd/root.go
+git commit -m "feat(agent): add lobster episodes for non-interactive episode listing
+
+An agent cannot guess episode numbers, so play --season/--episode is
+unusable without a listing. Takes a ref from find and prints seasons plus
+the selected season's episodes as JSON."
+```
+
+---
+
+### Task 5: `lobster play` (attached path)
+
+**Files:**
+- Create: `cmd/play.go`
+- Create: `cmd/play_test.go`
+- Modify: `cmd/root.go` (register `playCmd`)
+
+**Interfaces:**
+- Consumes: Tasks 1-4 (`emitErr`, `decodeRef`, `agentProvider`, `flagRef`, `flagSeason`, `flagEpisode`, `hostileEnv`)
+- Produces:
+  - `var playCmd *cobra.Command`
+  - `var agentResolveAndPlay = resolveAndPlay` — test seam
+  - `func playRun(cmd *cobra.Command, args []string) error`
+
+**Why this reuses existing code:** `resolveAndPlay` at `cmd/search.go:223` is already non-interactive for movies, and for TV when `season > 0 && episode > 0` and `flagDownload == ""`. Its four blocking calls (`cmd/search.go:279,290,351,364`) are all in `else` branches. Reimplementing playback would duplicate the fallback chain, subtitle handling and history writes for no benefit.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/play_test.go`:
+
+```go
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// A TV ref without both season and episode would fall through to the
+// interactive season picker, which hangs. Refuse it with a clear message
+// instead.
+func TestPlayRejectsTVWithoutSeasonAndEpisode(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	ref, err := encodeRef(playRef{ID: "tv/show", Title: "Some Show", Type: "tv"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevS, prevE := flagRef, flagSeason, flagEpisode
+	flagRef, flagSeason, flagEpisode = ref, 0, 0
+	t.Cleanup(func() { flagRef, flagSeason, flagEpisode = prevRef, prevS, prevE })
+
+	if err := playRun(playCmd, nil); err == nil {
+		t.Fatal("playRun accepted a TV ref with no season/episode, want an error")
+	}
+}
+
+// The ref's title and year must reach the playback path. If they are dropped,
+// the resolver searches for "" and ranking collapses — which plays the wrong
+// film rather than failing.
+func TestPlayPassesFullSelectionThrough(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	var got media.SearchResult
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(p provider.Provider, sel media.SearchResult, season, episode int) error {
+		got = sel
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{
+		ID: "movie/watch-the-matrix-19724", Title: "The Matrix", Year: "1999", Type: "movie",
+	})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if got.Title != "The Matrix" {
+		t.Fatalf("Title = %q, want The Matrix", got.Title)
+	}
+	if got.Year != "1999" {
+		t.Fatalf("Year = %q, want 1999 (the resolver ranks on it)", got.Year)
+	}
+	if got.ID != "movie/watch-the-matrix-19724" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+	if got.Type != media.Movie {
+		t.Fatalf("Type = %v, want Movie", got.Type)
+	}
+}
+
+// A total resolution failure is exit 3, so the agent knows to run doctor
+// rather than suggest a spelling fix.
+func TestPlayResolutionFailureExitsThree(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		return fmt.Errorf("all providers failed")
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	err = playRun(playCmd, nil)
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("playRun returned %T (%v), want *exitError", err, err)
+	}
+	if ee.code != exitProvidersFailed {
+		t.Fatalf("exit code = %d, want %d", ee.code, exitProvidersFailed)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestPlay' -v`
+
+Expected: FAIL to build — `undefined: playCmd`, `undefined: playRun`, `undefined: agentResolveAndPlay`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/play.go`:
+
+```go
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"lobster/internal/media"
+	"lobster/internal/provider"
+)
+
+// agentResolveAndPlay is the playback entry point, as a package var so tests
+// can observe what selection reaches it without launching a player.
+var agentResolveAndPlay = resolveAndPlay
+
+var playCmd = &cobra.Command{
+	Use:   "play --ref <REF>",
+	Short: "Play a ref returned by lobster find (no prompts)",
+	Long: `Play the exact title a ref identifies, without prompting.
+
+The ref pins the selection — title, year, type and originating base. It does
+not pin the stream: resolution still runs through the fallback chain at play
+time, so if the original source is down another provider's copy may be served.
+
+For a series, both --season and --episode are required; without them playback
+would fall through to the interactive picker and hang.`,
+	Args:          cobra.NoArgs,
+	RunE:          playRun,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	playCmd.Flags().StringVar(&flagRef, "ref", "", "Ref from lobster find (required)")
+	playCmd.Flags().IntVar(&flagSeason, "season", 0, "Season number (required for TV)")
+	playCmd.Flags().IntVar(&flagEpisode, "episode", 0, "Episode number (required for TV)")
+}
+
+func playRun(cmd *cobra.Command, args []string) error {
+	r, err := decodeRef(flagRef)
+	if err != nil {
+		return emitErr("bad_ref", 1, "%v", err)
+	}
+
+	sel := r.searchResult()
+	if sel.Type == media.TV && (flagSeason <= 0 || flagEpisode <= 0) {
+		return emitErr("season_episode_required", 1,
+			"%q is a series: pass --season and --episode (list them with 'lobster episodes --ref ...')", r.Title)
+	}
+
+	// Downloading walks a different, interactive path (batch range prompts), so
+	// it is not supported here.
+	if flagDownload != "" {
+		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
+	}
+
+	var p provider.Provider = agentProvider()
+	if err := agentResolveAndPlay(p, sel, flagSeason, flagEpisode); err != nil {
+		return emitErr("providers_failed", exitProvidersFailed, "%v", err)
+	}
+
+	return emitJSON(map[string]any{
+		"status": "finished",
+		"title":  r.Title,
+	})
+}
+```
+
+- [ ] **Step 4: Register the command**
+
+In `cmd/root.go` `init()`, add:
+
+```go
+	rootCmd.AddCommand(playCmd)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestPlay' -v`
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Verify the whole suite and commit**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...`
+
+```bash
+git add cmd/play.go cmd/play_test.go cmd/root.go
+git commit -m "feat(agent): add lobster play --ref for non-interactive playback
+
+Reuses resolveAndPlay, which is already non-interactive for movies and
+for TV when season and episode are both set — its four blocking calls
+(cmd/search.go:279,290,351,364) are all in else branches.
+
+A TV ref without both --season and --episode is refused rather than
+falling through to the season picker, which would hang. Resolution
+failure exits 3 so the agent runs doctor instead of suggesting a
+spelling fix."
+```
+
+---
+
+### Task 5b: Regression test for the foreign-ID-namespace case
+
+**Files:**
+- Create: `internal/resolver/foreign_id_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks — this guards `internal/resolver`
+- Produces: no production code
+
+**Why this exists as its own task:** every other test in this plan uses a stub
+provider that answers with the ID it was asked for, which is exactly the case
+where a bare `--id` would have worked. That masks the problem `ref` was built
+to solve. This test uses a provider whose IDs are from a *different namespace*,
+which is the real situation across lobster's fallback chain — and proves that
+carrying Title and Year is what saves the selection.
+
+It lives in `internal/resolver` because `candidatesFor` is unexported, and
+calling it directly keeps the test fast and network-free while still exercising
+the real ranking code rather than a reimplementation.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/resolver/foreign_id_test.go`:
+
+```go
+package resolver
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// A fallback provider indexes its own catalogue, so the ID the user's
+// selection came from means nothing to it. What still identifies the work is
+// the title and year — which is why the agent-facing ref carries them rather
+// than an ID alone.
+//
+// Without Title and Year the request degenerates and a franchise query returns
+// whichever sequel the provider happens to rank first.
+func TestCandidatesForPicksRightWorkWhenIDsAreForeign(t *testing.T) {
+	// None of these IDs match the request: this provider uses its own scheme.
+	results := []media.SearchResult{
+		{ID: "yts/9001", Title: "The Matrix Resurrections", Year: "2021", Type: media.Movie},
+		{ID: "yts/9002", Title: "The Matrix Reloaded", Year: "2003", Type: media.Movie},
+		{ID: "yts/9003", Title: "The Matrix", Year: "1999", Type: media.Movie},
+	}
+
+	req := Request{
+		ID:        "movie/watch-the-matrix-19724", // from a different provider
+		Title:     "The Matrix",
+		Year:      "1999",
+		MediaType: media.Movie,
+	}
+
+	got := candidatesFor(results, req)
+	if len(got) == 0 {
+		t.Fatal("no candidates returned")
+	}
+	if got[0].Title != "The Matrix" || got[0].Year != "1999" {
+		t.Fatalf("top candidate = %q (%s), want The Matrix (1999); "+
+			"title+year ranking is what rescues a foreign ID", got[0].Title, got[0].Year)
+	}
+}
+
+// The counter-case: strip Title and Year, as a bare --id would, and the
+// ranking has nothing to work with. This documents why the ref carries more
+// than an ID — if this ever starts passing, the ref could be simplified.
+func TestCandidatesForCannotDisambiguateWithoutTitleOrYear(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "yts/9001", Title: "The Matrix Resurrections", Year: "2021", Type: media.Movie},
+		{ID: "yts/9003", Title: "The Matrix", Year: "1999", Type: media.Movie},
+	}
+
+	req := Request{ID: "movie/watch-the-matrix-19724", MediaType: media.Movie}
+
+	got := candidatesFor(results, req)
+	if len(got) == 0 {
+		t.Fatal("no candidates returned")
+	}
+	if got[0].Title == "The Matrix" && got[0].Year == "1999" {
+		t.Fatal("an ID-only request picked the right film; if this is now " +
+			"reliable, revisit whether playRef still needs Title and Year")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./internal/resolver/ -run 'TestCandidatesFor.*Foreign|TestCandidatesForCannot' -v`
+
+Expected: **both PASS immediately.** These characterise existing behaviour
+rather than driving new code, so there is no red phase. If the first one fails,
+stop — the premise behind `playRef` is wrong and the design needs revisiting
+before any more of this plan is built.
+
+This was measured against `origin/main` while writing the plan, and the result
+is why `ref` carries more than an ID:
+
+| Request | Top-ranked result |
+| ------- | ----------------- |
+| ID + Title + Year | `The Matrix` (1999) |
+| ID only | `The Matrix Resurrections` (2021) |
+
+A bare `--id` does not fail loudly — it plays the wrong film.
+
+- [ ] **Step 3: Confirm the assertions actually bite**
+
+Temporarily change `req` in the first test to drop `Title` and `Year`:
+
+```go
+	req := Request{ID: "movie/watch-the-matrix-19724", MediaType: media.Movie}
+```
+
+Run the first test again. Expected: **FAIL**, proving the assertion depends on
+title/year ranking rather than passing by luck. Then revert the change and
+re-run to confirm PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/resolver/foreign_id_test.go
+git commit -m "test(resolver): pin title+year ranking when provider IDs are foreign
+
+Every other test around the agent commands uses a stub that answers with
+the ID it was asked for, which is exactly the case where a bare ID would
+have worked — so it masks the problem the ref token exists to solve.
+
+This uses results from a different ID namespace, as the fallback chain
+really does, and pins that title+year is what identifies the work. The
+paired counter-test documents why the ref carries more than an ID: if it
+ever starts failing, the ref could be simplified."
+```
+
+---
+
+### Task 6: `--detach` supervisor
+
+**Files:**
+- Create: `cmd/detach.go`
+- Create: `cmd/detach_unix.go`
+- Create: `cmd/detach_windows.go`
+- Create: `cmd/detach_test.go`
+- Modify: `cmd/play.go` (add `--detach`, hidden `--supervised`, branch in `playRun`)
+
+**Interfaces:**
+- Consumes: Tasks 1-5
+- Produces:
+  - `func supervisorArgs(exe string, ref string, season, episode int) []string`
+  - `func detachLogPath(pid int) (string, error)`
+  - `func detachSpawnAttr() *syscall.SysProcAttr` (per-platform)
+  - `var flagDetach bool`, `var flagSupervised bool`
+
+**Why re-exec rather than skipping `cmd.Wait()`:** playback depends on process-local resources that die when lobster exits — the de-obfuscating HLS proxy whose cleanup every player defers (`internal/player/mpv.go:41`, `vlc.go:33`, `generic.go:31`, used by AniPub), the torrent server at `cmd/search.go:518-522` (all YTS content is magnets), and the subtitle temp dir at `cmd/search.go:497-499`. It is also not mechanically possible: `vlc.go:57` and `generic.go:53` call `cmd.Run()`, with no `Start`/`Wait` to split.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/detach_test.go`:
+
+```go
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// The supervisor must be told to actually play, and must be marked supervised
+// so it does not recurse into spawning another supervisor.
+func TestSupervisorArgsArePlayableAndNonRecursive(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF123", 2, 3)
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "play") {
+		t.Fatalf("args %v do not invoke play", args)
+	}
+	if !strings.Contains(joined, "--ref REF123") {
+		t.Fatalf("args %v do not carry the ref", args)
+	}
+	if !strings.Contains(joined, "--season 2") || !strings.Contains(joined, "--episode 3") {
+		t.Fatalf("args %v lost season/episode", args)
+	}
+	if !strings.Contains(joined, "--supervised") {
+		t.Fatalf("args %v missing --supervised; the child would spawn its own child forever", args)
+	}
+	if strings.Contains(joined, "--detach") {
+		t.Fatalf("args %v still carry --detach; that is the recursion", args)
+	}
+}
+
+// Season and episode are meaningless for a film and must not be passed as
+// zeroes, which the play command would reject.
+func TestSupervisorArgsOmitZeroSeasonEpisode(t *testing.T) {
+	args := supervisorArgs("/usr/bin/lobster", "REF", 0, 0)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--season") || strings.Contains(joined, "--episode") {
+		t.Fatalf("args %v pass zero season/episode", args)
+	}
+}
+
+func TestDetachLogPathIsPerPID(t *testing.T) {
+	a, err := detachLogPath(111)
+	if err != nil {
+		t.Fatalf("detachLogPath: %v", err)
+	}
+	b, err := detachLogPath(222)
+	if err != nil {
+		t.Fatalf("detachLogPath: %v", err)
+	}
+	if a == b {
+		t.Fatalf("log paths collide: %q", a)
+	}
+	if !strings.Contains(a, "111") {
+		t.Fatalf("log path %q does not identify the pid", a)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestSupervisorArgs|TestDetachLogPath' -v`
+
+Expected: FAIL to build — `undefined: supervisorArgs`, `undefined: detachLogPath`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/detach.go`:
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// supervisorArgs builds the argv for the background lobster that actually
+// plays. It carries --supervised so the child does not spawn a child of its
+// own, and drops --detach for the same reason.
+func supervisorArgs(exe, ref string, season, episode int) []string {
+	args := []string{exe, "play", "--ref", ref, "--supervised"}
+	if season > 0 {
+		args = append(args, "--season", strconv.Itoa(season))
+	}
+	if episode > 0 {
+		args = append(args, "--episode", strconv.Itoa(episode))
+	}
+	return args
+}
+
+// detachLogPath is where a detached play writes its output. Per-pid so
+// concurrent plays do not interleave, and so the JSON payload can point at a
+// specific run.
+func detachLogPath(pid int) (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("locating cache dir: %w", err)
+	}
+	dir = filepath.Join(dir, "lobster")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating %s: %w", dir, err)
+	}
+	return filepath.Join(dir, fmt.Sprintf("play-%d.log", pid)), nil
+}
+
+// detachLiveness is how long the foreground waits before declaring success.
+// cmd.Start succeeding only means the binary exec'd; mpv's own failure
+// detection is "exited within 5s with no playback" (internal/player/mpv.go).
+// This does not close the race, it removes the common case of reporting
+// success for a stream that never started.
+var detachLiveness = 1 * time.Second
+```
+
+- [ ] **Step 4: Write the platform spawn attributes**
+
+Create `cmd/detach_unix.go`:
+
+```go
+//go:build !windows
+
+package cmd
+
+import "syscall"
+
+// detachSpawnAttr puts the supervisor in its own process group so it survives
+// the agent's shell exiting.
+func detachSpawnAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+```
+
+Create `cmd/detach_windows.go`:
+
+```go
+//go:build windows
+
+package cmd
+
+import "syscall"
+
+// detachSpawnAttr detaches the supervisor from the console so it survives the
+// agent's shell exiting. Setpgid does not exist on Windows.
+func detachSpawnAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | 0x00000008, // DETACHED_PROCESS
+	}
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestSupervisorArgs|TestDetachLogPath' -v`
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Verify the Windows build compiles**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 GOOS=windows go build ./... && GOOS=windows go vet ./cmd/`
+
+Expected: no output (success). This is the step that catches `Setpgid` not existing on Windows.
+
+- [ ] **Step 7: Wire `--detach` into play**
+
+In `cmd/play.go`, add to the flag block in `init()`:
+
+```go
+	playCmd.Flags().BoolVar(&flagDetach, "detach", false, "Start playback in the background and return immediately")
+	playCmd.Flags().BoolVar(&flagSupervised, "supervised", false, "Internal: marks the background supervisor process")
+	_ = playCmd.Flags().MarkHidden("supervised")
+```
+
+Declare the vars in `cmd/detach.go`:
+
+```go
+var (
+	flagDetach     bool
+	flagSupervised bool
+)
+```
+
+In `playRun`, insert this immediately after the `flagDownload` check and before the `agentProvider()` call:
+
+```go
+	if flagDetach && !flagSupervised {
+		return playDetached(r)
+	}
+```
+
+Add `playDetached` to `cmd/detach.go`:
+
+```go
+// playDetached re-executes lobster as a background supervisor and returns as
+// soon as it looks alive. The child performs an ordinary attached play, so the
+// HLS proxy, torrent server, subtitle temp dir and mpv IPC all behave exactly
+// as they do interactively.
+func playDetached(r playRef) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return emitErr("internal", 1, "locating lobster binary: %v", err)
+	}
+
+	argv := supervisorArgs(exe, flagRef, flagSeason, flagEpisode)
+
+	c := exec.Command(argv[0], argv[1:]...)
+	c.SysProcAttr = detachSpawnAttr()
+	c.Stdin = nil // no TTY to inherit
+
+	// The child's output must never reach the pipe the caller is parsing: all
+	// three players set cmd.Stdout = os.Stdout, which would interleave with the
+	// JSON envelope and corrupt it.
+	tmpLog, err := detachLogPath(os.Getpid())
+	if err != nil {
+		return emitErr("internal", 1, "%v", err)
+	}
+	lf, err := os.Create(tmpLog)
+	if err != nil {
+		return emitErr("internal", 1, "creating log %s: %v", tmpLog, err)
+	}
+	defer lf.Close()
+	c.Stdout = lf
+	c.Stderr = lf
+
+	if err := c.Start(); err != nil {
+		return emitErr("player_unavailable", exitPlayerUnavailable, "starting background player: %v", err)
+	}
+
+	// Rename the log to the child's pid now that we know it, so the payload
+	// points at a file the user can find from the pid alone.
+	finalLog, err := detachLogPath(c.Process.Pid)
+	if err == nil && os.Rename(tmpLog, finalLog) == nil {
+		tmpLog = finalLog
+	}
+
+	time.Sleep(detachLiveness)
+	if !processAlive(c.Process.Pid) {
+		return emitErr("providers_failed", exitProvidersFailed,
+			"playback exited immediately; see %s", tmpLog)
+	}
+
+	return emitJSON(map[string]any{
+		"status":          "playing",
+		"pid":             c.Process.Pid,
+		"title":           r.Title,
+		"log":             tmpLog,
+		"resume_tracking": playerTracksPosition(),
+	})
+}
+
+// playerTracksPosition reports whether the configured player reports playback
+// position. Only mpv does: vlc.go and generic.go both return an empty
+// PlayResult regardless of detach.
+func playerTracksPosition() bool {
+	if cfg == nil {
+		return false
+	}
+	return strings.EqualFold(cfg.Player, "mpv")
+}
+```
+
+Add `processAlive` to `cmd/detach_unix.go`:
+
+```go
+// processAlive reports whether the pid is still running. Signal 0 performs the
+// permission and existence checks without delivering anything.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+```
+
+Add `processAlive` to `cmd/detach_windows.go`:
+
+```go
+// processAlive reports whether the pid is still running. On Windows
+// os.FindProcess fails outright for a dead pid, which is the check.
+func processAlive(pid int) bool {
+	_, err := os.FindProcess(pid)
+	return err == nil
+}
+```
+
+Add the needed imports: `os`, `os/exec`, `strings`, `time` in `cmd/detach.go`; `os`, `syscall` in `cmd/detach_unix.go`; `os`, `syscall` in `cmd/detach_windows.go`.
+
+- [ ] **Step 8: Write a test for the recursion guard**
+
+Append to `cmd/detach_test.go`:
+
+```go
+// A supervised process must play, not spawn another supervisor. Without this
+// guard --detach forks forever.
+func TestSupervisedPlayDoesNotDetachAgain(t *testing.T) {
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	called := false
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevD, prevS := flagRef, flagDetach, flagSupervised
+	flagRef, flagDetach, flagSupervised = ref, true, true
+	t.Cleanup(func() { flagRef, flagDetach, flagSupervised = prevRef, prevD, prevS })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if !called {
+		t.Fatal("supervised play did not reach playback; it re-detached instead")
+	}
+}
+```
+
+Add imports `"lobster/internal/media"` and `"lobster/internal/provider"` to `cmd/detach_test.go`.
+
+- [ ] **Step 9: Run the detach tests**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go test ./cmd/ -run 'TestSupervisor|TestDetach|TestSupervised' -v`
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 10: Verify both platforms and the whole suite**
+
+```bash
+cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 GOOS=windows go build ./...
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 GOOS=darwin go build ./...
+```
+
+Expected: all succeed.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add cmd/detach.go cmd/detach_unix.go cmd/detach_windows.go cmd/detach_test.go cmd/play.go
+git commit -m "feat(agent): --detach re-execs lobster as a background supervisor
+
+Skipping cmd.Wait() would have black-screened anime and all YTS
+playback: the HLS deobfuscation proxy (player/*.go defer its cleanup),
+the torrent server (search.go:522) and the subtitle temp dir
+(search.go:497) are all torn down when lobster exits. vlc and generic
+also call cmd.Run(), so there is no Wait to skip.
+
+Re-exec means the background process does an ordinary attached play, so
+every resource behaves as it does interactively and resume tracking is
+preserved rather than sacrificed.
+
+Setpgid is unix-only, so spawn attrs are split behind build tags
+following the existing ipc_windows.go pattern. The foreground waits 1s
+and checks liveness before reporting success, so the common case of a
+stream that dies instantly is not reported as playing."
+```
+
+---
+
+### Task 7: The `lobster-play` skill and docs
+
+**Files:**
+- Create: `skills/lobster-play/SKILL.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: Tasks 1-6 (the full command surface)
+- Produces: no code
+
+- [ ] **Step 1: Write the skill**
+
+Create `skills/lobster-play/SKILL.md`:
+
+```markdown
+---
+name: lobster-play
+description: Use when the user asks to find, search for, or play a movie or TV episode — for example "put on Parasite", "find me something to watch", "play The Bear season 2 episode 3".
+---
+
+# Playing movies and TV with lobster
+
+`lobster` is a terminal media streamer. It has a machine-readable mode that
+never prompts, which is what you use. Its interactive commands will hang you
+forever — see the do-not-run list below.
+
+## Never run these
+
+These block on `fzf` or open a full-screen TUI and will not return:
+
+| Command | What happens |
+| ------- | ------------ |
+| `lobster` (no arguments) | opens a full-screen TUI |
+| `lobster <query>` | blocks on an fzf picker |
+| `lobster trending` / `lobster recent` | blocks on an fzf picker |
+| `lobster history` | blocks on an fzf picker |
+
+Use `find`, `episodes` and `play` instead. They print JSON on stdout and
+never wait for input.
+
+## The workflow
+
+### 1. Find candidates
+
+```
+lobster find "the matrix" --limit 10
+```
+
+```json
+{
+  "schema": 1,
+  "results": [
+    {"idx": 0, "ref": "eyJpZCI6...", "title": "The Matrix", "year": "1999", "type": "movie"}
+  ]
+}
+```
+
+### 2. Show the user the candidates and stop
+
+**Always ask which one before playing.** Do not pick for them, even when one
+result looks obviously right. List the titles and years and wait for an answer.
+
+### 3. Play the one they chose
+
+```
+lobster play --ref "eyJpZCI6..." --detach
+```
+
+```json
+{"schema": 1, "status": "playing", "pid": 48213,
+ "title": "The Matrix (1999)",
+ "log": "/home/u/.cache/lobster/play-48213.log",
+ "resume_tracking": true}
+```
+
+Always pass `--detach`. Without it the command blocks for the entire film and
+your tool call will not return. Report the pid so the user can stop playback.
+
+## TV series
+
+A TV ref needs both `--season` and `--episode`. Get the numbers first:
+
+```
+lobster episodes --ref "eyJpZCI6..." --season 2
+```
+
+```json
+{"schema": 1, "title": "Some Show", "seasons": [1, 2, 3], "season": 2,
+ "episodes": [{"number": 1, "title": "Pilot"}]}
+```
+
+Then:
+
+```
+lobster play --ref "eyJpZCI6..." --season 2 --episode 3 --detach
+```
+
+## Rules
+
+- **Never construct or edit a `ref`.** Only pass back one that `find` returned
+  verbatim. Refs are opaque; their contents are not a stable interface.
+- **Never reuse an `idx` from an earlier search.** It is only meaningful inside
+  the payload it came from. Search results vary between runs.
+- **Do not overclaim the source.** A ref pins the *selection*, not the stream.
+  If the original provider is down, another provider's copy of the same title
+  may be served. Say "playing The Matrix (1999)", not "playing it from X".
+- **Check `schema`.** If it is not `1`, the installed lobster does not match
+  this skill — tell the user instead of guessing at the output.
+
+## When something fails
+
+Errors are JSON on stdout too, so parse unconditionally:
+
+```json
+{"schema": 1, "error": {"code": "no_results", "message": "nothing matched \"the matirx\""}}
+```
+
+Branch on the exit code:
+
+| Exit | Meaning | What to do |
+| ---- | ------- | ---------- |
+| 0 | success | — |
+| 2 | no results | Suggest a spelling correction, or a different title |
+| 3 | every provider failed | Run `lobster doctor` and report which sources are down. Do **not** suggest a spelling fix — the title was found, the sources are broken |
+| 4 | player unavailable | mpv (or the configured player) is not installed |
+
+Exit 3 is common. Providers break often; this usually means "try again later"
+or "try a different title", not "you typed it wrong".
+
+## Out of scope
+
+Live TV channel listing and channel surfing are not available in this mode.
+For those, tell the user to run `lobster` interactively themselves.
+```
+
+- [ ] **Step 2: Add install instructions to the README**
+
+Add this section to `README.md`, immediately before the Configuration section:
+
+```markdown
+## Use it from a coding agent
+
+`lobster` ships an agent skill so you can ask Claude Code (or another agent)
+to find and play something for you.
+
+```bash
+mkdir -p ~/.claude/skills
+cp -r skills/lobster-play ~/.claude/skills/
+```
+
+Then just ask: *"find me The Matrix and play it"*. The agent will show you the
+matches and wait for you to pick one before starting playback.
+
+Under the hood it uses three non-interactive commands, which are useful for
+scripting on their own:
+
+```bash
+lobster find "the matrix" --limit 5      # JSON candidates, each with a ref
+lobster episodes --ref <REF> --season 2  # JSON season/episode listing
+lobster play --ref <REF> --detach        # start playback, return immediately
+```
+
+All three print JSON on stdout and never prompt.
+```
+
+- [ ] **Step 3: Verify the skill frontmatter parses**
+
+Run: `cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill && head -5 skills/lobster-play/SKILL.md`
+
+Expected: a `---` delimited block containing `name:` and `description:` on single lines.
+
+- [ ] **Step 4: Verify the whole suite one last time**
+
+```bash
+cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 GOOS=windows go build ./...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/lobster-play/SKILL.md README.md
+git commit -m "docs(agent): add the lobster-play skill and install instructions
+
+The do-not-run list is the highest-value part: bare lobster opens a TUI
+and the query/trending/recent/history commands all block on fzf, so an
+agent that runs one hangs with no error, which reads to the user as the
+agent freezing.
+
+The skill instructs confirm-before-play rather than leaving it to model
+judgement, and tells the agent not to overclaim the source, since a ref
+pins the selection but not which provider ultimately serves it."
+```
+
+---
+
+## Manual verification
+
+After Task 7, verify by hand — the automated tests deliberately never touch the
+network or launch a player, so the end-to-end path is unproven until someone
+runs it.
+
+```bash
+cd /tmp/claude-1000/-home-williams-Documents-personal-lobster/2d217750-8ae7-47ec-be0b-d867c2ff5307/scratchpad/wt-agentskill
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build -o /tmp/lobster-agent .
+
+# 1. find returns JSON and does not hang
+/tmp/lobster-agent find "the matrix" --limit 3
+
+# 2. the same, with stdin closed — must still return, not hang
+/tmp/lobster-agent find "the matrix" --limit 3 < /dev/null
+
+# 3. play the first result detached; must return in ~1s
+REF=$(/tmp/lobster-agent find "the matrix" --limit 1 | grep -o '"ref": "[^"]*"' | cut -d'"' -f4)
+time /tmp/lobster-agent play --ref "$REF" --detach
+
+# 4. confirm the player is actually running and the log exists
+#    (the pid and log path are in the JSON from step 3)
+
+# 5. a nonsense query exits 2
+/tmp/lobster-agent find "zzzznotarealfilmzzzz"; echo "exit=$?"
+```
+
+Expected: steps 1-2 print JSON immediately; step 3 returns in roughly a second
+with `"status": "playing"`; step 4 shows mpv running; step 5 prints an error
+envelope and `exit=2`.
+
+## Sequencing note
+
+This branch is based on `origin/main`. PR #36 (`feat/tbcpl-catalog-feed`) is
+being resolved against `cmd/fallback.go` and `cmd/search.go`. Land #36 first,
+then rebase or merge `main` into this branch before opening a PR, so the two
+sets of changes to those files do not have to be untangled at once.

--- a/docs/superpowers/specs/2026-09-03-agent-play-skill-design.md
+++ b/docs/superpowers/specs/2026-09-03-agent-play-skill-design.md
@@ -205,7 +205,7 @@ do interactively — including resume tracking, which is preserved rather than
 sacrificed.
 
 ```json
-{"schema":1,"status":"playing","pid":48213,
+{"schema":1,"status":"started","pid":48213,
  "log":"~/.cache/lobster/play-48213.log","resume_tracking":true}
 ```
 
@@ -223,8 +223,11 @@ Implementation requirements:
 - **Liveness wait before reporting success.** `cmd.Start()` succeeding only
   means the binary exec'd. mpv's own "stream failed to load" detection is
   "exited in under 5s with no playback" (`mpv.go:120-122`). The foreground waits
-  ~1s and confirms the child is alive before emitting `status: playing`;
+  ~1s and confirms the child is alive before emitting `status: started`;
   otherwise it reports the failure with exit code 3 or 4 and points at the log.
+  The status word is "started", not "playing", precisely because the wait is
+  ~1s while extraction takes 5-30s: all the parent can honestly claim is that a
+  player process started, which is why the `log` path is part of the contract.
   This does not eliminate the race — a stream can still die at 3s — but it
   removes the common case of reporting success for a stream that never started.
 - **`resume_tracking` is player-dependent, not detach-dependent.** VLC and

--- a/docs/superpowers/specs/2026-09-03-agent-play-skill-design.md
+++ b/docs/superpowers/specs/2026-09-03-agent-play-skill-design.md
@@ -1,0 +1,333 @@
+# Agent-driven playback: non-interactive CLI mode + `lobster-play` skill
+
+Date: 2026-09-03
+Status: approved design, not yet implemented
+
+## Problem
+
+A user should be able to tell a coding agent "find and play Parasite" and have
+it work. Today that is impossible, and not for a small reason.
+
+Every search path — the bare `lobster <query>` root command, `trending`, and
+`recent` — routes selection through `internal/ui.Select`, which shells out to
+`fzf` and blocks on human input (`internal/ui/ui.go:24-86`). It does this
+unconditionally, including when the search returned exactly one result. The
+existing `--json` flag does not help: it is read in `playStream`
+(`cmd/search.go:470`), *after* a title has been chosen interactively, so
+`lobster --json "the matrix"` hangs at the fzf prompt rather than printing
+anything.
+
+So an agent cannot complete the task, and worse, an agent that *tries* will hang
+until killed — which the user experiences as the agent freezing, with no error
+to explain it.
+
+A skill file alone would document a workflow the CLI cannot perform. This design
+covers both halves: a machine-readable CLI surface, and the skill that drives it.
+
+## Scope
+
+**v1: movies and TV episodes.** They share one code path and cover the common
+case.
+
+**Live TV is deferred to its own spec.** Not for effort reasons — it has a
+correctness problem that needs a real answer first. `internal/provider/livetv.go:161-172`
+disambiguates colliding channel IDs by *load order* (`base`, `base-2`,
+`base-3`), and base IDs come from remote iptv-org playlists refetched per
+process, where a failed source is silently skipped (`livetv.go:134-137`). So a
+`channels` → `play --channel sports-2` round trip across two processes can
+select a different channel, or none. There is also no `cmd/`-layer LiveTV
+wiring at all today; it is constructed only in the TUI
+(`internal/tui/app.go:145`).
+
+**Channel surfing is out of scope permanently.** The continuous
+next/previous flow has no terminal state, so there is nothing coherent for a
+command to return. The skill hands off to the interactive CLI.
+
+**An MCP server was considered and rejected** as surface area to maintain for no
+capability the CLI cannot already provide.
+
+## Command surface
+
+Three commands. All emit JSON on stdout, none ever invoke `fzf`.
+
+```
+lobster find "the matrix" [--type movie|tv] [--limit N]
+lobster episodes --ref <REF> [--season N]
+lobster play --ref <REF> [--season N --episode N] [--detach]
+```
+
+Every existing command is untouched. Nothing about interactive use changes.
+
+### Why new verbs rather than flags on existing commands
+
+Adding `--pick N` to the root command was rejected: it makes one code path serve
+both interactive and non-interactive selection, which is where selection bugs
+hide, and it overloads `--json`, which today means "post-selection stream
+metadata."
+
+Namespacing as `lobster agent search|play` was rejected as clunky and
+duplicative.
+
+The one idea kept from the namespaced option is an explicit contract marker:
+every payload carries `"schema": 1`, so a skill written against a different
+lobster version detects the mismatch instead of silently misparsing.
+
+## The replay reference (`--ref`)
+
+This is the core of the design, and the first draft of this spec got it wrong.
+
+**An ID alone is not sufficient to replay a selection.** Three facts force this:
+
+1. `media.SearchResult.ID` is provider-scoped — `media/types.go:25` calls it
+   "Provider-specific ID".
+2. The resolver **re-searches by title** on every fallback provider:
+   `resolveWithProvider` calls `p.Search(req.Title)` (`internal/resolver/probe.go:84`).
+   Its doc comment (`probe.go:65-67`) states plainly that "IDs are not portable
+   across all of them." ID equality is only a tiebreak in `candidateScore`,
+   worth +8 of a possible 16 (`probe.go:198-227`).
+3. `find` aggregates across providers. `gatherSearchResults` merges the
+   primary's results with parallel fallback results whenever the primary
+   returned fewer than three (`cmd/multisearch.go:36`), so one payload contains
+   IDs from mixed namespaces. `cmd/multisearch.go:112-124` documents a real past
+   bug where a donated ID from the wrong namespace caused playback of a
+   different work.
+
+Given only `--id`, `resolver.Request.Title` and `.Year` would be empty, so the
+provider would be asked to `Search("")` and ranking would collapse. The result
+is not a failure — it is *playing the wrong film*, which is exactly what
+confirm-before-play was supposed to prevent.
+
+**Therefore `find` emits an opaque `ref` per result**, a base64url-encoded JSON
+object carrying everything replay needs:
+
+```json
+{"id":"movie/watch-the-matrix-19724","title":"The Matrix",
+ "year":"1999","type":"movie","base":"flixhq.ws"}
+```
+
+`base` is included because the primary provider is flag/config-selected, and an
+ID found under `--base yts` is meaningless under the default base.
+
+The agent echoes a `ref` back verbatim and never constructs one. The token is
+opaque by contract but plain base64 for debuggability — decoding it by hand
+during support is deliberate.
+
+**Honest cost:** this makes `lobster play` less pleasant for humans than a bare
+`--id` would have been. Humans keep the existing interactive path, which is
+unchanged. `--ref` is a machine contract and is documented as such.
+
+**What `ref` does and does not guarantee.** It pins the *selection* — the title,
+year, type and originating base the user confirmed. It does not pin the
+*stream*: resolution still happens at play time through the fallback chain, and
+if the originating provider is down, another provider's copy of the same title
+may be served. That is lobster's existing and desirable behaviour. The
+distinction is stated in the skill so the agent does not overclaim.
+
+## Output contract
+
+**stdout is always pure JSON. All human and diagnostic text goes to stderr.**
+This holds for errors too, so an agent can parse unconditionally.
+
+```json
+{"schema":1,"results":[
+  {"idx":0,"ref":"eyJpZCI6Im1v...","title":"The Matrix",
+   "year":"1999","type":"movie"}
+]}
+```
+
+`year` is a **string** and may be empty — `media.SearchResult.Year` is a string
+(`media/types.go:28`) and is frequently absent; `cmd/multisearch.go` has
+extensive year-less handling. A schema promising an int would either lie or
+lose data.
+
+`idx` is stable **within a payload only**. `multiProviderSearch` applies a 5s
+timeout and discards slow providers (`cmd/multisearch.go:15,58`), so the result
+set legitimately varies between runs. Agents must use `ref`, never a
+remembered `idx`.
+
+`--limit` interacts with a broadening heuristic worth knowing: fallback
+providers are only queried when the primary returns fewer than three results
+(`multisearch.go:36`), so a large limit usually returns primary-only results.
+
+Errors use the same envelope:
+
+```json
+{"schema":1,"error":{"code":"no_results",
+ "message":"nothing matched \"the matirx\""}}
+```
+
+### Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | success |
+| 2 | no results |
+| 3 | all providers failed |
+| 4 | player unavailable |
+| 1 | anything else |
+
+`2` and `3` are deliberately distinct. On this repo `3` is common — the title
+exists but every source is down — and should send the agent to `lobster doctor`,
+not to a spelling suggestion.
+
+**This requires plumbing that does not exist yet.** `cmd/root.go:44-48`
+hard-codes `os.Exit(1)`, and neither `SilenceErrors` nor `SilenceUsage` is set
+(`root.go:34-41`), so flag-parse and `loadConfig` failures print plain-text
+`Error: …` plus full usage before any command body runs. Both must change for
+the contract to hold. (Cobra already routes error/usage text to stderr, so that
+part is satisfied.)
+
+## Detached playback
+
+`lobster play --detach` **re-executes lobster as a background supervisor.** The
+foreground process spawns `lobster play --ref … --_supervised`, waits briefly to
+confirm it is still alive, prints JSON, and exits.
+
+The first draft specified detach as "skip `cmd.Wait()`". That was wrong, and
+would have produced a black screen on lobster's most important paths, because
+playback depends on process-local resources that die when lobster exits:
+
+- **The de-obfuscating HLS proxy.** `wrapDeobfuscated` starts a loopback proxy
+  and returns a cleanup that every player defers (`mpv.go:41`, `vlc.go:33`,
+  `generic.go:31`). It serves `Deobfuscate` streams — set by AniPub
+  (`internal/provider/anipub.go:207`), the working anime path.
+- **The torrent server.** `cmd/search.go:518-522` stands up an in-process
+  `torrentstream` server with `defer ts.Close()`. YTS returns magnets
+  exclusively.
+- **The subtitle temp dir.** `cmd/search.go:497-499` defers `os.RemoveAll`.
+
+It was also not mechanically possible as described: `vlc.go:57` and
+`generic.go:53` call `cmd.Run()`, with no `Start`/`Wait` to split.
+
+Re-exec avoids all of it. The background process performs an ordinary attached
+play, so proxy, torrent server, subtitles and mpv IPC all behave exactly as they
+do interactively — including resume tracking, which is preserved rather than
+sacrificed.
+
+```json
+{"schema":1,"status":"playing","pid":48213,
+ "log":"~/.cache/lobster/play-48213.log","resume_tracking":true}
+```
+
+Implementation requirements:
+
+- **Platform-specific spawn.** `syscall.SysProcAttr{Setpgid:true}` is Unix-only;
+  Windows needs `CreationFlags: CREATE_NEW_PROCESS_GROUP|DETACHED_PROCESS`. CI
+  runs windows-latest, so this needs a `detach_unix.go` / `detach_windows.go`
+  pair, following the existing build-tag pattern (`ipc_windows.go`,
+  `fzf_path_windows.go`). No `SysProcAttr` exists anywhere in the tree today.
+- **Child output goes to the log file**, never to the inherited pipe — all three
+  players set `cmd.Stdout = os.Stdout` (`mpv.go:80`, `vlc.go:53`,
+  `generic.go:49`), which would otherwise interleave with the JSON already
+  written and corrupt it. Child stdin is nil; there is no TTY.
+- **Liveness wait before reporting success.** `cmd.Start()` succeeding only
+  means the binary exec'd. mpv's own "stream failed to load" detection is
+  "exited in under 5s with no playback" (`mpv.go:120-122`). The foreground waits
+  ~1s and confirms the child is alive before emitting `status: playing`;
+  otherwise it reports the failure with exit code 3 or 4 and points at the log.
+  This does not eliminate the race — a stream can still die at 3s — but it
+  removes the common case of reporting success for a stream that never started.
+- **`resume_tracking` is player-dependent, not detach-dependent.** VLC and
+  Generic never track position (`vlc.go:26-27`, `generic.go:25` both return an
+  empty `PlayResult`). The field reflects the actual configured player.
+
+## The skill
+
+Ships in-repo at `skills/lobster-play/SKILL.md`, with install instructions in
+the README (copy to `~/.claude/skills/`, or an `install.sh` flag). Keeping it in
+the repo versions it alongside the CLI contract it depends on.
+
+The frontmatter description triggers on intent, not tool name — users say "put
+on Parasite," not "use lobster":
+
+> Use when the user asks to find, search for, or play a movie or TV episode.
+
+The body teaches five things:
+
+1. **Run `find` first, show candidates, and stop.** Never play without
+   confirmation. An instruction, not a judgement call left to the model.
+2. **Never construct a `ref`** — only echo back one `find` returned.
+3. **Always `--detach`**, and report the pid and log path.
+4. **Do not overclaim.** `ref` pins the selection, not the stream; if a
+   different provider serves the title, say so rather than asserting the exact
+   source.
+5. **A do-not-run list.** This is the highest-value part: without it the most
+   likely agent failure is an indefinite hang with no error.
+
+   | Command | What happens |
+   | ------- | ------------ |
+   | `lobster` (no args) | opens a full-screen Bubble Tea TUI (`cmd/search.go:41-52`) |
+   | `lobster <query>` | blocks on fzf |
+   | `lobster trending` / `recent` | blocks on fzf |
+   | `lobster history` | blocks on fzf (`cmd/history.go:31`) |
+
+Error handling maps the exit codes: `2` suggest a spelling fix, `3` run
+`lobster doctor` and report which providers are down, `4` the player is not
+installed.
+
+## Testing
+
+Red-green throughout, per existing repo practice.
+
+**The primary guard is a hostile environment, not a mock.** Run each new command
+in a test with `os.Stdin` replaced by a closed pipe *and* a `PATH` containing an
+`fzf` shim that fails the test if executed. Injecting `ui.Select` alone —
+the first draft's proposal — is insufficient, because it misses every other
+blocking vector:
+
+- `ui.Input` (`ui.go:98-127`) execs fzf directly and never touches `Select`;
+  used at `search.go:290,364`.
+- `ui.SelectWithTimeout` (`ui.go:133-196`) calls `term.MakeRaw(os.Stdin)` and
+  blocks reading stdin before reaching `Select`; used at `session.go:94`.
+- `tui.StartApp` (`search.go:52`) is Bubble Tea, not fzf at all.
+- All three players set `cmd.Stdin = os.Stdin`.
+
+The environment guard catches all of these, and any vector added later.
+Injecting `ui.Select` remains a useful complement, not a substitute.
+
+**A `newPlayer` seam is required**, mirroring the `flixhqDomain` stubbing
+pattern already in `cmd/fallback_providers_test.go:30-36`. `player.New` is
+called concretely at `cmd/search.go:571`; without a seam the detach test can only
+be written as an integration test that really launches mpv.
+
+Also covered:
+
+- `find` → `play` round-trip **through the real fallback resolver**, not only a
+  stub provider — that is where the ID-portability problem bites, so a stub
+  would test the wrong thing.
+- Every error path emits parseable JSON on stdout with the correct exit code.
+- Nothing writes to stdout except the JSON envelope. (Spinners are already
+  stderr-only — `internal/ui/spinner.go:17-25` — but player output is not.)
+- `ref` encode/decode round-trips, and a malformed `ref` produces a clean error
+  rather than a panic.
+
+Tests make no live network calls, following the `TestMain` stubbing pattern in
+`cmd/fallback_providers_test.go`, which exists precisely to stop tests probing
+real hosts.
+
+## Sequencing risk
+
+This touches `cmd/fallback.go`, `cmd/search.go` and the provider chain — the
+same area PR #36 (`feat/tbcpl-catalog-feed`) is resolving conflicts in.
+Implementation should wait for #36 to land, or proceed on a clean worktree.
+
+## Decisions taken
+
+| Decision | Choice | Why |
+| -------- | ------ | --- |
+| Scope | Skill + non-interactive CLI | Skill alone documents an impossible workflow |
+| Ambiguous matches | Always confirm with user | Removes the need for a ranking heuristic entirely |
+| Media types | Movies + TV; Live TV deferred | Channel IDs are not stable across processes |
+| Replay | Opaque `--ref` token, not `--id` | IDs are provider-scoped; resolver re-searches by title |
+| Detach | Re-exec self as supervisor | Proxy, torrent server and subtitles must outlive the foreground |
+| Surface | New verbs + `schema` field | Avoids dual-mode selection paths |
+
+## Revision note
+
+An adversarial review of the first draft found that `play --id` could play the
+wrong film, and that `--detach` as specified would break anime and all YTS
+playback. Both claims were verified against source before this rewrite. The
+first draft's "there is no re-search between confirmation and playback" was
+simply false. Recorded here because the same mistake is easy to repeat: lobster's
+resilience comes from re-searching across providers, which is precisely what
+makes a bare ID an unreliable handle.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/image v0.42.0
 	golang.org/x/term v0.41.0
+	golang.org/x/text v0.38.0
 	modernc.org/sqlite v1.50.0
 )
 
@@ -114,7 +115,6 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	lukechampine.com/blake3 v1.1.6 // indirect
 	modernc.org/libc v1.72.0 // indirect

--- a/internal/provider/allanime.go
+++ b/internal/provider/allanime.go
@@ -157,7 +157,7 @@ func (a *AllAnime) Search(query string) ([]media.SearchResult, error) {
 		}
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("no anime found for %q", query)
+		return nil, fmt.Errorf("%w: no anime found for %q", ErrNoResults, query)
 	}
 	// AllAnime returns specials/spinoffs (1 episode) ahead of the main series, so
 	// "Death Note" lands on a 1-ep special instead of the 37-ep show. Rank exact

--- a/internal/provider/anipub.go
+++ b/internal/provider/anipub.go
@@ -98,7 +98,7 @@ func (p *AniPub) Search(query string) ([]media.SearchResult, error) {
 		})
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("no anime found for %q", query)
+		return nil, fmt.Errorf("%w: no anime found for %q", ErrNoResults, query)
 	}
 	return out, nil
 }
@@ -244,7 +244,7 @@ func (p *AniPub) searchVariants(title string) ([]media.SearchResult, error) {
 		}
 	}
 	if lastErr == nil {
-		lastErr = fmt.Errorf("no anime found for %q", title)
+		lastErr = fmt.Errorf("%w: no anime found for %q", ErrNoResults, title)
 	}
 	return nil, lastErr
 }

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -1,0 +1,17 @@
+package provider
+
+import "errors"
+
+// ErrNoResults reports that a provider was reached and answered, but its
+// catalog has nothing for the query.
+//
+// Most providers signal an empty search by returning an error rather than an
+// empty slice, which makes "this title does not exist" indistinguishable from
+// "this provider is down" to a caller that only sees `err != nil`. That
+// ambiguity is not cosmetic: cmd/find.go turns it into an exit code, and
+// exit 3 ("every source is down, run lobster doctor") on what is usually a
+// typo sends an agent to diagnose provider health over a misspelling.
+//
+// Wrap this with %w at every such site so callers can use errors.Is instead of
+// matching the message text.
+var ErrNoResults = errors.New("no results found")

--- a/internal/provider/errors_test.go
+++ b/internal/provider/errors_test.go
@@ -1,0 +1,156 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Every provider whose Search signals an empty catalog with an *error* must
+// wrap ErrNoResults, or cmd.gatherSearchResults classifies a typo as an
+// outage and `find` exits 3 ("run lobster doctor") instead of 2.
+//
+// This is the test the plumbing in cmd/ cannot provide: those tests construct
+// ErrNoResults themselves, so they pass even if not one real provider ever
+// produces it. Here each provider is driven, through its own parser, to the
+// zero-result branch and the returned error is inspected.
+//
+// The four providers that return an empty slice with a nil error instead —
+// Consumet, YTS, MovieBox and LiveTV — need no sentinel: gatherSearchResults
+// already reads err == nil as "reached".
+// TestSearchProvidersThatReportEmptyAsNilError pins the two of those that have
+// an injectable endpoint.
+func TestSearchWrapsErrNoResultsOnAnEmptyCatalog(t *testing.T) {
+	// An HTML page with no result cards: what every scraper provider gets back
+	// for a query its site does not index. TLS, and the provider is built by
+	// hand with ts.Client() and a scheme-less base — the same shape as
+	// TestFlixHQWSGetServersIntegration. The constructors cannot be used here:
+	// BaseURL() prepends "https://" itself and httputil rejects anything else,
+	// so a plain httptest.NewServer URL turns into "https://http//127.0.0.1:..."
+	// and the test performs a real DNS lookup for the host "http".
+	emptyHTML := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><div class="film_list-wrap"></div></body></html>`))
+	}))
+	t.Cleanup(emptyHTML.Close)
+	htmlHost := strings.TrimPrefix(emptyHTML.URL, "https://")
+
+	// TMDB's multi-search answering with an empty result set.
+	emptyTMDB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	t.Cleanup(emptyTMDB.Close)
+
+	oldTMDB := tmdbBaseURL
+	tmdbBaseURL = emptyTMDB.URL
+	t.Cleanup(func() { tmdbBaseURL = oldTMDB })
+
+	tbcpl := NewTBCPL("tbcpl")
+	tbcpl.tmdbBaseURL = emptyTMDB.URL
+
+	// AniPub answers a miss with a bare `{"found":false}` object; AllAnime with
+	// an empty GraphQL edge list. fakeDoer's default response covers both.
+	anipub := NewAniPub()
+	anipub.client = fakeDoer{routes: map[string]string{"/api/search/": `{"found":false}`}}
+
+	allanime := NewAllAnime(false)
+	allanime.client = fakeDoer{routes: map[string]string{
+		"shows": `{"data":{"shows":{"edges":[]}}}`,
+	}}
+
+	cases := []struct {
+		name string
+		p    Provider
+	}{
+		{"flixhq", &FlixHQ{base: htmlHost, client: emptyHTML.Client()}},
+		{"flixhqws", &FlixHQWS{base: htmlHost, client: emptyHTML.Client()}},
+		{"kimcartoon", &KimCartoon{base: htmlHost, client: emptyHTML.Client()}},
+		{"soap2day", NewSoap2Day()},
+		{"vidnest", NewVidNest()},
+		{"vaplayer", NewVaPlayer()},
+		{"tbcpl", tbcpl},
+		{"anipub", anipub},
+		{"allanime", allanime},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := tc.p.Search("zzzznotathing")
+			if err == nil {
+				// Not a failure of this package's contract — a provider may
+				// legitimately report empty as (nil, nil) — but it means this
+				// row is in the wrong table and proves nothing.
+				t.Fatalf("Search returned (%v, nil); this table is for providers that error on empty", results)
+			}
+			if !errors.Is(err, ErrNoResults) {
+				t.Fatalf("Search error = %v; want errors.Is(err, ErrNoResults) so cmd/find can exit 2 rather than 3", err)
+			}
+			// The query has to survive the wrap: the interactive path prints
+			// this error verbatim.
+			if !strings.Contains(err.Error(), "zzzznotathing") {
+				t.Fatalf("error %q does not name the query", err)
+			}
+		})
+	}
+}
+
+// AniPub's title-variant search is a second, independent zero-result site on
+// the same provider, reached by ResolveByTitle rather than Search.
+func TestAniPubSearchVariantsWrapsErrNoResults(t *testing.T) {
+	p := NewAniPub()
+	p.client = fakeDoer{routes: map[string]string{"/api/search/": `{"found":false}`}}
+
+	_, err := p.searchVariants("zzzznotathing")
+	if !errors.Is(err, ErrNoResults) {
+		t.Fatalf("searchVariants error = %v, want errors.Is(err, ErrNoResults)", err)
+	}
+}
+
+// The other half of the contract. These providers report an empty catalog as
+// an empty slice and a nil error, which gatherSearchResults already reads as
+// "provider reached". If one of them ever starts erroring instead it must join
+// the table above, so assert the current shape rather than leaving it implied.
+//
+// Consumet and YTS are covered here because both take an injectable endpoint.
+// MovieBox (moviebox.go, end of Search) and LiveTV (livetv.go, end of Search)
+// have the same shape but reach a hardcoded host with no seam, so they are
+// verified by inspection only — do not read this test as covering them.
+func TestSearchProvidersThatReportEmptyAsNilError(t *testing.T) {
+	emptyJSON := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	t.Cleanup(emptyJSON.Close)
+
+	consumet := &Consumet{baseURL: emptyJSON.URL, client: emptyJSON.Client()}
+	results, err := consumet.Search("zzzznotathing")
+	if err != nil {
+		t.Fatalf("Consumet.Search on an empty catalog = %v; if it now errors it must wrap ErrNoResults", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("Consumet.Search = %+v, want no results", results)
+	}
+
+	// YTS answers a miss with movie_count 0 and a null movies array.
+	emptyYTS := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","data":{"movie_count":0,"movies":null}}`))
+	}))
+	t.Cleanup(emptyYTS.Close)
+
+	oldYTS := ytsBase
+	ytsBase = emptyYTS.URL
+	t.Cleanup(func() { ytsBase = oldYTS })
+
+	yts := &YTS{client: emptyYTS.Client()}
+	results, err = yts.Search("zzzznotathing")
+	if err != nil {
+		t.Fatalf("YTS.Search on an empty catalog = %v; if it now errors it must wrap ErrNoResults", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("YTS.Search = %+v, want no results", results)
+	}
+}

--- a/internal/provider/flixhq.go
+++ b/internal/provider/flixhq.go
@@ -64,7 +64,7 @@ func (f *FlixHQ) Search(query string) ([]media.SearchResult, error) {
 	}
 
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 
 	// Sort by relevance to the original query

--- a/internal/provider/flixhqws.go
+++ b/internal/provider/flixhqws.go
@@ -65,7 +65,7 @@ func (f *FlixHQWS) Search(query string) ([]media.SearchResult, error) {
 	}
 
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 
 	sortByRelevance(results, query)

--- a/internal/provider/kimcartoon.go
+++ b/internal/provider/kimcartoon.go
@@ -79,7 +79,7 @@ func (k *KimCartoon) Search(query string) ([]media.SearchResult, error) {
 	}
 
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 
 	sortByRelevance(results, query)

--- a/internal/provider/soap2day.go
+++ b/internal/provider/soap2day.go
@@ -75,7 +75,7 @@ func (s *Soap2Day) Search(query string) ([]media.SearchResult, error) {
 		return nil, fmt.Errorf("search: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 	return results, nil
 }

--- a/internal/provider/tbcpl.go
+++ b/internal/provider/tbcpl.go
@@ -196,7 +196,7 @@ func (t *TBCPL) Search(query string) ([]media.SearchResult, error) {
 		return nil, fmt.Errorf("tbcpl search: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 	return results, nil
 }

--- a/internal/provider/vaplayer.go
+++ b/internal/provider/vaplayer.go
@@ -81,7 +81,7 @@ func (vp *VaPlayer) Search(query string) ([]media.SearchResult, error) {
 		return nil, fmt.Errorf("vaplayer search: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 	return results, nil
 }

--- a/internal/provider/vidnest.go
+++ b/internal/provider/vidnest.go
@@ -63,7 +63,7 @@ func (v *VidNest) Search(query string) ([]media.SearchResult, error) {
 		return nil, fmt.Errorf("search: %w", err)
 	}
 	if len(results) == 0 {
-		return nil, fmt.Errorf("no results found for %q", query)
+		return nil, fmt.Errorf("%w for %q", ErrNoResults, query)
 	}
 	return results, nil
 }

--- a/internal/resolver/foreign_id_test.go
+++ b/internal/resolver/foreign_id_test.go
@@ -1,0 +1,60 @@
+package resolver
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// A fallback provider indexes its own catalogue, so the ID the user's
+// selection came from means nothing to it. What still identifies the work is
+// the title and year — which is why the agent-facing ref carries them rather
+// than an ID alone.
+//
+// Without Title and Year the request degenerates and a franchise query returns
+// whichever sequel the provider happens to rank first.
+func TestCandidatesForPicksRightWorkWhenIDsAreForeign(t *testing.T) {
+	// None of these IDs match the request: this provider uses its own scheme.
+	results := []media.SearchResult{
+		{ID: "yts/9001", Title: "The Matrix Resurrections", Year: "2021", Type: media.Movie},
+		{ID: "yts/9002", Title: "The Matrix Reloaded", Year: "2003", Type: media.Movie},
+		{ID: "yts/9003", Title: "The Matrix", Year: "1999", Type: media.Movie},
+	}
+
+	req := Request{
+		ID:        "movie/watch-the-matrix-19724", // from a different provider
+		Title:     "The Matrix",
+		Year:      "1999",
+		MediaType: media.Movie,
+	}
+
+	got := candidatesFor(results, req)
+	if len(got) == 0 {
+		t.Fatal("no candidates returned")
+	}
+	if got[0].Title != "The Matrix" || got[0].Year != "1999" {
+		t.Fatalf("top candidate = %q (%s), want The Matrix (1999); "+
+			"title+year ranking is what rescues a foreign ID", got[0].Title, got[0].Year)
+	}
+}
+
+// The counter-case: strip Title and Year, as a bare --id would, and the
+// ranking has nothing to work with. This documents why the ref carries more
+// than an ID: if this ever starts passing, the ref could be simplified.
+func TestCandidatesForCannotDisambiguateWithoutTitleOrYear(t *testing.T) {
+	results := []media.SearchResult{
+		{ID: "yts/9001", Title: "The Matrix Resurrections", Year: "2021", Type: media.Movie},
+		{ID: "yts/9003", Title: "The Matrix", Year: "1999", Type: media.Movie},
+	}
+
+	req := Request{ID: "movie/watch-the-matrix-19724", MediaType: media.Movie}
+
+	got := candidatesFor(results, req)
+	if len(got) == 0 {
+		t.Fatal("no candidates returned")
+	}
+	if got[0].Title == "The Matrix" && got[0].Year == "1999" {
+		t.Fatal("an ID-only request picked the right film; if this is now " +
+			"reliable, revisit whether playRef still needs Title and Year")
+	}
+}

--- a/internal/resolver/matches_test.go
+++ b/internal/resolver/matches_test.go
@@ -1,0 +1,184 @@
+package resolver
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// Matches is the gate that stops a fallback provider's *different* show being
+// printed under a ref's title (cmd.probeSeasons). These cases pin both halves
+// of that: what a ref must still recognise across catalogues that punctuate
+// titles differently, and what it must refuse however plausible it ranks.
+func TestMatches(t *testing.T) {
+	tests := []struct {
+		name   string
+		result media.SearchResult
+		req    Request
+		want   bool
+	}{
+		// --- identity by ID ---
+		{
+			name:   "identical ID beats a differing title",
+			result: media.SearchResult{ID: "tv/1396", Title: "Breaking Bad (2008)"},
+			req:    Request{ID: "tv/1396", Title: "Breaking Bad"},
+			want:   true,
+		},
+		{
+			name:   "identical ID with a wholly unrelated title still matches",
+			result: media.SearchResult{ID: "tv/1396", Title: "Bryzgun Belyi"},
+			req:    Request{ID: "tv/1396", Title: "Breaking Bad"},
+			want:   true,
+		},
+		{
+			name:   "different ID falls through to the title test",
+			result: media.SearchResult{ID: "fb/9", Title: "Breaking Bad"},
+			req:    Request{ID: "tv/1396", Title: "Breaking Bad"},
+			want:   true,
+		},
+
+		// --- titles that are the same work spelled differently ---
+		{
+			name:   "exact title",
+			result: media.SearchResult{ID: "fb/1", Title: "Breaking Bad"},
+			req:    Request{ID: "tv/1396", Title: "Breaking Bad"},
+			want:   true,
+		},
+		{
+			name:   "case and surrounding space",
+			result: media.SearchResult{ID: "fb/1", Title: "  BREAKING BAD "},
+			req:    Request{ID: "tv/1396", Title: "breaking bad"},
+			want:   true,
+		},
+		{
+			name:   "ampersand against the spelled-out and",
+			result: media.SearchResult{ID: "fb/1", Title: "Rick and Morty"},
+			req:    Request{ID: "tv/1", Title: "Rick & Morty"},
+			want:   true,
+		},
+		{
+			name:   "ampersand in the ref's direction too",
+			result: media.SearchResult{ID: "fb/1", Title: "Rick & Morty"},
+			req:    Request{ID: "tv/1", Title: "Rick and Morty"},
+			want:   true,
+		},
+		{
+			name:   "hyphen against a space",
+			result: media.SearchResult{ID: "fb/1", Title: "Spider Man"},
+			req:    Request{ID: "tv/1", Title: "Spider-Man"},
+			want:   true,
+		},
+		{
+			name:   "accented letter against its ASCII fold",
+			result: media.SearchResult{ID: "fb/1", Title: "Pokemon"},
+			req:    Request{ID: "tv/1", Title: "Pokémon"},
+			want:   true,
+		},
+		{
+			name:   "apostrophe and period noise",
+			result: media.SearchResult{ID: "fb/1", Title: "Marvels Agents of S H I E L D"},
+			req:    Request{ID: "tv/1", Title: "Marvel's Agents of S.H.I.E.L.D."},
+			want:   true,
+		},
+		{
+			name:   "ref carries a parenthetical region qualifier the provider omits",
+			result: media.SearchResult{ID: "fb/1", Title: "The Office"},
+			req:    Request{ID: "tv/1", Title: "The Office (US)"},
+			want:   true,
+		},
+		{
+			name:   "provider carries the parenthetical the ref omits",
+			result: media.SearchResult{ID: "fb/1", Title: "The Office (US)"},
+			req:    Request{ID: "tv/1", Title: "The Office"},
+			want:   true,
+		},
+		{
+			name:   "ampersand jammed against its neighbours",
+			result: media.SearchResult{ID: "fb/1", Title: "Rick&Morty"},
+			req:    Request{ID: "tv/1", Title: "Rick and Morty"},
+			want:   true,
+		},
+		{
+			name:   "ref carries a colon-separated season qualifier the provider omits",
+			result: media.SearchResult{ID: "fb/1", Title: "Attack on Titan"},
+			req:    Request{ID: "tv/1", Title: "Attack on Titan: Final Season"},
+			want:   true,
+		},
+
+		// --- different works that must never be admitted ---
+		{
+			name:   "provider title merely begins with the ref's",
+			result: media.SearchResult{ID: "fb/1", Title: "Lost in Space"},
+			req:    Request{ID: "tv/1", Title: "Lost"},
+			want:   false,
+		},
+		{
+			name:   "provider title is the ref's franchise plus a subtitle",
+			result: media.SearchResult{ID: "fb/1", Title: "Star Trek: Discovery"},
+			req:    Request{ID: "tv/1", Title: "Star Trek"},
+			want:   false,
+		},
+		{
+			name:   "ref's subtitle names a distinct work, not a season of the provider's",
+			result: media.SearchResult{ID: "fb/1", Title: "Star Trek"},
+			req:    Request{ID: "tv/1", Title: "Star Trek: Discovery"},
+			want:   false,
+		},
+		{
+			name:   "ref title merely begins with the provider's, with no qualifier separator",
+			result: media.SearchResult{ID: "fb/1", Title: "Lost"},
+			req:    Request{ID: "tv/1", Title: "Lost in Space"},
+			want:   false,
+		},
+		{
+			name:   "sibling regional editions are not each other",
+			result: media.SearchResult{ID: "fb/1", Title: "The Office (UK)"},
+			req:    Request{ID: "tv/1", Title: "The Office (US)"},
+			want:   false,
+		},
+		{
+			name:   "wholly unrelated title",
+			result: media.SearchResult{ID: "fb/1", Title: "Completely Different Show"},
+			req:    Request{ID: "tv/1", Title: "Breaking Bad"},
+			want:   false,
+		},
+		{
+			name:   "empty ref title cannot admit anything by title",
+			result: media.SearchResult{ID: "fb/1", Title: "Breaking Bad"},
+			req:    Request{ID: "tv/1", Title: ""},
+			want:   false,
+		},
+		{
+			name:   "empty ref title with an empty provider title is still not a match",
+			result: media.SearchResult{ID: "fb/1", Title: ""},
+			req:    Request{ID: "tv/1", Title: ""},
+			want:   false,
+		},
+		{
+			name:   "empty provider title cannot match a real ref",
+			result: media.SearchResult{ID: "fb/1", Title: ""},
+			req:    Request{ID: "tv/1", Title: "Breaking Bad"},
+			want:   false,
+		},
+		{
+			name:   "a ref title that is only punctuation matches nothing",
+			result: media.SearchResult{ID: "fb/1", Title: "Breaking Bad"},
+			req:    Request{ID: "tv/1", Title: ":-"},
+			want:   false,
+		},
+		{
+			name:   "an empty ref ID does not admit an empty provider ID",
+			result: media.SearchResult{ID: "", Title: "Completely Different Show"},
+			req:    Request{ID: "", Title: "Breaking Bad"},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Matches(tt.result, tt.req); got != tt.want {
+				t.Fatalf("Matches(%q, ref %q) = %v, want %v", tt.result.Title, tt.req.Title, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/resolver/matches_type_test.go
+++ b/internal/resolver/matches_type_test.go
@@ -1,0 +1,103 @@
+package resolver
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// Matches ignored media type entirely, so a TV ref was admitted by a
+// same-titled *film*. cmd.probeSeasons then called GetSeasons on a movie ID
+// and, when the provider answered with anything at all, printed it as that
+// show's seasons under the ref's own title, exit 0.
+//
+// "Spider-Man" is the real shape of this: the 2002 film and the 1994 animated
+// series share a title exactly, so every title-based test in Matches passes.
+func TestMatchesRejectsACandidateOfADifferentMediaType(t *testing.T) {
+	tests := []struct {
+		name   string
+		result media.SearchResult
+		req    Request
+		want   bool
+	}{
+		{
+			name:   "a film is not the series a TV ref asked for",
+			result: media.SearchResult{ID: "fb/557", Title: "Spider-Man", Type: media.Movie},
+			req:    Request{ID: "tv/888", Title: "Spider-Man", MediaType: media.TV},
+			want:   false,
+		},
+		{
+			name:   "a series is not the film a movie ref asked for",
+			result: media.SearchResult{ID: "fb/888", Title: "Spider-Man", Type: media.TV},
+			req:    Request{ID: "movie/557", Title: "Spider-Man", MediaType: media.Movie},
+			want:   false,
+		},
+		{
+			name:   "the qualifier rules do not smuggle a film past the type gate",
+			result: media.SearchResult{ID: "fb/1", Title: "The Office (US)", Type: media.Movie},
+			req:    Request{ID: "tv/2", Title: "The Office", MediaType: media.TV},
+			want:   false,
+		},
+		{
+			name:   "the right type still matches on title alone",
+			result: media.SearchResult{ID: "fb/888", Title: "Spider-Man", Type: media.TV},
+			req:    Request{ID: "tv/888-other", Title: "Spider-Man", MediaType: media.TV},
+			want:   true,
+		},
+		{
+			name:   "a movie ref still matches a movie by title",
+			result: media.SearchResult{ID: "fb/557", Title: "Spider-Man", Type: media.Movie},
+			req:    Request{ID: "movie/557-other", Title: "Spider-Man", MediaType: media.Movie},
+			want:   true,
+		},
+		{
+			// Decision (a): the type check sits BELOW the identical-ID return.
+			// IDs in this codebase carry their own type — "tv/1396",
+			// "movie/557", "series/watch-breaking-bad-39516" — so a candidate
+			// sharing a ref's ID while disagreeing about its type has
+			// contradicted itself, and the ID is the half that came from the
+			// catalogue rather than from a scraper's guess at a URL path.
+			// Letting the label win here would reject the one conclusive
+			// match there is.
+			name:   "an identical ID outranks a provider's own type label",
+			result: media.SearchResult{ID: "tv/1396", Title: "Breaking Bad", Type: media.Movie},
+			req:    Request{ID: "tv/1396", Title: "Breaking Bad", MediaType: media.TV},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Matches(tt.result, tt.req); got != tt.want {
+				t.Fatalf("Matches(%q %v, ref %q %v) = %v, want %v",
+					tt.result.Title, tt.result.Type, tt.req.Title, tt.req.MediaType, got, tt.want)
+			}
+		})
+	}
+}
+
+// Decision (b), pinned rather than left as a comment: media.Movie is the zero
+// value of media.MediaType, so a Request that never sets MediaType is
+// indistinguishable from one asking for a film, and the gate will refuse every
+// TV candidate. That is a live regression risk — a narrow fix on this path has
+// already made a fallback unreachable once — so the contract is asserted here
+// and both production construction sites are named.
+//
+// The two sites: cmd/episodes.go:seasonSource sets media.TV explicitly, and
+// cmd/fallback.go:tryFallbackStream copies content.Type off the selected
+// search result. Neither can leave it unset. Any third caller must set it too;
+// this test is what will tell them.
+func TestMatchesTreatsAnUnsetRequestMediaTypeAsMovie(t *testing.T) {
+	tv := media.SearchResult{ID: "fb/888", Title: "Spider-Man", Type: media.TV}
+	film := media.SearchResult{ID: "fb/557", Title: "Spider-Man", Type: media.Movie}
+
+	// MediaType deliberately omitted.
+	req := Request{Title: "Spider-Man"}
+
+	if Matches(tv, req) {
+		t.Fatal("a Request with no MediaType admitted a TV candidate; the zero value is media.Movie, so callers must set MediaType and this is the contract that says so")
+	}
+	if !Matches(film, req) {
+		t.Fatal("a Request with no MediaType must still match a movie — the zero value is media.Movie")
+	}
+}

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -124,6 +124,15 @@ func FallbackCandidates(results []media.SearchResult, mediaType media.MediaType)
 	return fallbackCandidates(results, mediaType)
 }
 
+// Candidates ranks results against the work req identifies, best first, capped
+// at MaxCandidates. Unlike FallbackCandidates it uses ID, Title and Year rather
+// than the provider's own relevance order — the same ranking resolveWithProvider
+// applies, exported for callers outside the resolver that re-search a foreign
+// catalog by title (cmd.seasonSource).
+func Candidates(results []media.SearchResult, req Request) []media.SearchResult {
+	return candidatesFor(results, req)
+}
+
 func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
 	return truncateCandidates(dedupeByType(results, mediaType))
 }

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -172,9 +172,44 @@ func Candidates(results []media.SearchResult, req Request) []media.SearchResult 
 // This is deliberately stricter than candidateScore, which still awards a
 // point for a bare prefix. Ranking may prefer a near miss; admission may not
 // accept one.
+//
+// # Media type
+//
+// A candidate of the wrong media type is not the work req identifies, however
+// well its title reads. "Spider-Man" is the 2002 film and the 1994 animated
+// series under one title, so no title rule can separate them. Nor does ranking
+// remove the film: candidatesFor delegates to dedupeByType, which returns the
+// *other* type when the requested one is absent, so a provider holding only
+// the film offers the film. Without this check cmd.probeSeasons went on to call
+// GetSeasons on a movie ID and printed whatever came back as the show's
+// seasons, under the ref's own title, exit 0.
+//
+// Two things about where the check sits and what it assumes:
+//
+// The check is BELOW the identical-ID return, so an ID match still wins. IDs
+// here carry their own type — "tv/1396", "movie/557",
+// "series/watch-breaking-bad-39516" — so a candidate that shares a ref's ID
+// while disagreeing about its type has contradicted itself, and the ID is the
+// half that came from the catalogue rather than from a scraper inferring a type
+// out of a URL path. Above the ID return, one mislabelled row would throw away
+// the only conclusive evidence of identity there is.
+//
+// Request.MediaType has no "unspecified": media.Movie is the zero value of
+// media.MediaType, so a Request that never sets it asks for a film and this
+// gate refuses every TV candidate. Callers must set it. Both production sites
+// do — cmd/episodes.go's seasonSource passes media.TV outright, and
+// cmd/fallback.go's tryFallbackStream copies Type off the search result the
+// user picked — and TestMatchesTreatsAnUnsetRequestMediaTypeAsMovie pins the
+// consequence so a third caller finds out from a test rather than from an
+// empty season list. Adding a sentinel to media.MediaType was the alternative;
+// it renumbers an iota compared across the codebase to fix a hazard with no
+// instances, which is the worse trade.
 func Matches(r media.SearchResult, req Request) bool {
 	if req.ID != "" && r.ID == req.ID {
 		return true
+	}
+	if r.Type != req.MediaType {
+		return false
 	}
 	title, want := normalize(r.Title), normalize(req.Title)
 	if title == "" || want == "" {

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 
 	"lobster/internal/extract"
 	"lobster/internal/media"
@@ -144,20 +147,126 @@ func Candidates(results []media.SearchResult, req Request) []media.SearchResult 
 // The test is the identity of the work, not the strength of the ranking:
 // candidateScore awards points for a year within one of req's, so a score
 // above zero is reachable by an unrelated show that happens to share a
-// release year. Only an identical ID — conclusive, the provider indexes the
-// same catalog — or a title that is req's title or begins with it counts.
+// release year. Admission needs an identical ID — conclusive, the provider
+// indexes the same catalog — or titles that reduce to the same normalized key.
 //
-// Deliberately the same title rule candidateScore rewards, so ranking and
-// admission cannot disagree about what a match is.
+// The rule is equality of keys, never a prefix. A prefix test admits a
+// *different* work whose title merely starts with the ref's: "Lost" would take
+// "Lost in Space", "Star Trek" would take "Star Trek: Discovery", and the
+// envelope would print the ref's own title over the impostor's seasons with
+// nothing for the caller to detect. normalize is what absorbs the harmless
+// disagreements instead — case, accents, "&" against "and", hyphens, dots and
+// apostrophes — so "Rick & Morty", "Spider-Man" and "Pokémon" still meet
+// "Rick and Morty", "Spider Man" and "Pokemon".
+//
+// One controlled inequality survives: a *qualifier* one side carries and the
+// other does not — a trailing parenthetical ("The Office (US)") or a
+// season/part subtitle ("Attack on Titan: Final Season"). stripQualifier is
+// applied to one side at a time and only where it removes something, so the
+// side being compared against keeps its own qualifier intact. That is what
+// keeps siblings apart: "The Office (US)" against "The Office (UK)" compares
+// "the office" to "the office uk" and "the office us" to "the office", and
+// fails both ways. An arbitrary subtitle is not a qualifier, so
+// "Star Trek: Discovery" is never reduced to "Star Trek" in either direction.
+//
+// This is deliberately stricter than candidateScore, which still awards a
+// point for a bare prefix. Ranking may prefer a near miss; admission may not
+// accept one.
 func Matches(r media.SearchResult, req Request) bool {
 	if req.ID != "" && r.ID == req.ID {
 		return true
 	}
-	if req.Title == "" {
+	title, want := normalize(r.Title), normalize(req.Title)
+	if title == "" || want == "" {
 		return false
 	}
-	title, want := normalize(r.Title), normalize(req.Title)
-	return title == want || strings.HasPrefix(title, want)
+	if title == want {
+		return true
+	}
+	// Qualifier stripped from one side only, never both at once.
+	if base, ok := stripQualifier(r.Title); ok && base == want {
+		return true
+	}
+	if base, ok := stripQualifier(req.Title); ok && base == title {
+		return true
+	}
+	return false
+}
+
+// stripQualifier returns the normalized key of s with an edition qualifier
+// removed, and whether one was actually there. A qualifier is a trailing
+// parenthesised or bracketed group ("The Office (US)", "Doctor Who (2005)"),
+// or a subtitle after a colon or a spaced dash that names a season, part or
+// cour rather than a distinct work ("Attack on Titan: Final Season").
+//
+// Subtitles that are not season designators are left alone precisely so that
+// "Star Trek: Discovery" cannot be reduced to "Star Trek".
+func stripQualifier(s string) (string, bool) {
+	t := strings.TrimSpace(s)
+	full := normalize(t)
+
+	for {
+		trimmed := trimTrailingGroup(t)
+		if trimmed == t {
+			break
+		}
+		t = trimmed
+	}
+
+	if head, tail, ok := splitSubtitle(t); ok && isSeasonQualifier(tail) {
+		t = head
+	}
+
+	key := normalize(t)
+	if key == "" || key == full {
+		return "", false
+	}
+	return key, true
+}
+
+// trimTrailingGroup removes one trailing "(...)" or "[...]" group from s.
+func trimTrailingGroup(s string) string {
+	s = strings.TrimSpace(s)
+	var open byte
+	switch {
+	case strings.HasSuffix(s, ")"):
+		open = '('
+	case strings.HasSuffix(s, "]"):
+		open = '['
+	default:
+		return s
+	}
+	i := strings.LastIndexByte(s[:len(s)-1], open)
+	if i <= 0 {
+		return s
+	}
+	return strings.TrimSpace(s[:i])
+}
+
+// splitSubtitle splits s at the first colon or spaced dash separator. The
+// dash must be spaced so that "Spider-Man" is one title, not two.
+func splitSubtitle(s string) (head, tail string, ok bool) {
+	if i := strings.IndexByte(s, ':'); i > 0 {
+		return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+1:]), true
+	}
+	for _, sep := range []string{" - ", " – ", " — "} {
+		if i := strings.Index(s, sep); i > 0 {
+			return strings.TrimSpace(s[:i]), strings.TrimSpace(s[i+len(sep):]), true
+		}
+	}
+	return s, "", false
+}
+
+// isSeasonQualifier reports whether a subtitle names a slice of the same work
+// ("Final Season", "Part 2", "Cour 1") rather than a separate one.
+func isSeasonQualifier(tail string) bool {
+	for _, w := range strings.Fields(normalize(tail)) {
+		switch w {
+		case "season", "seasons", "part", "parts", "cour":
+			return true
+		}
+	}
+	return false
 }
 
 func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {
@@ -260,9 +369,47 @@ func candidateScore(r media.SearchResult, req Request) int {
 	return score
 }
 
-// normalize lowercases and trims a title for comparison.
+// normalize reduces a title to a comparison key, so that two catalogs
+// punctuating the same work differently still agree. It case-folds, strips
+// accents (NFD then drop the combining marks, so "Pokémon" keys as
+// "pokemon"), spells "&" as "and", drops apostrophes outright so "Marvel's"
+// keys as "marvels", and collapses every other non-alphanumeric run —
+// hyphens, colons, dots, brackets — to a single space.
+//
+// Dropping rather than spacing apostrophes is the one asymmetry: catalogs
+// write "Marvels", never "Marvel s". Dots become spaces because
+// "S.H.I.E.L.D." is written "S H I E L D" as often as it is elided.
+//
+// A key can legitimately be empty (a title of pure punctuation); callers must
+// treat that as "no title" rather than as something to compare.
 func normalize(s string) string {
-	return strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	b.Grow(len(s))
+	pendingSpace := false
+	for _, r := range norm.NFD.String(strings.ToLower(s)) {
+		switch {
+		case unicode.Is(unicode.Mn, r):
+			// A combining mark NFD split off an accented letter.
+		case r == '\'' || r == '’':
+			// Elided, not spaced.
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			if pendingSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			pendingSpace = false
+			b.WriteRune(r)
+		case r == '&':
+			// Always a word of its own, so "Rick&Morty" keys like "Rick & Morty".
+			if b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString("and")
+			pendingSpace = true
+		default:
+			pendingSpace = true
+		}
+	}
+	return b.String()
 }
 
 // yearDiff returns the absolute difference between two year strings, or a large

--- a/internal/resolver/probe.go
+++ b/internal/resolver/probe.go
@@ -129,8 +129,35 @@ func FallbackCandidates(results []media.SearchResult, mediaType media.MediaType)
 // than the provider's own relevance order — the same ranking resolveWithProvider
 // applies, exported for callers outside the resolver that re-search a foreign
 // catalog by title (cmd.seasonSource).
+//
+// Ranking is not filtering. Every candidate of the right media type is
+// returned, including ones that match nothing about req: within resolution
+// that is safe, because a candidate still has to yield a playable stream. A
+// caller that only reads metadata off the candidate has no such check and must
+// gate on Matches first.
 func Candidates(results []media.SearchResult, req Request) []media.SearchResult {
 	return candidatesFor(results, req)
+}
+
+// Matches reports whether r can plausibly be the work req identifies.
+//
+// The test is the identity of the work, not the strength of the ranking:
+// candidateScore awards points for a year within one of req's, so a score
+// above zero is reachable by an unrelated show that happens to share a
+// release year. Only an identical ID — conclusive, the provider indexes the
+// same catalog — or a title that is req's title or begins with it counts.
+//
+// Deliberately the same title rule candidateScore rewards, so ranking and
+// admission cannot disagree about what a match is.
+func Matches(r media.SearchResult, req Request) bool {
+	if req.ID != "" && r.ID == req.ID {
+		return true
+	}
+	if req.Title == "" {
+		return false
+	}
+	title, want := normalize(r.Title), normalize(req.Title)
+	return title == want || strings.HasPrefix(title, want)
 }
 
 func fallbackCandidates(results []media.SearchResult, mediaType media.MediaType) []media.SearchResult {

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -5,36 +5,71 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"golang.org/x/term"
 )
 
+// spinnerVisible reports whether an animated spinner belongs on stderr.
+//
+// A spinner is a cursor-addressing animation: every frame is "\r" plus an SGR
+// sequence, which only means anything to a terminal. Where stderr is a file or
+// a pipe the carriage returns do not overwrite, so a 10-second resolve at 80ms
+// a frame deposits ~125 frames — several KB of "⠋ Fetching..." — into whatever
+// is on the other end.
+//
+// That is not merely untidy for `play --detach`: cmd/detach.go points the
+// child's stderr at a log file, and that log is the only diagnostic an agent
+// has once the parent has already returned {"status":"started"}. It has to
+// stay readable.
+//
+// Overridable so tests can drive both branches; a pty is not worth requiring.
+var spinnerVisible = func() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
 // StartSpinner starts a simple animated CLI loader attached to stderr.
-// It returns a closer function that MUST be called to stop the spinner and restore the cursor.
+// It returns a closer function that MUST be called to stop the spinner and
+// restore the cursor. When stderr is not a terminal the spinner is suppressed
+// entirely and the closer is a no-op — see spinnerVisible.
+//
+// The closer waits for the animation goroutine to finish, so once it returns
+// nothing further is written to stderr. It used to close a channel and sleep
+// 10ms instead, which does not hold: the goroutine slept 80ms between frames,
+// so its cursor-restore landed up to 80ms after the caller had moved on — over
+// whatever the next writer had already printed.
 func StartSpinner(msg string) func() {
+	if !spinnerVisible() {
+		return func() {}
+	}
+
 	stopChan := make(chan struct{})
+	done := make(chan struct{})
 	frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
 	go func() {
+		defer close(done)
 		fmt.Fprintf(os.Stderr, "\033[?25l") // Hide terminal cursor
-		i := 0
-		for {
+		ticker := time.NewTicker(80 * time.Millisecond)
+		defer ticker.Stop()
+		for i := 0; ; i = (i + 1) % len(frames) {
+			fmt.Fprintf(os.Stderr, "\r\033[35m%s\033[0m %s", frames[i], msg)
+			// The stop check sits on the same select as the frame delay, so a
+			// stop is observed immediately rather than after the current
+			// frame's sleep has run to completion.
 			select {
 			case <-stopChan:
 				fmt.Fprintf(os.Stderr, "\r\033[K\033[?25h") // Clear current line and show cursor
 				return
-			default:
-				fmt.Fprintf(os.Stderr, "\r\033[35m%s\033[0m %s", frames[i], msg)
-				i = (i + 1) % len(frames)
-				time.Sleep(80 * time.Millisecond)
+			case <-ticker.C:
 			}
 		}
 	}()
 
 	var once sync.Once
 	return func() {
-		once.Do(func() {
-			close(stopChan)
-			// Small delay to ensure the goroutine receives the close signal and clears the prompt
-			time.Sleep(10 * time.Millisecond)
-		})
+		once.Do(func() { close(stopChan) })
+		// Outside the Once so a second call also waits rather than racing
+		// ahead of a stop still in flight.
+		<-done
 	}
 }

--- a/internal/ui/spinner_test.go
+++ b/internal/ui/spinner_test.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withPipedStderr points os.Stderr at a pipe for the duration of a test and
+// returns everything written to it. A pipe is what stderr actually is for a
+// detached run (cmd/detach.go hands the child a log file), so this is the real
+// non-terminal shape, not a mock of one.
+func withPipedStderr(t *testing.T, run func()) (out string) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	prev := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = prev }()
+
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				b.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- b.String()
+	}()
+
+	// Deferred rather than written after run(), with a named return so the
+	// value survives: a t.Fatal inside run() calls runtime.Goexit, which runs
+	// defers but never reaches a trailing statement — an unclosed write end
+	// would leave the reader goroutine blocked on Read for the rest of the
+	// run.
+	defer func() { r.Close() }()
+	defer func() { out = <-done }()
+	defer func() { w.Close() }()
+
+	run()
+	return
+}
+
+// The production rule itself, with no stub in the way: the real
+// spinnerVisible must say no when stderr is a pipe. Everything below relies on
+// this, so it is tested first rather than assumed.
+func TestSpinnerVisibleRejectsAPipedStderr(t *testing.T) {
+	var got bool
+	withPipedStderr(t, func() { got = spinnerVisible() })
+	if got {
+		t.Fatal("spinnerVisible() = true for a piped stderr, want false")
+	}
+}
+
+// The regression: a detached play wrote several KB of spinner frames into the
+// log the agent is told to read when the user reports nothing happened.
+func TestStartSpinnerSilentWhenStderrIsNotATerminal(t *testing.T) {
+	// No stub: withPipedStderr makes stderr genuinely non-terminal, which is
+	// exactly the state cmd/detach.go puts the child in.
+	out := withPipedStderr(t, func() {
+		stop := StartSpinner("Fetching The Matrix media stream...")
+		// Several frame intervals: 80ms each, so this would be ~5 frames.
+		time.Sleep(400 * time.Millisecond)
+		stop()
+	})
+
+	if out != "" {
+		t.Fatalf("spinner wrote %d bytes to a non-terminal stderr: %q", len(out), out)
+	}
+}
+
+// The suppression must not cost an interactive user their spinner.
+func TestStartSpinnerAnimatesWhenStderrIsATerminal(t *testing.T) {
+	prev := spinnerVisible
+	spinnerVisible = func() bool { return true }
+	t.Cleanup(func() { spinnerVisible = prev })
+
+	out := withPipedStderr(t, func() {
+		stop := StartSpinner("Searching...")
+		time.Sleep(200 * time.Millisecond)
+		stop()
+	})
+
+	if !strings.Contains(out, "Searching...") {
+		t.Fatalf("spinner did not write its message to a terminal stderr: %q", out)
+	}
+	if !strings.Contains(out, "\033[?25l") {
+		t.Fatalf("spinner did not hide the cursor: %q", out)
+	}
+	if !strings.Contains(out, "\033[35m") {
+		t.Fatalf("spinner did not emit a coloured frame: %q", out)
+	}
+	// Asserted, not hand-waved: the closer joins the animation goroutine, so
+	// the line clear and the cursor restore have provably landed by the time
+	// stop() returns. A closer that merely signalled and slept would make this
+	// a coin flip.
+	if !strings.HasSuffix(out, "\r\033[K\033[?25h") {
+		t.Fatalf("spinner did not clear the line and restore the cursor before stop() returned: %q", out)
+	}
+}
+
+// The closer is returned in both branches and must be safe to call, and safe
+// to call more than once.
+func TestStartSpinnerCloserIsIdempotent(t *testing.T) {
+	for _, visible := range []bool{true, false} {
+		prev := spinnerVisible
+		spinnerVisible = func() bool { return visible }
+
+		withPipedStderr(t, func() {
+			stop := StartSpinner("x")
+			stop()
+			stop()
+		})
+
+		spinnerVisible = prev
+	}
+}

--- a/skills/lobster-play/SKILL.md
+++ b/skills/lobster-play/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: lobster-play
+description: Use when the user asks to find, search for, or play a movie or TV episode — for example "put on Parasite", "find me something to watch", "play The Bear season 2 episode 3".
+---
+
+# Playing movies and TV with lobster
+
+`lobster` is a terminal media streamer. It has a machine-readable mode that
+never prompts, which is what you use. Its interactive commands will hang you
+forever — see the do-not-run list below.
+
+## Never run these
+
+These block on `fzf` or open a full-screen TUI and will not return:
+
+| Command | What happens |
+| ------- | ------------ |
+| `lobster` (no arguments) | opens a full-screen TUI |
+| `lobster <query>` | blocks on an fzf picker |
+| `lobster trending` / `lobster recent` | blocks on an fzf picker |
+| `lobster history` | blocks on an fzf picker |
+
+Use `find`, `episodes` and `play` instead. They print JSON on stdout and
+never wait for input.
+
+## The workflow
+
+### 1. Find candidates
+
+```
+lobster find "the matrix" --limit 10
+```
+
+```json
+{
+  "schema": 1,
+  "results": [
+    {"idx": 0, "ref": "eyJpZCI6...", "title": "The Matrix", "year": "1999", "type": "movie"}
+  ]
+}
+```
+
+### 2. Show the user the candidates and stop
+
+**Always ask which one before playing.** Do not pick for them, even when one
+result looks obviously right. List the titles and years and wait for an answer.
+
+### 3. Play the one they chose
+
+```
+lobster play --ref "eyJpZCI6..." --detach
+```
+
+```json
+{"schema": 1, "status": "playing", "pid": 48213,
+ "title": "The Matrix (1999)",
+ "log": "/home/u/.cache/lobster/play-847264193.log",
+ "resume_tracking": true}
+```
+
+Always pass `--detach`. Without it the command blocks for the entire film and
+your tool call will not return. Report the pid so the user can stop playback.
+
+The `log` path is randomly generated (`play-<random>.log` in the user cache
+dir) — it is not derived from the pid, so the only way to find a given run's
+log is the `log` key in that run's own JSON output. `resume_tracking` reflects
+whether the *configured player* reports playback position (true for mpv,
+false for vlc/iina and other players) — it has nothing to do with whether you
+detached; a detached play runs the same attached playback internally, in a
+background process.
+
+A ref remembers the provider base it was found under (e.g. `find --base
+yts`). `play --ref` resolves against that same base automatically, so you
+normally don't need to pass `--base` yourself. Pass `--base` explicitly only
+to deliberately override it.
+
+## TV series
+
+A TV ref needs both `--season` and `--episode`. Get the numbers first:
+
+```
+lobster episodes --ref "eyJpZCI6..." --season 2
+```
+
+```json
+{"schema": 1, "title": "Some Show", "seasons": [1, 2, 3], "season": 2,
+ "episodes": [{"number": 1, "title": "Pilot"}]}
+```
+
+Then:
+
+```
+lobster play --ref "eyJpZCI6..." --season 2 --episode 3 --detach
+```
+
+## Rules
+
+- **Never construct or edit a `ref`.** Only pass back one that `find` returned
+  verbatim. Refs are opaque; their contents are not a stable interface.
+- **Never reuse an `idx` from an earlier search.** It is only meaningful inside
+  the payload it came from. Search results vary between runs.
+- **Do not overclaim the source.** A ref pins the *selection*, not the stream.
+  If the original provider is down, another provider's copy of the same title
+  may be served. Say "playing The Matrix (1999)", not "playing it from X".
+- **Check `schema`.** If it is not `1`, the installed lobster does not match
+  this skill — tell the user instead of guessing at the output.
+- **`--download` is not supported by `play`.** It is rejected outright; if the
+  user wants a file saved rather than streamed, tell them to run the
+  interactive CLI themselves.
+
+## When something fails
+
+Errors are JSON on stdout too, so parse unconditionally:
+
+```json
+{"schema": 1, "error": {"code": "no_results", "message": "nothing matched \"the matirx\""}}
+```
+
+Branch on the exit code:
+
+| Exit | Meaning | What to do |
+| ---- | ------- | ---------- |
+| 0 | success | — |
+| 2 | no results | Suggest a spelling correction, or a different title |
+| 3 | every provider failed | Run `lobster doctor` and report which sources are down. Do **not** suggest a spelling fix — the title was found, the sources are broken |
+| 4 | player unavailable | mpv (or the configured player) is not installed |
+
+Exit 3 is common. Providers break often; this usually means "try again later"
+or "try a different title", not "you typed it wrong".
+
+## Out of scope
+
+Live TV channel listing and channel surfing are not available in this mode.
+For those, tell the user to run `lobster` interactively themselves.

--- a/skills/lobster-play/SKILL.md
+++ b/skills/lobster-play/SKILL.md
@@ -52,14 +52,28 @@ lobster play --ref "eyJpZCI6..." --detach
 ```
 
 ```json
-{"schema": 1, "status": "playing", "pid": 48213,
- "title": "The Matrix (1999)",
+{"schema": 1, "status": "started", "pid": 48213,
+ "title": "The Matrix",
  "log": "/home/u/.cache/lobster/play-847264193.log",
  "resume_tracking": true}
 ```
 
-Always pass `--detach`. Without it the command blocks for the entire film and
-your tool call will not return. Report the pid so the user can stop playback.
+**`--detach` is mandatory for you.** Two separate reasons, either one fatal:
+
+1. Without it the command blocks for the entire film and your tool call will
+   not return.
+2. Without it the JSON-on-stdout contract does not hold. An attached player
+   inherits lobster's stdout, so mpv's progress output is interleaved with the
+   JSON envelope and stdout will not parse. Only `--detach` redirects the
+   player's output (to the `log` file) and leaves stdout clean.
+
+`"status": "started"` means a player process was started — not that anything is
+on screen yet. lobster returns after about a second, while finding a working
+source and extracting the stream usually takes five to thirty, so most failures
+happen after this response was sent. **If the user says nothing happened, read
+the `log` path from this response** — that is where the child's output went.
+
+Report the pid so the user can stop playback.
 
 The `log` path is randomly generated (`play-<random>.log` in the user cache
 dir) — it is not derived from the pid, so the only way to find a given run's
@@ -70,9 +84,9 @@ detached; a detached play runs the same attached playback internally, in a
 background process.
 
 A ref remembers the provider base it was found under (e.g. `find --base
-yts`). `play --ref` resolves against that same base automatically, so you
-normally don't need to pass `--base` yourself. Pass `--base` explicitly only
-to deliberately override it.
+yts`). Both `play --ref` and `episodes --ref` resolve against that same base
+automatically, so you normally don't need to pass `--base` yourself. Pass
+`--base` explicitly only to deliberately override it.
 
 ## TV series
 
@@ -121,7 +135,8 @@ Branch on the exit code:
 | Exit | Meaning | What to do |
 | ---- | ------- | ---------- |
 | 0 | success | — |
-| 2 | no results | Suggest a spelling correction, or a different title |
+| 1 | bad invocation | You called it wrong: a malformed `ref`, a missing `--season`/`--episode`, an unrecognised `--type`, `--download` (unsupported), or an invalid config value. Fix the command; do not retry it unchanged |
+| 2 | no results | Suggest a spelling correction, or a different title. Also returned when the season or episode number does not exist — re-run `lobster episodes` and check |
 | 3 | every provider failed | Run `lobster doctor` and report which sources are down. Do **not** suggest a spelling fix — the title was found, the sources are broken |
 | 4 | player unavailable | mpv (or the configured player) is not installed |
 


### PR DESCRIPTION
Lets a coding agent find and play something: `lobster find` → show the user the
candidates → `lobster play --ref <REF> --detach`. Ships the CLI surface and the
agent skill together, because a skill alone would document a workflow the CLI
could not perform.

## Why this was needed

Every existing search path routes selection through `internal/ui.Select`, which
execs `fzf` and waits for a human — unconditionally, even for a single result.
`--json` does not help: it is read in `playStream` *after* interactive
selection, so `lobster --json "the matrix"` hangs at the prompt. An agent that
tries hangs until killed, which reads to the user as the agent freezing.

## What's here

```
lobster find "the matrix" [--type movie|tv] [--limit N]   -> JSON candidates, each with a ref
lobster episodes --ref <REF> [--season N]                 -> JSON season/episode listing
lobster play --ref <REF> [--season N --episode N] [--detach]
```

All JSON on stdout, never `fzf`. `skills/lobster-play/SKILL.md` + README install
steps. Existing commands are untouched — **`cmd/search.go` has zero diff**; only
`README.md`, `cmd/root.go` and two test files were modified.

## Two design decisions worth reviewing

**A bare `--id` would play the wrong film.** Provider IDs are not portable and
the resolver re-searches by title (`internal/resolver/probe.go:84`, doc comment
65-67). Measured on this codebase:

| Request | Top-ranked result |
| --- | --- |
| ID + Title + Year | The Matrix (1999) |
| ID only | The Matrix Resurrections (2021) |

So selections round-trip through an opaque `--ref` carrying id/title/year/type/base.
Pinned by `internal/resolver/foreign_id_test.go`, including a counter-test that
starts failing if the property ever changes.

**`--detach` re-execs lobster as a supervisor rather than skipping `cmd.Wait()`.**
Playback depends on process-local resources torn down by defers when lobster
exits: the HLS de-obfuscation proxy (deferred in `internal/player/*.go`, used by
the AniPub anime path), the torrent server (`cmd/search.go:518-522`; all YTS
content is magnets), and the subtitle temp dir. Skipping `Wait` would black-screen
those. It is also not mechanically possible — `vlc.go` and `generic.go` call
`cmd.Run()`.

## Verification

`go build`/`go vet`/`go test ./...` green; `GOOS=windows` build + vet and
`GOOS=darwin` build green; suite stable under `-shuffle=on` and `-race`. Tests
make no network calls, launch no player, and spawn no detached process.

**Not yet verified end to end:** `playDetached` itself has never executed — no
supervisor has been spawned, and no detached mpv has been confirmed playing. The
manual steps are in `docs/superpowers/plans/2026-09-03-agent-play-skill.md` and
take about two minutes.

## Known limitations

- `find` stamps the configured base on every result, but results may come from
  fallback providers with a different base. Documented on `playRef.Base` rather
  than fixed — correcting attribution needs provider identity threaded out of
  `gatherSearchResults`.
- The test helper that proves commands never prompt skips on Windows (its `fzf`
  shim needs a POSIX shell), so the new command bodies are compiled and vetted
  but not *run* on windows CI.
- A hand-edited ref with an unrecognised `type` maps to movie rather than erroring.
- Non-detached `play --ref` lets player output onto stdout, so it does not honour
  the JSON-only contract. Documented in the command help and the skill, which
  require `--detach` for agent use.
- Live TV is deliberately out of scope: channel IDs are disambiguated by load
  order (`internal/provider/livetv.go:161-172`) and so are not stable across
  processes.

## Merge order

#36 has since landed (`fa989cd`), so this branch is the only one open. It was
branched from `38e5888`; merge `main` in before landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added non-interactive `find`, `episodes`, and `play` commands for searching, browsing episodes, and starting playback.
  - Added machine-readable JSON results, structured errors, and meaningful exit codes.
  - Added reference tokens for selecting and replaying search results.
  - Added detached playback that continues after the terminal closes and reports status, process ID, and log location.
  - Added fallback episode discovery when the primary source cannot provide seasons.
  - Added the `lobster-play` agent skill and usage documentation.

- **Bug Fixes**
  - Prevented spinners from appearing when output is redirected or not attached to a terminal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->