### PR TITLE
docs: add CLAUDE.md and a ship skill for agent-assisted work

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: ship
+description: Use when carrying out any code change on lobster — from picking up a task through local CodeRabbit review, opening a PR, and monitoring it to merge. Covers worktrees, subagent delegation, and how to tell when a CodeRabbit review is genuinely finished.
+---
+
+# Shipping a change to lobster
+
+The standing rules are in `CLAUDE.md` and apply throughout. This is the
+procedure.
+
+**The main window coordinates; subagents do the work.** Every implementation,
+review, and investigation step below is a dispatch. The main window holds the
+plan and the decisions, not file contents or diffs.
+
+## 1. Set up an isolated workspace
+
+```bash
+git fetch origin
+git worktree add -b feat/<name> .worktrees/<name> origin/main
+```
+
+Never work on `main`. Check `git worktree list` and `git status` first — another
+session may be mid-merge in this checkout; if so, leave it alone.
+
+## 2. Understand before building
+
+For anything non-trivial, dispatch a read-only agent to map the area and report
+back the specific functions, seams and constraints that matter. Two things this
+repo punishes you for not knowing up front:
+
+- **Interactive blocking.** `internal/ui.Select` execs `fzf` unconditionally;
+  `ui.Input` execs it directly; `ui.SelectWithTimeout` reads raw stdin; the
+  no-arg root command opens a Bubble Tea TUI. Anything an agent or script must
+  drive has to avoid all four.
+- **Provider IDs are not portable.** The resolver re-searches by title
+  (`internal/resolver/probe.go`), so an ID alone does not identify a work. Carry
+  title and year too.
+
+## 3. Implement in small, reviewed steps
+
+Write the failing test first, watch it fail **on an assertion**, then implement.
+One logical change per commit.
+
+Dispatch an implementer per task with a brief and a report-file path. Ask it to
+return only: status, commit SHA, one-line test summary, concerns. Read the report
+file only if you need detail.
+
+Run the gate from `CLAUDE.md` before every commit.
+
+## 4. Local CodeRabbit review — before pushing
+
+The CLI is installed (`coderabbit`, authenticated). Review locally so obvious
+findings never reach a public PR:
+
+```bash
+cd .worktrees/<name>
+coderabbit review --plain --type committed --base main > /tmp/cr-local.md
+```
+
+`--type uncommitted` reviews the working tree; `--type all` does both. Use
+`--config CLAUDE.md` to give it this repo's conventions.
+
+Hand `/tmp/cr-local.md` to a subagent to triage — do not read it into the main
+window. For each finding: reproduce it first, fix only what is real, and record
+what you rejected and why.
+
+## 5. Open the PR
+
+```bash
+git push -u origin feat/<name>
+gh pr create --base main --title "<type>(<scope>): <summary>" --body-file /tmp/pr-body.md
+```
+
+No AI attribution anywhere in the title or body. A good body states what changed,
+*why* the non-obvious decisions were made, what was verified, and what was **not**
+verified — an honest limitations section is worth more than a feature list.
+
+## 6. Monitoring the PR — the part that goes wrong
+
+**A CodeRabbit review is finished only when the commit range in its walkthrough
+comment ends at the current head.** Nothing else is reliable:
+
+```bash
+head=$(gh pr view N --json headRefOid --jq .headRefOid)
+rng=$(gh api repos/billmal071/lobster/issues/N/comments --paginate \
+        --jq '.[] | select(.user.login=="coderabbitai[bot]") | .body' \
+      | grep -oE 'and [0-9a-f]{40}' | tail -1 | cut -d' ' -f2)
+[ "$head" = "$rng" ] && echo "reviewed current head" || echo "STALE — do not merge"
+```
+
+Traps, each of which has caused a wrong call here:
+
+- `gh pr view --json reviews` reports **stale passes**, and shows CodeRabbit's
+  in-thread replies as full reviews against the new head.
+- `gh pr checks` showing "CodeRabbit — pass" can mean *"Review rate limited"*.
+- The bot login differs per API: `coderabbitai[bot]` for issue comments,
+  `coderabbitai` in the GraphQL `reviewThreads` API. Filtering on the wrong one
+  returns an empty list, which reads as "no findings".
+- CodeRabbit posts **new** findings on re-review, so a PR that was clean an hour
+  ago may not be. Re-check the whole gate on the current head, every time.
+
+Unresolved threads:
+
+```bash
+gh api graphql -f query='{repository(owner:"billmal071",name:"lobster"){pullRequest(number:N){
+  reviewThreads(last:100){nodes{isResolved path line comments(first:3){nodes{databaseId author{login} body}}}}}}}' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)'
+```
+
+Reply **in-thread** — note the endpoint includes the PR number, and omitting it
+404s:
+
+```bash
+gh api repos/billmal071/lobster/pulls/N/comments/<comment_id>/replies -f body='...'
+```
+
+The "Docstring Coverage" pre-merge check is a warning, not a blocker: it fires
+because Go test functions have no doc comments, which is normal. Do not pad tests
+to satisfy it.
+
+## 7. Merge
+
+Merge only when all four hold: walkthrough range ends at head, zero unresolved
+threads, CI green (SKIPPED is fine — the weekly shai-hulud job normally is), and
+`mergeable == MERGEABLE`. Right after another merge GitHub returns `UNKNOWN`
+while it recomputes; re-poll rather than treating that as a blocker.
+
+```bash
+gh pr merge N --squash --delete-branch
+```
+
+Squash is this repo's convention — `main` is one commit per PR.
+
+Then clean up:
+
+```bash
+git worktree remove .worktrees/<name>
+git worktree prune
+```
+
+## For long waits
+
+Reviews land 10–60 minutes after a push. Don't poll in a tight loop — either use
+a scheduled check, or stop and report the state honestly so the owner can decide.
+Never write "the PR is done" off a single poll; that mistake has been made here.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -54,8 +54,13 @@ findings never reach a public PR:
 
 ```bash
 cd .worktrees/<name>
-coderabbit review --plain --type committed --base main > /tmp/cr-local.md
+git fetch origin
+coderabbit review --plain --type committed --base origin/main > /tmp/cr-local.md
 ```
+
+Use `origin/main`, not `main`: your local `main` is only as fresh as your last
+pull, so reviewing against it can compare the wrong range and hide or invent
+findings.
 
 `--type uncommitted` reviews the working tree; `--type all` does both. Use
 `--config CLAUDE.md` to give it this repo's conventions.
@@ -82,11 +87,26 @@ comment ends at the current head.** Nothing else is reliable:
 
 ```bash
 head=$(gh pr view N --json headRefOid --jq .headRefOid)
+# Select the walkthrough comment specifically, then read its range. Scanning
+# every bot comment and taking the last hash is unsound: any other bot comment
+# carrying a 40-hex sha wins, and a stale walkthrough then reads as current.
 rng=$(gh api repos/billmal071/lobster/issues/N/comments --paginate \
-        --jq '.[] | select(.user.login=="coderabbitai[bot]") | .body' \
+        --jq '.[] | select(.user.login=="coderabbitai[bot]")
+                  | select(.body | contains("<!-- walkthrough_start -->"))
+                  | .body' \
       | grep -oE 'and [0-9a-f]{40}' | tail -1 | cut -d' ' -f2)
-[ "$head" = "$rng" ] && echo "reviewed current head" || echo "STALE — do not merge"
+
+if [ -z "$rng" ]; then
+  echo "no walkthrough found — treat as NOT reviewed"   # fail closed
+elif [ "$head" = "$rng" ]; then
+  echo "reviewed current head"
+else
+  echo "STALE ($rng != $head) — do not merge"
+fi
 ```
+
+Fail closed on an empty result. An absent walkthrough means CodeRabbit has not
+reported on this head yet — never the same thing as a pass.
 
 Traps, each of which has caused a wrong call here:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,16 +38,24 @@ output.
 ## The gate before any commit
 
 ```bash
-PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...
+export PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0
+go build ./... && go vet ./... && go test ./...
 ```
+
+`export` matters. A `VAR=x cmd1 && cmd2` prefix applies only to `cmd1`, so the
+inline form silently runs `go vet` and `go test` with cgo enabled while only the
+build is cgo-disabled — the gate then validates a different configuration from
+the one that ships.
 
 CI runs ubuntu, windows and macos, so anything touching syscalls, paths or
 process handling also needs:
 
 ```bash
-CGO_ENABLED=0 GOOS=windows go build ./... && GOOS=windows go vet ./cmd/
-CGO_ENABLED=0 GOOS=darwin  go build ./...
+GOOS=windows go build ./... && GOOS=windows go vet ./cmd/
+GOOS=darwin  go build ./...
 ```
+
+(`CGO_ENABLED` is already exported above, so these do not need it inline.)
 
 Never commit on a red suite.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# Working on lobster
+
+Standing rules for this repo. The full ship procedure lives in the `ship` skill
+(`.claude/skills/ship/SKILL.md`) — invoke it with `/ship` when starting a change.
+
+## Authorship
+
+Commits and PRs belong to the repo owner. **Never** add a `Co-Authored-By`
+trailer, a "Generated with Claude Code" footer, or any other AI attribution — not
+in commit messages, not in PR descriptions, not in issue bodies. Write the commit
+message as the author would.
+
+## Delegate the work
+
+Do implementation, review, and investigation in **subagents**, not in the main
+window. The main window coordinates: it holds the plan, dispatches, reads short
+status lines, and decides. It should not hold file contents, diffs, or test
+output.
+
+- Give a subagent a written brief and a report-file path. It writes detail to the
+  file and returns a status line, commits, and a one-line test summary.
+- Never run two implementation subagents on the same branch at once.
+- Hand diffs over as files (`git diff > /tmp/...`), never pasted into a prompt.
+
+## Branching and worktrees
+
+- Never commit to `main`. Branch first.
+- Use a worktree per branch, under `.worktrees/<name>`:
+  `git worktree add -b feat/thing .worktrees/thing origin/main`
+  This repo already follows that layout; keep it.
+- **Never force-push a PR branch.** It discards the CodeRabbit reviews sitting on
+  that head and restarts the whole review cycle. To update a branch, `git merge
+  origin/main` — never rebase.
+- Another session may be working in this checkout. Before switching branches or
+  resetting, check `git status` and `git worktree list`; if a merge is in
+  progress that you did not start, leave it alone and use your own worktree.
+
+## The gate before any commit
+
+```bash
+PATH=/usr/local/go/bin:$PATH CGO_ENABLED=0 go build ./... && go vet ./... && go test ./...
+```
+
+CI runs ubuntu, windows and macos, so anything touching syscalls, paths or
+process handling also needs:
+
+```bash
+CGO_ENABLED=0 GOOS=windows go build ./... && GOOS=windows go vet ./cmd/
+CGO_ENABLED=0 GOOS=darwin  go build ./...
+```
+
+Never commit on a red suite.
+
+## Tests
+
+- **No live network calls.** A test that probes a real provider is slow and flaky
+  in CI. Stub through the package-level seams (`agentProvider`, `agentSearch`,
+  `agentResolveAndPlay`, `agentPlayerCheck`, `flixhqDomain`) or the `TestMain`
+  pattern in `cmd/fallback_providers_test.go`. If a test suddenly takes seconds,
+  it is probing something.
+- Never launch a real media player or spawn a detached process in a test.
+- Watch every new test **fail first**, on an assertion. A compile error is not a
+  red — it proves a symbol is missing, not that the test detects the bug.
+- Restore package-level vars and the global `cfg` with `t.Cleanup`.
+
+## Verify findings before fixing them
+
+Reviews on this repo have produced real bugs, wrong suggested fixes, and outright
+false alarms. Reproduce a finding against the actual code before changing
+anything, and say in the reply what you verified. If a suggested fix is wrong,
+push back with the reason rather than implementing it.
+
+## Content boundaries
+
+Do not author brand-new scrapers for pirate streaming sites, and do not
+reverse-engineer any site's private API, decryption, or crypto gating. Wiring
+existing or documented public APIs is fine.


### PR DESCRIPTION
Conventions for agent-assisted work on this repo. Opened as a PR only because a
ruleset on `main` requires one — this is tooling config for my own use, not a
change to lobster itself. No Go code is touched.

## What's here

`CLAUDE.md` — loads automatically each session: no AI attribution in commits or
PRs; work happens in subagents so the coordinating window stays free; branches
live in `.worktrees/`; never force-push a PR branch, since that discards the
CodeRabbit reviews already on that head; the build gate covers `GOOS=windows`
and `GOOS=darwin` because CI runs all three; tests make no live network calls and
must be watched failing on an assertion first.

`.claude/skills/ship/SKILL.md` — the procedure end to end, plus the review
monitoring traps: a CodeRabbit review is finished only when the commit range in
its walkthrough comment ends at the current head. `gh pr view --json reviews`
reports stale passes, `gh pr checks` can show "pass" meaning "rate limited", and
the bot login differs between the REST and GraphQL APIs so filtering on the wrong
one silently returns nothing.

## Second commit

I ran `coderabbit review` against these docs before pushing. It found three real
defects, all verified before fixing:

- The gate command was wrong. A `VAR=x cmd1 && cmd2` prefix applies only to
  `cmd1`, so `CGO_ENABLED=0` reached `go build` but never `go vet` or `go test` —
  the gate validated a different configuration from the one that ships. `go` is
  on the default PATH, so nothing failed loudly. Now exported.
- The local review compared against local `main` rather than `origin/main`, so it
  could review a stale range.
- The walkthrough check scanned every bot comment and took the last 40-hex match,
  so an unrelated bot comment carrying a sha could win and make a stale
  walkthrough read as current — a false "reviewed" in the one check documented as
  trustworthy. It now selects the walkthrough by its marker and fails closed when
  none exists. Verified against two real PRs: a reviewed one reports current, a
  freshly opened one fails closed.
