### PR TITLE
docs: document the agent surface and correct the exit-code contract

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -123,6 +123,118 @@ Output format:
 }
 ```
 
+## Scripting and Agents
+
+The commands above all use fzf, so they wait for a human. Three commands don't:
+`find`, `episodes` and `play`. They never open a picker, never wait for input,
+and print a JSON envelope on stdout — including when they fail.
+
+### Finding something
+
+```bash
+./lobster find "the matrix"              # every match, as JSON
+./lobster find "the bear" --type tv      # only series (movie | tv, case-insensitive)
+./lobster find "dune" --limit 5          # cap the result count
+```
+
+```json
+{
+  "schema": 1,
+  "results": [
+    {"idx": 0, "ref": "eyJpZCI6...", "title": "The Matrix", "year": "1999", "type": "movie"}
+  ]
+}
+```
+
+The `ref` is the handle for everything else. It is opaque — don't build one or
+edit one, just pass back what `find` printed. It carries the title, year and
+type as well as the ID, plus the base it was found under, so `episodes` and
+`play` resolve it against the same source without you passing `--base` again.
+`idx` is only meaningful inside the payload it came from; results vary between
+runs, so don't hold on to it.
+
+### Listing episodes
+
+```bash
+./lobster episodes --ref "$REF"             # first season
+./lobster episodes --ref "$REF" --season 2  # a specific one
+```
+
+```json
+{
+  "schema": 1,
+  "title": "Some Show",
+  "seasons": [1, 2, 3],
+  "season": 2,
+  "episodes": [{"number": 1, "title": "Pilot"}]
+}
+```
+
+`seasons` is the full list, so one call tells you both what exists and what is
+in the season you asked for.
+
+### Playing
+
+```bash
+./lobster play --ref "$REF" --detach                          # a movie
+./lobster play --ref "$REF" --season 2 --episode 3 --detach   # an episode
+```
+
+```json
+{
+  "schema": 1,
+  "status": "started",
+  "pid": 48213,
+  "title": "The Matrix",
+  "log": "/home/you/.cache/lobster/play-847264193.log",
+  "resume_tracking": true
+}
+```
+
+A series ref needs both `--season` and `--episode` — without them playback would
+fall through to the interactive picker and hang, so `play` rejects it instead.
+
+Pass `--detach` from a script. Attached, the player inherits lobster's stdout so
+that a human running `play --ref` still sees mpv's output — which means the JSON
+envelope is interleaved with progress lines and won't parse. `--detach` sends
+the player's output to the `log` file and returns in about a second.
+
+That second is the whole caveat: `"status": "started"` means a player process
+exists, not that anything is on screen. Finding a working source usually takes
+five to thirty seconds, so most failures land after the envelope was printed.
+The `log` path is where they land, and it's randomly named rather than derived
+from the pid, so keep it. `resume_tracking` says whether the configured player
+reports playback position — only mpv does.
+
+Attached, playing an episode starts the same continuous-playback session
+described above: the countdown runs when it ends and the next episode follows.
+Detached there is no terminal for that menu, so playback stops after the episode
+you asked for.
+
+`--download` is not supported by `play` — batch downloading is a prompt-driven
+path. Use the interactive CLI for that.
+
+### Exit codes
+
+Errors are JSON on stdout too, so parse unconditionally:
+
+```json
+{"schema": 1, "error": {"code": "no_results", "message": "nothing matched \"the matirx\""}}
+```
+
+The exit code is what to branch on:
+
+| Exit | Meaning |
+|------|---------|
+| **0** | Success |
+| **1** | You called it wrong — bad ref, missing `--season`/`--episode`, unknown flag, invalid config value, `--download`. Also internal failures like an unwritable cache dir |
+| **2** | Nothing matched. A typo, or a season/episode number the show doesn't have |
+| **3** | Every provider failed. The title is fine, the sources aren't — run `./lobster doctor` |
+| **4** | The configured player isn't installed or isn't on PATH |
+
+Check `schema`. If it isn't `1`, the output shape has changed and your script
+should say so rather than guess.
+
 ## Configuration
 
 Config file: `~/.config/lobster/config.toml`

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -232,6 +232,10 @@ The exit code is what to branch on:
 | **3** | Every provider failed. The title is fine, the sources aren't — run `./lobster doctor` |
 | **4** | The configured player isn't installed or isn't on PATH |
 
+One exception to exit 3: from `play --detach` it means the background process
+started and then died within a second. That isn't a provider outage report, and
+`doctor` won't explain it — the error message names the log file that will.
+
 Check `schema`. If it isn't `1`, the output shape has changed and your script
 should say so rather than guess.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -230,7 +230,7 @@ The exit code is what to branch on:
 | **1** | You called it wrong — bad ref, missing `--season`/`--episode`, unknown flag, invalid config value, `--download`. Also internal failures like an unwritable cache dir |
 | **2** | Nothing matched. A typo, or a season/episode number the show doesn't have |
 | **3** | Every provider failed. The title is fine, the sources aren't — run `./lobster doctor` |
-| **4** | The configured player isn't installed or isn't on PATH |
+| **4** | The configured player isn't installed or isn't on PATH, or the background process couldn't be started |
 
 One exception to exit 3: from `play --detach` it means the background process
 started and then died within a second. That isn't a provider outage report, and

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ scripting on their own:
 
 ```bash
 lobster find "the matrix" --limit 5      # JSON candidates, each with a ref
+lobster find "the bear" --type tv        # filter to movie | tv (case-insensitive)
 lobster episodes --ref <REF> --season 2  # JSON season/episode listing
 lobster play --ref <REF> --detach        # start playback, return immediately
 ```
@@ -263,6 +264,19 @@ player inherits lobster's stdout and its progress output is interleaved with
 the envelope. That is deliberate — a human running `lobster play --ref` should
 still see the player — so a script must pass `--detach` and read the player's
 output from the `log` path in the response.
+
+Failures use the same envelope — `{"schema": 1, "error": {"code": ..., "message": ...}}`
+— so stdout always parses. The exit code is what to branch on:
+
+| Exit | Meaning | What it usually means |
+| ---- | ------- | --------------------- |
+| `0` | Success | — |
+| `1` | Bad invocation | Malformed `ref`, missing `--season`/`--episode`, unknown flag, unrecognised `--type`, `--download` (unsupported by `play`), or an invalid config value. Also internal failures such as an unwritable cache directory. Retrying unchanged will not help |
+| `2` | Nothing matched | A misspelling, or a season/episode number the show does not have |
+| `3` | Every provider failed | The title exists, the sources are down. Run `lobster doctor`; do not suggest a spelling fix |
+| `4` | Player unavailable | mpv (or whichever player is configured) is not installed or not on `PATH` |
+
+Check `schema` before trusting the shape of the rest.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Failures use the same envelope — `{"schema": 1, "error": {"code": ..., "messag
 | `1` | Bad invocation | Malformed `ref`, missing `--season`/`--episode`, unknown flag, unrecognised `--type`, `--download` (unsupported by `play`), or an invalid config value. Also internal failures such as an unwritable cache directory. Retrying unchanged will not help |
 | `2` | Nothing matched | A misspelling, or a season/episode number the show does not have |
 | `3` | Every provider failed | The title exists, the sources are down. Run `lobster doctor`; do not suggest a spelling fix. From `play --detach` it means something narrower — the background process started and then died within a second, and the error message names the log that says why |
-| `4` | Player unavailable | mpv (or whichever player is configured) is not installed or not on `PATH` |
+| `4` | Player unavailable | mpv (or whichever player is configured) is not installed or not on `PATH`. From `play --detach` it also covers a background process that could not be started at all — distinct from exit 3, which is one that started and then died |
 
 Check `schema` before trusting the shape of the rest.
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Failures use the same envelope — `{"schema": 1, "error": {"code": ..., "messag
 | `0` | Success | — |
 | `1` | Bad invocation | Malformed `ref`, missing `--season`/`--episode`, unknown flag, unrecognised `--type`, `--download` (unsupported by `play`), or an invalid config value. Also internal failures such as an unwritable cache directory. Retrying unchanged will not help |
 | `2` | Nothing matched | A misspelling, or a season/episode number the show does not have |
-| `3` | Every provider failed | The title exists, the sources are down. Run `lobster doctor`; do not suggest a spelling fix |
+| `3` | Every provider failed | The title exists, the sources are down. Run `lobster doctor`; do not suggest a spelling fix. From `play --detach` it means something narrower — the background process started and then died within a second, and the error message names the log that says why |
 | `4` | Player unavailable | mpv (or whichever player is configured) is not installed or not on `PATH` |
 
 Check `schema` before trusting the shape of the rest.

--- a/skills/lobster-play/SKILL.md
+++ b/skills/lobster-play/SKILL.md
@@ -40,6 +40,9 @@ lobster find "the matrix" --limit 10
 }
 ```
 
+Add `--type tv` or `--type movie` when the user was specific ("play the
+*series*"), so a same-named film and show do not both come back.
+
 ### 2. Show the user the candidates and stop
 
 **Always ask which one before playing.** Do not pick for them, even when one
@@ -135,13 +138,19 @@ Branch on the exit code:
 | Exit | Meaning | What to do |
 | ---- | ------- | ---------- |
 | 0 | success | — |
-| 1 | bad invocation | You called it wrong: a malformed `ref`, a missing `--season`/`--episode`, an unrecognised `--type`, `--download` (unsupported), or an invalid config value. Fix the command; do not retry it unchanged |
+| 1 | bad invocation | You called it wrong: a malformed `ref`, a missing `--season`/`--episode`, `episodes` on a movie ref, an unrecognised `--type` or other flag, `--download` (unsupported), or an invalid config value. Also internal failures such as an unwritable cache directory. Fix the command; do not retry it unchanged |
 | 2 | no results | Suggest a spelling correction, or a different title. Also returned when the season or episode number does not exist — re-run `lobster episodes` and check |
 | 3 | every provider failed | Run `lobster doctor` and report which sources are down. Do **not** suggest a spelling fix — the title was found, the sources are broken |
-| 4 | player unavailable | mpv (or the configured player) is not installed |
+| 4 | player unavailable | mpv (or the configured player) is not installed, or the background process could not be started |
 
-Exit 3 is common. Providers break often; this usually means "try again later"
-or "try a different title", not "you typed it wrong".
+**A misspelling exits 2, not 3.** `find` distinguishes "every provider answered
+and none has this title" from "nothing answered at all", so exit 3 really does
+mean broken sources — never reach for a spelling fix on it. It is not the
+default failure; treat it as a genuine outage report and say so.
+
+Exit 3 from `play --detach` is a narrower case: the background process was
+started and then died within a second. The message names the log file. Read
+that log rather than running `doctor` — the cause is in it.
 
 ## Out of scope
 


### PR DESCRIPTION
Closes the documentation gaps left after #43. Docs only — no code changed.

## What changed

**GUIDE.md** — new "Scripting and Agents" section between "JSON Output" and
"Configuration". GUIDE said nothing about the agent surface; its only `--json`
mention was stream metadata. Covers `find` (including `--type`, which was
documented nowhere but the flag help), `episodes`, `play --ref/--detach`, what a
ref actually pins, why `--detach` is required for a parseable stdout, and the
exit codes. Written as a walkthrough rather than a copy of the README block.

**README.md** — the agent section presented these commands as useful for
scripting without ever saying what they exit with. Adds the exit-code table, and
`find --type` to the example block.

**skills/lobster-play/SKILL.md** — corrections to the exit-code table, below.

## What I corrected as untrue

- **"Exit 3 is common. Providers break often"** — written when a misspelling
  returned exit 3. That was the bug #43 fixed: `gatherSearchResults` now
  distinguishes `errNoResults` ("every provider answered, none has this title")
  from `errProvidersFailed` ("nothing answered"), and `findRun` maps the first to
  exit 2 (`cmd/find.go:77`, `cmd/multisearch.go:28-31,72-77`). Exit 3 is now a
  genuine outage signal, not the default failure. Rewritten to say so.
- **Exit 3 was defined as "every provider failed" everywhere.** `playDetached`
  also returns it when the background process dies inside the 1s liveness window
  (`cmd/detach.go:201-204`), where `doctor` explains nothing and the log named in
  the message does. Now stated in all three files. Caught by the local
  CodeRabbit review, on the first two files, before I had written it into them.
- **Exit 1 row was incomplete.** It also covers `episodes` on a movie ref
  (`not_a_series`, `cmd/episodes.go:43`) and internal failures — ref encoding,
  locating the binary, creating the log — which are not "you called it wrong".
- **Exit 4 row was incomplete.** Also returned when `c.Start()` fails for the
  background process (`cmd/detach.go:198`), not only when the player is missing.

## What I verified, by reading the code

- Every `emitErr` call site and its exit constant, across `find.go`,
  `episodes.go`, `play.go`, `detach.go`, `agentjson.go`, `root.go`.
- `find`'s JSON keys (`idx`/`ref`/`title`/`year`/`type`), `episodes`'
  (`title`/`seasons`/`season`/`episodes`) and `detachPayload`'s
  (`status`/`pid`/`title`/`log`/`resume_tracking`) match what the docs show.
- `resume_tracking` is mpv-only (`playerTracksPosition`), and unrelated to detach.
- "never prompts" holds: `resolveAndPlay` only reaches `ui.Select` when season or
  episode is `<= 0`, which `playRun` rejects for TV first.
- "stdout is only JSON" holds for `find`/`episodes`: the spinner writes to stderr
  and is suppressed when stderr is not a terminal (`internal/ui/spinner.go`).
- The forwarded-flag list README already claimed matches `forwardedStringFlags` +
  `forwardedBoolFlags` exactly (9 flags).
- The SKILL's "never run these" table: `history`, `trending`, `recent` do call
  `ui.Select`; `doctor`, which the SKILL tells the agent to run, does not.
- Gate green on both commits: `go build ./... && go vet ./... && go test ./...`.
- Local CodeRabbit: 2 findings, both real, both fixed; re-review clean.

## What I did NOT verify

- **Nothing was executed against a live provider.** No binary was run at all.
  Every claim here comes from reading the code and the hermetic `cmd/` tests, so
  the exit codes are verified as written, not as observed end-to-end.
- The GUIDE sentence that a **detached** play stops after the requested episode
  is reasoned, not run: `runPlaybackLoop` continues into the countdown menu,
  which needs raw-mode stdin or fzf, and the detached child has neither
  (`c.Stdin = nil`). Confident from the code, but it has not been watched happen.
  The attached half of that sentence follows directly from `cmd/search.go:389`.
- I left the `cmd/agentjson.go:16-18` comment ("on this repo the latter is the
  common one") alone. Post-fix it is arguably stale for `find`, but it remains
  true for `play`/`episodes` resolution failures, and the sentence it sits in —
  why 2 and 3 are distinct — is still correct. Flagging rather than changing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for non-interactive `find`, `episodes`, and `play` commands, including flags, JSON output, reusable references, detached playback, and exit codes.
  * Added examples and guidance for filtering results by TV series or movie type.
  * Clarified error handling for invalid references, unsupported operations, internal failures, unavailable players, failed process startup, and detached processes that stop shortly after starting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->