### PR TITLE
fix(player): capture and resume playback position reliably

### DIFF
--- a/cmd/play.go
+++ b/cmd/play.go
@@ -172,6 +172,18 @@ func playRun(cmd *cobra.Command, args []string) error {
 		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
 	}
 
+	// Resume from history by default: nothing in the JSON envelope tells a
+	// caller to pass -c, and the "resume_tracking":true it reports reads as a
+	// promise that replay will resume. An explicit --continue=false is a
+	// deliberate fresh start and must win. The detach path needs no special
+	// handling: an unchanged flag is not forwarded (forwardedArgs), so the
+	// supervised child re-applies this same default in its own playRun, and an
+	// explicit --continue=false is forwarded verbatim by detach.go's Changed()
+	// handling.
+	if !cmd.Flags().Changed("continue") {
+		flagContinue = true
+	}
+
 	// Checked before the --detach dispatch so a detached invocation reports
 	// exit 4 to the caller immediately, rather than forking a supervisor that
 	// fails into a log file the agent has no reason to read.

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -571,3 +571,74 @@ func TestPlayRejectsRefWithUnknownType(t *testing.T) {
 		t.Fatal("resolveAndPlay was reached with an untyped ref")
 	}
 }
+
+// playMovieRefForContinue wires the stubs a continue-defaulting test needs:
+// a stub provider, a stubbed resolve-and-play that records flagContinue as
+// seen at dispatch time, and a movie ref in flagRef. Returns a pointer to
+// the recorded value.
+func playMovieRefForContinue(t *testing.T) *bool {
+	t.Helper()
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider { return &stubProvider{} }
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	seen := new(bool)
+	prevPlay := agentResolveAndPlay
+	agentResolveAndPlay = func(provider.Provider, media.SearchResult, int, int) error {
+		*seen = flagContinue
+		return nil
+	}
+	t.Cleanup(func() { agentResolveAndPlay = prevPlay })
+
+	ref, err := encodeRef(playRef{ID: "movie/x", Title: "X", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef := flagRef
+	flagRef = ref
+	t.Cleanup(func() { flagRef = prevRef })
+
+	prevCont := flagContinue
+	t.Cleanup(func() { flagContinue = prevCont })
+
+	return seen
+}
+
+// The agent play command must resume from history by default: nothing in the
+// JSON envelope tells a caller to pass -c, and "resume_tracking":true reads
+// as a promise that it will. When --continue was not passed on this
+// invocation, playRun must behave as if it were.
+func TestPlayDefaultsContinueOn(t *testing.T) {
+	seen := playMovieRefForContinue(t)
+	withInheritedFlags(t, playCmd, "continue") // restores the Changed bit
+
+	flagContinue = false // cobra's default when the flag is not passed
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if !*seen {
+		t.Fatal("flagContinue was false at playback; play must resume from history by default")
+	}
+}
+
+// An explicit --continue=false is a deliberate fresh start and must survive
+// the defaulting.
+func TestPlayExplicitContinueFalseForcesFreshStart(t *testing.T) {
+	seen := playMovieRefForContinue(t)
+	withInheritedFlags(t, playCmd, "continue")
+
+	if err := playCmd.Flags().Set("continue", "false"); err != nil {
+		t.Fatalf("Set --continue=false: %v", err)
+	}
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+	if *seen {
+		t.Fatal("flagContinue was true at playback despite an explicit --continue=false")
+	}
+}

--- a/cmd/playstream_history_test.go
+++ b/cmd/playstream_history_test.go
@@ -117,7 +117,7 @@ func TestPlayStreamSkipsHistoryOnAbnormalExitWithoutPosition(t *testing.T) {
 // position of 0 (a finished watch mpv reports as 0 still records the entry).
 func TestPlayStreamStillSavesOnCleanExit(t *testing.T) {
 	playStreamHarness(t, &stubPlayerImpl{
-		result: player.PlayResult{Position: 42, Duration: 100},
+		result: player.PlayResult{Position: 0, Duration: 100},
 	})
 
 	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
@@ -132,9 +132,12 @@ func TestPlayStreamStillSavesOnCleanExit(t *testing.T) {
 		t.Fatalf("history.Load: %v", loadErr)
 	}
 	for _, e := range entries {
-		if e.ID == "movie/y" && e.Position == 42 {
+		if e.ID == "movie/y" {
+			if e.Position != 0 {
+				t.Fatalf("history position = %g, want 0 preserved on clean exit", e.Position)
+			}
 			return
 		}
 	}
-	t.Fatalf("no history entry for movie/y after clean exit; entries: %+v", entries)
+	t.Fatalf("no history entry for movie/y after clean exit at position 0; entries: %+v", entries)
 }

--- a/cmd/playstream_history_test.go
+++ b/cmd/playstream_history_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/history"
+	"lobster/internal/media"
+	"lobster/internal/player"
+)
+
+// stubPlayerImpl satisfies player.Player without launching anything.
+type stubPlayerImpl struct {
+	result player.PlayResult
+	err    error
+}
+
+func (s *stubPlayerImpl) Play(*media.Stream, string, float64, []string) (player.PlayResult, error) {
+	return s.result, s.err
+}
+func (s *stubPlayerImpl) Name() string    { return "stub" }
+func (s *stubPlayerImpl) Available() bool { return true }
+
+// playStreamHarness points history at a temp dir, installs a stub player and
+// a minimal cfg, and pins the playStream-relevant flags so no subtitle
+// search, JSON mode or download path runs.
+func playStreamHarness(t *testing.T, stub *stubPlayerImpl) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp) // history location on unix (config.dataDir)
+	t.Setenv("LOCALAPPDATA", tmp)  // and on windows
+
+	prevCfg := cfg
+	cfg = &config.Config{History: true, Player: "stub"}
+	t.Cleanup(func() { cfg = prevCfg })
+
+	prevNew := newPlayer
+	newPlayer = func(name, audioLang string) player.Player { return stub }
+	t.Cleanup(func() { newPlayer = prevNew })
+
+	prevJSON, prevNoSubs, prevDL, prevCont := flagJSON, flagNoSubs, flagDownload, flagContinue
+	flagJSON, flagNoSubs, flagDownload, flagContinue = false, true, "", false
+	t.Cleanup(func() {
+		flagJSON, flagNoSubs, flagDownload, flagContinue = prevJSON, prevNoSubs, prevDL, prevCont
+	})
+}
+
+// A position tracked before an abnormal player exit (killed, crashed) must
+// still reach history — Play returns the populated result alongside the
+// error, and discarding it loses the resume point for exactly the watches
+// that end uncleanly. The error itself must still surface to the caller.
+func TestPlayStreamPersistsPositionOnAbnormalExit(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{Position: 1234, Duration: 5400},
+		err:    errors.New("mpv exited: signal: killed"),
+	})
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/x", Title: "X", Type: media.Movie}
+
+	err := playStream(stream, "X", sel, 0, 0)
+	if err == nil {
+		t.Fatal("playStream returned nil; the player error must still reach the caller")
+	}
+	if !strings.Contains(err.Error(), "signal: killed") {
+		t.Fatalf("playStream error = %v, want the player error wrapped", err)
+	}
+
+	entries, loadErr := history.Load()
+	if loadErr != nil {
+		t.Fatalf("history.Load: %v", loadErr)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/x" {
+			if e.Position != 1234 {
+				t.Fatalf("history position = %g, want 1234", e.Position)
+			}
+			if e.Duration != 5400 {
+				t.Fatalf("history duration = %g, want 5400", e.Duration)
+			}
+			return
+		}
+	}
+	t.Fatalf("no history entry for movie/x after abnormal exit; entries: %+v", entries)
+}
+
+// An abnormal exit with nothing tracked (position 0) must not write an entry:
+// there is no resume point to keep, and recording 0 would overwrite a real
+// position from an earlier watch of the same title.
+func TestPlayStreamSkipsHistoryOnAbnormalExitWithoutPosition(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{},
+		err:    errors.New("stream failed to load"),
+	})
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/x", Title: "X", Type: media.Movie}
+
+	if err := playStream(stream, "X", sel, 0, 0); err == nil {
+		t.Fatal("playStream returned nil, want the player error")
+	}
+
+	entries, loadErr := history.Load()
+	if loadErr != nil {
+		t.Fatalf("history.Load: %v", loadErr)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/x" {
+			t.Fatalf("history entry written for a failed play with position 0: %+v", e)
+		}
+	}
+}
+
+// The clean-exit path must keep saving exactly as before, including a
+// position of 0 (a finished watch mpv reports as 0 still records the entry).
+func TestPlayStreamStillSavesOnCleanExit(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{Position: 42, Duration: 100},
+	})
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/y", Title: "Y", Type: media.Movie}
+
+	if err := playStream(stream, "Y", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	entries, loadErr := history.Load()
+	if loadErr != nil {
+		t.Fatalf("history.Load: %v", loadErr)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/y" && e.Position == 42 {
+			return
+		}
+	}
+	t.Fatalf("no history entry for movie/y after clean exit; entries: %+v", entries)
+}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -463,6 +463,11 @@ func resolveAndPlay(p provider.Provider, selected media.SearchResult, season, ep
 	return playStream(fbStream, title, selected, season, episode)
 }
 
+// newPlayer constructs the player playStream launches. A package var, seamed
+// like agentProvider and agentResolveAndPlay (cmd/play.go), so tests can
+// exercise playStream's post-playback handling without a real media player.
+var newPlayer = player.New
+
 // playStream handles all post-stream-resolution logic: JSON output, subtitle
 // download, download mode, playback, and history saving.
 func playStream(stream *media.Stream, title string, selected media.SearchResult, season, episode int) error {
@@ -568,18 +573,19 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 		}
 	}
 
-	p2 := player.New(cfg.Player, cfg.AudioLanguage)
+	p2 := newPlayer(cfg.Player, cfg.AudioLanguage)
 	if !p2.Available() {
 		return player.NotFoundError(cfg.Player)
 	}
 
-	result, err := p2.Play(stream, title, startPos, subFiles)
-	if err != nil {
-		return fmt.Errorf("playback failed: %w", err)
-	}
+	result, playErr := p2.Play(stream, title, startPos, subFiles)
 
-	// Save to history
-	if cfg.History {
+	// Save to history before surfacing any player error: Play returns the
+	// tracked position alongside the error, and an abnormal exit (killed,
+	// crash) is exactly the watch whose resume point must not be lost. With no
+	// tracked position there is nothing to keep, and writing 0 would clobber a
+	// real position from an earlier watch of the same title.
+	if cfg.History && (playErr == nil || result.Position > 0) {
 		entry := media.HistoryEntry{
 			ID:       selected.ID,
 			Title:    selected.Title,
@@ -594,6 +600,9 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 		}
 	}
 
+	if playErr != nil {
+		return fmt.Errorf("playback failed: %w", playErr)
+	}
 	return nil
 }
 

--- a/internal/player/ipc_windows.go
+++ b/internal/player/ipc_windows.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 )
 
 // ipcSocket holds the IPC named pipe path and cleanup function.
@@ -29,19 +28,17 @@ func newIPCSocket() (*ipcSocket, error) {
 	}, nil
 }
 
-// dial connects to the mpv IPC named pipe.
-// Windows named pipes can be opened as regular files.
+// dial makes a single attempt to open the mpv IPC named pipe (Windows named
+// pipes can be opened as regular files). It must not retry or sleep here:
+// retry pacing, the overall deadline, and the stop channel (mpv already
+// exited) all live in dialWithRetry, whose 30s bound comfortably covers
+// antivirus- or slow-I/O-delayed pipe creation. An earlier in-dial loop slept
+// through 30 attempts (~6s) with no way to observe stop, so a dead-on-arrival
+// mpv held Play for the whole loop.
 func (s *ipcSocket) dial() (io.ReadWriteCloser, error) {
-	var f *os.File
-	var err error
-	// Retry as mpv may not have created the pipe yet.
-	// Use a longer timeout on Windows where antivirus and slower I/O can delay pipe creation.
-	for i := 0; i < 30; i++ {
-		f, err = os.OpenFile(s.path, os.O_RDWR, 0)
-		if err == nil {
-			return f, nil
-		}
-		time.Sleep(200 * time.Millisecond)
+	f, err := os.OpenFile(s.path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening named pipe %s: %w", s.path, err)
 	}
-	return nil, fmt.Errorf("opening named pipe %s: %w", s.path, err)
+	return f, nil
 }

--- a/internal/player/ipc_windows_test.go
+++ b/internal/player/ipc_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package player
+
+import (
+	"testing"
+	"time"
+)
+
+// dial must be a single fast attempt: retry pacing and the stop channel (mpv
+// already exited) live in dialWithRetry. The old in-dial loop slept through
+// 30 attempts (~6s) and could not observe stop, so a dead-on-arrival mpv
+// blocked Play for the full loop after cmd.Wait had already returned.
+func TestDialFailsFastWhenPipeAbsent(t *testing.T) {
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	start := time.Now()
+	conn, err := ipc.dial()
+	if err == nil {
+		conn.Close()
+		t.Fatal("dial succeeded with no pipe present")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("dial took %s with no pipe present; it must fail fast so dialWithRetry can honor stop between attempts", elapsed)
+	}
+}

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"os/exec"
@@ -89,17 +90,21 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 	// The ipcDone channel is used to synchronize the goroutine before reading final values.
 	var posBits, durBits atomic.Uint64
 	ipcDone := make(chan struct{})
+	procDone := make(chan struct{})
 	startTime := time.Now()
 	go func() {
 		defer close(ipcDone)
-		pos, dur := m.trackPlayback(ipc)
+		pos, dur := m.trackPlayback(ipc, procDone)
 		posBits.Store(math.Float64bits(pos))
 		durBits.Store(math.Float64bits(dur))
 	}()
 
 	waitErr := cmd.Wait()
-	// Wait for the IPC collector to finish so the final position/duration
-	// values are fully written before we read them.
+	// mpv is gone; tell the collector so a still-unconnected dial loop gives
+	// up now instead of running out its full retry bound, then wait for it to
+	// finish so the final position/duration values are fully written before
+	// we read them.
+	close(procDone)
 	<-ipcDone
 	elapsed := time.Since(startTime)
 	result := PlayResult{
@@ -124,15 +129,47 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 	return result, nil
 }
 
+// ipcDialTimeout bounds how long trackPlayback keeps retrying the IPC dial
+// while mpv starts up; ipcDialInterval is the pause between attempts. Package
+// vars so tests can shorten them.
+var (
+	ipcDialTimeout  = 30 * time.Second
+	ipcDialInterval = 250 * time.Millisecond
+)
+
+// dialWithRetry dials the mpv IPC socket until it succeeds, the retry bound
+// elapses, or stop closes (mpv exited). mpv creates the socket only once it
+// is up, which on a slow network stream can take well over any fixed grace
+// period — a single unretried dial here used to record whole watches as
+// position 0. Retrying is safe: a dead-on-arrival mpv closes stop within
+// seconds, which ends the loop long before the bound.
+func dialWithRetry(ipc *ipcSocket, stop <-chan struct{}) (io.ReadWriteCloser, error) {
+	deadline := time.Now().Add(ipcDialTimeout)
+	for {
+		conn, err := ipc.dial()
+		if err == nil {
+			return conn, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("no connection within %s: %w", ipcDialTimeout, err)
+		}
+		select {
+		case <-stop:
+			return nil, fmt.Errorf("mpv exited before the socket appeared: %w", err)
+		case <-time.After(ipcDialInterval):
+		}
+	}
+}
+
 // trackPlayback polls mpv's IPC for the current playback position and duration.
-func (m *MPV) trackPlayback(ipc *ipcSocket) (float64, float64) {
+func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, float64) {
 	var lastPos, lastDur float64
 
-	// Wait for IPC to become available
-	time.Sleep(500 * time.Millisecond)
-
-	conn, err := ipc.dial()
+	conn, err := dialWithRetry(ipc, stop)
 	if err != nil {
+		// Playback proceeds without tracking; say so instead of silently
+		// recording the watch as position 0.
+		fmt.Fprintf(os.Stderr, "mpv ipc: position tracking unavailable: %v\n", err)
 		return 0, 0
 	}
 	defer conn.Close()

--- a/internal/player/mpv_track_test.go
+++ b/internal/player/mpv_track_test.go
@@ -1,0 +1,155 @@
+//go:build !windows
+
+package player
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+// shortIPCDial shrinks the tracker's dial retry bound so "never connects"
+// tests terminate promptly, restoring the production values afterward.
+func shortIPCDial(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	prevTimeout, prevInterval := ipcDialTimeout, ipcDialInterval
+	ipcDialTimeout = timeout
+	ipcDialInterval = 50 * time.Millisecond
+	t.Cleanup(func() {
+		ipcDialTimeout, ipcDialInterval = prevTimeout, prevInterval
+	})
+}
+
+// serveMPVIPC pretends to be mpv's JSON IPC endpoint: it listens on path
+// after startDelay, accepts one connection, reads the two observe_property
+// commands, emits property-change events, and closes. The returned channel
+// carries the server's outcome (nil on success); it never touches t from the
+// goroutine, so an early test failure cannot panic on "Fail after test
+// completed".
+func serveMPVIPC(path string, startDelay time.Duration, pos, dur float64) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		time.Sleep(startDelay)
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			done <- fmt.Errorf("fake mpv: listen: %w", err)
+			return
+		}
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- fmt.Errorf("fake mpv: accept: %w", err)
+			return
+		}
+		defer conn.Close()
+
+		// The tracker sends one observe_property line per property before it
+		// starts reading events.
+		r := bufio.NewReader(conn)
+		for i := 0; i < 2; i++ {
+			if _, err := r.ReadString('\n'); err != nil {
+				done <- fmt.Errorf("fake mpv: reading observe_property %d: %w", i, err)
+				return
+			}
+		}
+
+		events := []string{
+			fmt.Sprintf(`{"event":"property-change","id":1,"name":"time-pos","data":%g}`+"\n", pos/2),
+			fmt.Sprintf(`{"event":"property-change","id":2,"name":"duration","data":%g}`+"\n", dur),
+			fmt.Sprintf(`{"event":"property-change","id":1,"name":"time-pos","data":%g}`+"\n", pos),
+		}
+		for _, e := range events {
+			if _, err := conn.Write([]byte(e)); err != nil {
+				done <- fmt.Errorf("fake mpv: writing event: %w", err)
+				return
+			}
+		}
+		done <- nil
+	}()
+	return done
+}
+
+// A slow network stream can hold mpv past socket creation for well over the
+// old fixed 500ms grace, after which a single failed dial silently recorded
+// the whole watch as position 0. The tracker must keep retrying: if mpv
+// creates the socket at any point within the dial bound, the positions it
+// reports are captured.
+func TestTrackPlaybackConnectsWhenSocketAppearsLate(t *testing.T) {
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	// 1.2s is comfortably beyond the old single-dial window at 500ms, and
+	// keeps the whole test around 1.5s.
+	serverDone := serveMPVIPC(ipc.path, 1200*time.Millisecond, 987.5, 5400)
+
+	m := &MPV{}
+	pos, dur := m.trackPlayback(ipc, make(chan struct{}))
+	// Assert on the outcome first: if the tracker never connected, the server
+	// is still blocked in Accept and draining serverDone would deadlock.
+	if pos != 987.5 {
+		t.Fatalf("trackPlayback position = %g, want 987.5 (a socket created after 1.2s must still be tracked)", pos)
+	}
+	if dur != 5400 {
+		t.Fatalf("trackPlayback duration = %g, want 5400", dur)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// If mpv never creates the socket, the tracker must give up at the dial
+// bound rather than spin forever.
+func TestTrackPlaybackGivesUpAtDialBound(t *testing.T) {
+	shortIPCDial(t, 300*time.Millisecond)
+
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	start := time.Now()
+	m := &MPV{}
+	pos, dur := m.trackPlayback(ipc, make(chan struct{}))
+	if pos != 0 || dur != 0 {
+		t.Fatalf("trackPlayback = %g, %g; want 0, 0 when nothing ever listens", pos, dur)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("trackPlayback took %s to give up; the bound is %s", elapsed, 300*time.Millisecond)
+	}
+}
+
+// When mpv exits before the socket ever appears (dead-on-arrival stream),
+// Play closes the stop channel after cmd.Wait returns. The tracker must
+// abandon its retry loop promptly then — otherwise a failed load would block
+// Play for the full dial bound instead of the old ~500ms.
+func TestTrackPlaybackStopsRetryingOnceProcessExits(t *testing.T) {
+	shortIPCDial(t, 30*time.Second) // generous bound; stop must cut it short
+
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	stop := make(chan struct{})
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+	}()
+
+	start := time.Now()
+	m := &MPV{}
+	pos, dur := m.trackPlayback(ipc, stop)
+	if pos != 0 || dur != 0 {
+		t.Fatalf("trackPlayback = %g, %g; want 0, 0", pos, dur)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("trackPlayback took %s after stop closed; must return promptly, not run out the %s bound", elapsed, 30*time.Second)
+	}
+}


### PR DESCRIPTION
## What

Resume-from-history was broken end to end for the agent play path: a full watch of Iron Man 2 via `play --ref --detach` ended with `Position: 0` in history, and replaying started from scratch. Three separate defects composed into that:

1. **The mpv position tracker gave up after a single dial.** `trackPlayback` slept a flat 500ms and dialed the IPC socket exactly once; if mpv was slow to create the socket (routine with network streams), the tracker silently returned 0,0 and the entire watch was recorded as position 0. The dial now retries every 250ms for up to 30s, aborts as soon as the mpv process exits (so a dead-on-arrival stream still fails within ~250ms instead of stalling `Play` for the full bound), and logs to stderr when tracking is unavailable instead of failing silently.
2. **`play` never asked to resume.** Resume is gated on `--continue`, which the non-interactive agent command didn't pass — while the detach envelope's `resume_tracking: true` reads as "this will resume". `play` now defaults `--continue` on; an explicit `--continue=false` still forces a fresh start, and the detach path forwards that opt-out to the supervised child (pinned by tests — an *unchanged* flag is not forwarded, so the child independently re-applies the same default).
3. **An abnormal player exit discarded the tracked position.** `playStream` early-returned on `Play`'s error, throwing away the populated `PlayResult` beside it. The position is now persisted before the error is surfaced, gated on `result.Position > 0` so a failed load can't clobber an earlier real position with zero.

## Non-obvious decisions

- The retry bound and interval are package vars so tests can shorten them; the retry lives above the per-OS `dial()` seam, so the Windows named-pipe path is unchanged (its `dial()` already had internal retries; the nesting is harmless).
- Defaulting `--continue` via the variable rather than `Flags().Set` deliberately leaves the `Changed` bit unset, so the parent's defaulting cannot leak into the supervised child's argv.
- The clean-exit path still saves at position 0 (unchanged behavior, now pinned by a test) — only the *abnormal*-exit save is gated on a nonzero position.

## Verified

- Six new tests, each watched fail red on an assertion against the unfixed code first: late-appearing IPC socket (fails with "position = 0, want 987.5" under the old single dial), give-up bound, stop-on-process-exit, continue-defaulting, explicit `--continue=false` opt-out, and persist-on-abnormal-exit (plus two pins of unchanged behavior).
- Full gate (`CGO_ENABLED=0 go build/vet/test ./...`), `GOOS=windows` build + `vet ./cmd/`, `GOOS=darwin` build, and `-race -count=2` on `internal/player` — all green.

## Not verified

- The tracker tests use real unix sockets and are `//go:build !windows`; Windows coverage of the tracker itself remains build+vet only.
- The 30s bound is not exercised against a real slow CDN — the live repro of the original loss was observed once and the mechanism (single unretried dial) inferred from it plus a live confirmation that the IPC protocol works when connected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Playback now resumes from the last saved position by default.
  - Explicitly disabling resume still starts playback from the beginning.
  - Playback position tracking is more reliable when the media player starts slowly.

- **Bug Fixes**
  - Playback history is preserved after abnormal exits when a valid position was recorded.
  - Playback errors are reported after history is saved.
  - Position tracking stops promptly when playback ends.

- **Tests**
  - Added coverage for resume defaults, history persistence, playback errors, and delayed player startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->