### PR TITLE
feat(player): checkpoint playback position periodically during playback

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -6,8 +6,38 @@ import (
 	"github.com/spf13/cobra"
 
 	"lobster/internal/history"
+	"lobster/internal/media"
 	"lobster/internal/ui"
 )
+
+// historyCheckpoint returns a player checkpoint callback that persists the
+// given watch's position to history mid-playback, so a hard shutdown loses at
+// most one checkpoint interval of resume position. It writes through
+// history.Save — the same update-in-place routine as the exit-time save — so
+// a checkpoint row and a final row are structurally identical, and the
+// exit-time save (which runs strictly after the last checkpoint; the player
+// guarantees no callback after Play returns) simply overwrites it. Zero
+// positions are skipped: writing 0 would clobber a real resume position from
+// an earlier watch of the same title.
+func historyCheckpoint(id, title string, mediaType media.MediaType, season, episode int) func(position, duration float64) {
+	return func(position, duration float64) {
+		if position <= 0 {
+			return
+		}
+		entry := media.HistoryEntry{
+			ID:       id,
+			Title:    title,
+			Type:     mediaType,
+			Season:   season,
+			Episode:  episode,
+			Position: position,
+			Duration: duration,
+		}
+		if err := history.Save(entry); err != nil {
+			debugf("checkpoint history save failed: %v", err)
+		}
+	}
+}
 
 var historyCmd = &cobra.Command{
 	Use:   "history",

--- a/cmd/play_checkpoint_test.go
+++ b/cmd/play_checkpoint_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/history"
+	"lobster/internal/media"
+	"lobster/internal/player"
+	"lobster/internal/provider"
+)
+
+// checkpointPlayProvider extends stubStreamProvider so resolveAndPlay's
+// StreamProvider branch finds a server and resolves the canned stream, keeping
+// the whole play path off the network and away from the fallback chain.
+type checkpointPlayProvider struct{ stubStreamProvider }
+
+func (p *checkpointPlayProvider) GetServers(string, string) ([]media.Server, error) {
+	return []media.Server{{Name: "Stub", ID: "srv1"}}, nil
+}
+
+// The agent surface (`lobster play --ref`, the owner's primary path and the
+// one the motivating hard-shutdown incident happened on) must checkpoint
+// mid-playback like the interactive paths. It funnels through
+// agentResolveAndPlay -> resolveAndPlay -> playStream, so this drives the real
+// playRun end to end (only the provider, player and availability probe are
+// stubbed) and asserts the position was on disk while the player was still
+// running.
+func TestAgentPlayPathCheckpointsPositionMidPlayback(t *testing.T) {
+	stub := &stubCheckpointPlayer{
+		stubPlayerImpl: stubPlayerImpl{result: player.PlayResult{Position: 1234, Duration: 5400}},
+		fire:           true,
+		mid:            [2]float64{600, 5400},
+	}
+	playStreamHarness(t, stub)
+	hostileEnv(t)
+	captureAgentOut(t)
+
+	prevProv := agentProvider
+	agentProvider = func() provider.Provider {
+		return &checkpointPlayProvider{stubStreamProvider{
+			stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"},
+		}}
+	}
+	t.Cleanup(func() { agentProvider = prevProv })
+
+	// agentPlayerCheck probes the real configured binary; the stub player is
+	// what actually plays, so force the probe to pass regardless of what is
+	// installed on the machine running the test.
+	prevCheck := agentPlayerCheck
+	agentPlayerCheck = func() (bool, string) { return true, "stub" }
+	t.Cleanup(func() { agentPlayerCheck = prevCheck })
+
+	ref, err := encodeRef(playRef{ID: "movie/agent", Title: "Agent", Type: "movie"})
+	if err != nil {
+		t.Fatalf("encodeRef: %v", err)
+	}
+	prevRef, prevDetach := flagRef, flagDetach
+	flagRef, flagDetach = ref, false
+	t.Cleanup(func() { flagRef, flagDetach = prevRef, prevDetach })
+
+	if err := playRun(playCmd, nil); err != nil {
+		t.Fatalf("playRun: %v", err)
+	}
+
+	// The state a hard shutdown mid-watch would have left behind.
+	var found bool
+	for _, e := range stub.midEntries {
+		if e.ID == "movie/agent" {
+			found = true
+			if e.Position != 600 || e.Duration != 5400 {
+				t.Fatalf("mid-playback history = pos %g dur %g, want 600/5400 from the checkpoint", e.Position, e.Duration)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no history entry existed during agent-path playback; a hard shutdown would have lost the position (mid entries: %+v)", stub.midEntries)
+	}
+
+	// The exit-time save still wins with the final, more precise position.
+	entries, loadErr := history.Load()
+	if loadErr != nil {
+		t.Fatalf("history.Load: %v", loadErr)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/agent" {
+			if e.Position != 1234 {
+				t.Fatalf("final history position = %g, want 1234 (exit save must win over the checkpoint)", e.Position)
+			}
+			return
+		}
+	}
+	t.Fatalf("no final history entry for movie/agent; entries: %+v", entries)
+}

--- a/cmd/playstream_checkpoint_test.go
+++ b/cmd/playstream_checkpoint_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/history"
+	"lobster/internal/media"
+	"lobster/internal/player"
+)
+
+// stubCheckpointPlayer is a stubPlayerImpl that also implements
+// player.Checkpointer. If fire is set, Play invokes the installed checkpoint
+// callback with mid (position, duration) — simulating trackPlayback's periodic
+// checkpoint — and snapshots the history file right after, so tests can assert
+// what a hard shutdown at that moment would have found on disk.
+type stubCheckpointPlayer struct {
+	stubPlayerImpl
+	fn         func(position, duration float64)
+	fire       bool
+	mid        [2]float64
+	midEntries []media.HistoryEntry
+}
+
+func (s *stubCheckpointPlayer) SetCheckpoint(fn func(position, duration float64)) { s.fn = fn }
+
+func (s *stubCheckpointPlayer) Play(st *media.Stream, title string, startPos float64, subFiles []string) (player.PlayResult, error) {
+	if s.fire && s.fn != nil {
+		s.fn(s.mid[0], s.mid[1])
+		s.midEntries, _ = history.Load()
+	}
+	return s.stubPlayerImpl.Play(st, title, startPos, subFiles)
+}
+
+// A checkpoint during playback must land in history immediately (that row is
+// all a power cut leaves behind), and the exit-time save must still win
+// afterwards: the final position differs from the checkpoint, and it is the
+// final one that must be on disk when playStream returns.
+func TestPlayStreamCheckpointPersistsMidPlaybackAndExitSaveWins(t *testing.T) {
+	stub := &stubCheckpointPlayer{
+		stubPlayerImpl: stubPlayerImpl{result: player.PlayResult{Position: 1234, Duration: 5400}},
+		fire:           true,
+		mid:            [2]float64{600, 5400},
+	}
+	playStreamHarness(t, stub)
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "tv/z", Title: "Z", Type: media.TV}
+
+	if err := playStream(stream, "Z", sel, 2, 5); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	// The state a hard shutdown mid-watch would have left behind.
+	var midFound bool
+	for _, e := range stub.midEntries {
+		if e.ID == "tv/z" && e.Season == 2 && e.Episode == 5 {
+			midFound = true
+			if e.Position != 600 || e.Duration != 5400 {
+				t.Fatalf("mid-playback history = pos %g dur %g, want 600/5400 from the checkpoint", e.Position, e.Duration)
+			}
+			if e.Title != "Z" || e.Type != media.TV {
+				t.Fatalf("mid-playback entry metadata = %+v, want title Z type tv (checkpoint rows must be structurally identical to final rows)", e)
+			}
+		}
+	}
+	if !midFound {
+		t.Fatalf("no history entry existed during playback; a hard shutdown would have lost the position (mid entries: %+v)", stub.midEntries)
+	}
+
+	// The exit-time save is more precise and must overwrite the checkpoint.
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	var rows int
+	for _, e := range entries {
+		if e.ID == "tv/z" && e.Season == 2 && e.Episode == 5 {
+			rows++
+			if e.Position != 1234 {
+				t.Fatalf("final history position = %g, want 1234 (the exit-time save must win over the 600s checkpoint)", e.Position)
+			}
+		}
+	}
+	if rows != 1 {
+		t.Fatalf("found %d rows for tv/z S02E05, want exactly 1 (checkpoint must update in place, not append)", rows)
+	}
+}
+
+// A zero-position checkpoint must not write: recording 0 would clobber a real
+// resume position from an earlier watch of the same title.
+func TestPlayStreamCheckpointSkipsZeroPosition(t *testing.T) {
+	stub := &stubCheckpointPlayer{
+		stubPlayerImpl: stubPlayerImpl{result: player.PlayResult{Position: 42, Duration: 100}},
+		fire:           true,
+		mid:            [2]float64{0, 100},
+	}
+	playStreamHarness(t, stub)
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/zero", Title: "Zero", Type: media.Movie}
+
+	if err := playStream(stream, "Zero", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+	for _, e := range stub.midEntries {
+		if e.ID == "movie/zero" {
+			t.Fatalf("zero-position checkpoint wrote a history entry: %+v", e)
+		}
+	}
+}
+
+// With history disabled no checkpoint callback may be installed at all — the
+// player must not be handed a writer that the config says must never write.
+func TestPlayStreamNoCheckpointWhenHistoryDisabled(t *testing.T) {
+	stub := &stubCheckpointPlayer{
+		stubPlayerImpl: stubPlayerImpl{result: player.PlayResult{Position: 99, Duration: 100}},
+	}
+	playStreamHarness(t, stub)
+	cfg.History = false
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/nohist", Title: "NoHist", Type: media.Movie}
+
+	if err := playStream(stream, "NoHist", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+	if stub.fn != nil {
+		t.Fatal("checkpoint callback installed with cfg.History disabled")
+	}
+}

--- a/cmd/playstream_history_test.go
+++ b/cmd/playstream_history_test.go
@@ -26,7 +26,7 @@ func (s *stubPlayerImpl) Available() bool { return true }
 // playStreamHarness points history at a temp dir, installs a stub player and
 // a minimal cfg, and pins the playStream-relevant flags so no subtitle
 // search, JSON mode or download path runs.
-func playStreamHarness(t *testing.T, stub *stubPlayerImpl) {
+func playStreamHarness(t *testing.T, stub player.Player) {
 	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp) // history location on unix (config.dataDir)

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -578,6 +578,15 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 		return player.NotFoundError(cfg.Player)
 	}
 
+	// Periodic checkpoints while playback runs: a hard shutdown (power cut,
+	// kernel panic) kills the player and this process together, so waiting
+	// for Play to return would lose the whole watch position.
+	if cfg.History {
+		if cp, ok := p2.(player.Checkpointer); ok {
+			cp.SetCheckpoint(historyCheckpoint(selected.ID, selected.Title, selected.Type, season, episode))
+		}
+	}
+
 	result, playErr := p2.Play(stream, title, startPos, subFiles)
 
 	// Save to history before surfacing any player error: Play returns the

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -233,9 +233,24 @@ func playCurrentEpisode(sess *playlist.Session) error {
 	}
 
 	// Normal playback with retry on failure
-	p := player.New(cfg.Player, cfg.AudioLanguage)
+	p := newPlayer(cfg.Player, cfg.AudioLanguage)
 	if !p.Available() {
 		return player.NotFoundError(cfg.Player)
+	}
+
+	// Periodic checkpoints while the episode plays: a hard shutdown kills the
+	// player and this process together, so the exit-time saveHistory in
+	// runPlaybackLoop alone would lose the whole watch position.
+	if cfg.History {
+		if cp, ok := p.(player.Checkpointer); ok {
+			cp.SetCheckpoint(historyCheckpoint(
+				sess.Content.ID,
+				sess.Content.Title,
+				sess.Content.Type,
+				sess.CurrentSeason().Number,
+				sess.Current().Number,
+			))
+		}
 	}
 
 	var startPos float64

--- a/cmd/session_checkpoint_test.go
+++ b/cmd/session_checkpoint_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+	"lobster/internal/player"
+	"lobster/internal/playlist"
+)
+
+// stubStreamProvider satisfies provider.StreamProvider without any network:
+// Watch returns a canned stream, so resolveStream takes the Primary path and
+// playCurrentEpisode never touches the fallback chain.
+type stubStreamProvider struct{ stream *media.Stream }
+
+func (p *stubStreamProvider) Search(string) ([]media.SearchResult, error)      { return nil, nil }
+func (p *stubStreamProvider) GetDetails(string) (*media.ContentDetail, error)  { return nil, nil }
+func (p *stubStreamProvider) GetSeasons(string) ([]media.Season, error)        { return nil, nil }
+func (p *stubStreamProvider) GetEpisodes(string, string) ([]media.Episode, error) {
+	return nil, nil
+}
+func (p *stubStreamProvider) GetServers(string, string) ([]media.Server, error) { return nil, nil }
+func (p *stubStreamProvider) GetEmbedURL(string) (string, error)                { return "", nil }
+func (p *stubStreamProvider) Trending(media.MediaType) ([]media.SearchResult, error) {
+	return nil, nil
+}
+func (p *stubStreamProvider) Recent(media.MediaType) ([]media.SearchResult, error) {
+	return nil, nil
+}
+func (p *stubStreamProvider) Watch(mediaID, episodeID, server, quality string) (*media.Stream, error) {
+	return p.stream, nil
+}
+
+func sessionForTest(prov *stubStreamProvider) *playlist.Session {
+	return playlist.New(
+		prov,
+		media.SearchResult{ID: "tv/s", Title: "S", Type: media.TV},
+		[]media.Season{{Number: 1, ID: "s1"}},
+		[]media.Episode{{Number: 3, ID: "ep3"}},
+		0, 0,
+	)
+}
+
+// The session (playlist) path has its own play loop, so it needs the same
+// mid-playback checkpointing as playStream: a hard shutdown during an episode
+// must find the position already in history, while the session's own
+// exit-time state still carries the (more precise) final position.
+func TestPlayCurrentEpisodeCheckpointsPositionMidPlayback(t *testing.T) {
+	stub := &stubCheckpointPlayer{
+		stubPlayerImpl: stubPlayerImpl{result: player.PlayResult{Position: 1234, Duration: 5400}},
+		fire:           true,
+		mid:            [2]float64{600, 5400},
+	}
+	playStreamHarness(t, stub)
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	sess := sessionForTest(prov)
+
+	if err := playCurrentEpisode(sess); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+
+	// The state a hard shutdown mid-episode would have left behind.
+	var found bool
+	for _, e := range stub.midEntries {
+		if e.ID == "tv/s" && e.Season == 1 && e.Episode == 3 {
+			found = true
+			if e.Position != 600 || e.Duration != 5400 {
+				t.Fatalf("mid-playback history = pos %g dur %g, want 600/5400 from the checkpoint", e.Position, e.Duration)
+			}
+			if e.Title != "S" || e.Type != media.TV {
+				t.Fatalf("mid-playback entry metadata = %+v, want title S type tv", e)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no history entry existed during session playback; a hard shutdown would have lost the position (mid entries: %+v)", stub.midEntries)
+	}
+
+	// The session still records the final position for its own exit-time save.
+	if sess.LastPosition != 1234 || sess.LastDuration != 5400 {
+		t.Fatalf("session final state = pos %g dur %g, want 1234/5400", sess.LastPosition, sess.LastDuration)
+	}
+}
+
+// With history disabled the session path must not install a checkpoint
+// callback either.
+func TestPlayCurrentEpisodeNoCheckpointWhenHistoryDisabled(t *testing.T) {
+	stub := &stubCheckpointPlayer{
+		stubPlayerImpl: stubPlayerImpl{result: player.PlayResult{Position: 99, Duration: 100}},
+	}
+	playStreamHarness(t, stub)
+	cfg.History = false
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	if err := playCurrentEpisode(sessionForTest(prov)); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+	if stub.fn != nil {
+		t.Fatal("checkpoint callback installed with cfg.History disabled")
+	}
+}

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -19,9 +19,18 @@ import (
 // MPV implements the Player interface for mpv.
 // Uses exec.Command with explicit args (no shell interpretation)
 // and IPC via Unix socket at a randomized temp path.
-type MPV struct{ audioLang string }
+type MPV struct {
+	audioLang  string
+	checkpoint func(position, duration float64)
+}
 
 func (m *MPV) Name() string { return "mpv" }
+
+// SetCheckpoint installs a callback that receives the current playback
+// position and duration periodically (throttled to checkpointInterval) while
+// playback is running. Must be called before Play; the callback is never
+// invoked after Play returns.
+func (m *MPV) SetCheckpoint(fn func(position, duration float64)) { m.checkpoint = fn }
 
 func (m *MPV) Available() bool {
 	bin := mpvBinaryName()
@@ -137,6 +146,10 @@ var (
 	ipcDialInterval = 250 * time.Millisecond
 )
 
+// checkpointInterval throttles the periodic position checkpoints trackPlayback
+// hands to the SetCheckpoint callback. A package var so tests can shorten it.
+var checkpointInterval = 30 * time.Second
+
 // dialWithRetry dials the mpv IPC socket until it succeeds, the retry bound
 // elapses, or stop closes (mpv exited). mpv creates the socket only once it
 // is up, which on a slow network stream can take well over any fixed grace
@@ -162,8 +175,34 @@ func dialWithRetry(ipc *ipcSocket, stop <-chan struct{}) (io.ReadWriteCloser, er
 }
 
 // trackPlayback polls mpv's IPC for the current playback position and duration.
+// If a checkpoint callback is installed, it receives (position, duration)
+// periodically — throttled to checkpointInterval — so a hard shutdown that
+// kills mpv and this process at once loses at most one interval of position.
+// The callback runs on its own goroutine (a slow history write must not back
+// up the IPC event loop), but trackPlayback drains it before returning, so no
+// invocation can interleave with the caller's exit-time save.
 func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, float64) {
 	var lastPos, lastDur float64
+
+	var ckCh chan [2]float64
+	ckDone := make(chan struct{})
+	if m.checkpoint != nil {
+		ckCh = make(chan [2]float64, 1)
+		go func() {
+			defer close(ckDone)
+			for v := range ckCh {
+				m.checkpoint(v[0], v[1])
+			}
+		}()
+	} else {
+		close(ckDone)
+	}
+	defer func() {
+		if ckCh != nil {
+			close(ckCh)
+		}
+		<-ckDone
+	}()
 
 	conn, err := dialWithRetry(ipc, stop)
 	if err != nil {
@@ -192,6 +231,7 @@ func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, floa
 		}
 	}
 
+	lastCheckpoint := time.Now()
 	for scanner.Scan() {
 		line := scanner.Text()
 		var event struct {
@@ -204,6 +244,17 @@ func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, floa
 		}
 		if event.Name == "time-pos" && event.Data > 0 {
 			lastPos = event.Data
+			// Hand the position to the checkpoint writer, at most once per
+			// interval. The send never blocks: if the writer is still busy
+			// with the previous write, this position is simply skipped and a
+			// later event delivers a fresher one.
+			if ckCh != nil && time.Since(lastCheckpoint) >= checkpointInterval {
+				select {
+				case ckCh <- [2]float64{lastPos, lastDur}:
+					lastCheckpoint = time.Now()
+				default:
+				}
+			}
 		}
 		if event.Name == "duration" && event.Data > 0 {
 			lastDur = event.Data

--- a/internal/player/mpv_checkpoint_test.go
+++ b/internal/player/mpv_checkpoint_test.go
@@ -1,0 +1,241 @@
+//go:build !windows
+
+package player
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// shortCheckpointInterval pins the checkpoint throttle for a test and
+// restores the production value afterward.
+func shortCheckpointInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := checkpointInterval
+	checkpointInterval = d
+	t.Cleanup(func() { checkpointInterval = prev })
+}
+
+// serveMPVIPCEvents is like serveMPVIPC but emits an arbitrary event script,
+// so tests can feed the tracker zero positions or long sequences.
+func serveMPVIPCEvents(path string, events []string) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		ln, err := net.Listen("unix", path)
+		if err != nil {
+			done <- fmt.Errorf("fake mpv: listen: %w", err)
+			return
+		}
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			done <- fmt.Errorf("fake mpv: accept: %w", err)
+			return
+		}
+		defer conn.Close()
+
+		r := bufio.NewReader(conn)
+		for i := 0; i < 2; i++ {
+			if _, err := r.ReadString('\n'); err != nil {
+				done <- fmt.Errorf("fake mpv: reading observe_property %d: %w", i, err)
+				return
+			}
+		}
+
+		for _, e := range events {
+			if _, err := conn.Write([]byte(e + "\n")); err != nil {
+				done <- fmt.Errorf("fake mpv: writing event: %w", err)
+				return
+			}
+		}
+		done <- nil
+	}()
+	return done
+}
+
+func timePosEvent(pos float64) string {
+	return fmt.Sprintf(`{"event":"property-change","id":1,"name":"time-pos","data":%g}`, pos)
+}
+
+func durationEvent(dur float64) string {
+	return fmt.Sprintf(`{"event":"property-change","id":2,"name":"duration","data":%g}`, dur)
+}
+
+// checkpointRecorder collects checkpoint invocations thread-safely.
+type checkpointRecorder struct {
+	mu    sync.Mutex
+	calls [][2]float64
+}
+
+func (r *checkpointRecorder) record(pos, dur float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, [2]float64{pos, dur})
+}
+
+func (r *checkpointRecorder) snapshot() [][2]float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([][2]float64(nil), r.calls...)
+}
+
+// While playback runs, the tracker must hand positions to the checkpoint
+// callback (throttled by checkpointInterval) — a hard shutdown that kills mpv
+// and the tracker at once must cost at most one interval of resume position,
+// not the whole watch.
+func TestTrackPlaybackInvokesCheckpointDuringPlayback(t *testing.T) {
+	shortCheckpointInterval(t, 0)
+
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	serverDone := serveMPVIPCEvents(ipc.path, []string{
+		durationEvent(5400),
+		timePosEvent(100),
+		timePosEvent(200),
+	})
+
+	rec := &checkpointRecorder{}
+	m := &MPV{}
+	m.SetCheckpoint(rec.record)
+	pos, dur := m.trackPlayback(ipc, make(chan struct{}))
+	if pos != 200 || dur != 5400 {
+		t.Fatalf("trackPlayback = %g, %g; want 200, 5400 (final state must be unaffected by checkpointing)", pos, dur)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) == 0 {
+		t.Fatal("checkpoint callback never invoked during playback; a hard shutdown would lose the whole watch position")
+	}
+	for _, c := range calls {
+		if c[0] <= 0 {
+			t.Fatalf("checkpoint invoked with position %g; zero positions must never be checkpointed", c[0])
+		}
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The throttle is real: with the interval far longer than the playback, no
+// checkpoint fires. Otherwise every IPC event would trigger a history write.
+func TestTrackPlaybackCheckpointHonoursInterval(t *testing.T) {
+	shortCheckpointInterval(t, time.Hour)
+
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	serverDone := serveMPVIPCEvents(ipc.path, []string{
+		durationEvent(5400),
+		timePosEvent(100),
+		timePosEvent(200),
+		timePosEvent(300),
+	})
+
+	rec := &checkpointRecorder{}
+	m := &MPV{}
+	m.SetCheckpoint(rec.record)
+	if pos, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 300 {
+		t.Fatalf("trackPlayback position = %g, want 300", pos)
+	}
+	if calls := rec.snapshot(); len(calls) != 0 {
+		t.Fatalf("checkpoint fired %d times inside a %s interval; want 0 (throttle must hold)", len(calls), time.Hour)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A zero or negative time-pos (mpv emits these at load and on some seeks)
+// must never reach the callback — writing 0 would clobber a real resume
+// position from an earlier watch, mirroring the exit-time skip-when-zero rule.
+func TestTrackPlaybackNeverCheckpointsZeroPosition(t *testing.T) {
+	shortCheckpointInterval(t, 0)
+
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	serverDone := serveMPVIPCEvents(ipc.path, []string{
+		timePosEvent(0),
+		durationEvent(5400),
+		timePosEvent(0),
+		timePosEvent(150),
+	})
+
+	rec := &checkpointRecorder{}
+	m := &MPV{}
+	m.SetCheckpoint(rec.record)
+	if pos, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 150 {
+		t.Fatalf("trackPlayback position = %g, want 150", pos)
+	}
+
+	calls := rec.snapshot()
+	if len(calls) == 0 {
+		t.Fatal("no checkpoint at all; the positive position must still be checkpointed")
+	}
+	for _, c := range calls {
+		if c[0] <= 0 {
+			t.Fatalf("checkpoint invoked with position %g; must skip zero positions", c[0])
+		}
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The callback does file I/O on its own goroutine so a slow write cannot back
+// up the IPC event loop — but every invocation must complete before
+// trackPlayback returns, because the caller runs the (more precise) exit-time
+// save immediately after and a late checkpoint would clobber it.
+func TestTrackPlaybackCheckpointNeverOutlivesTracking(t *testing.T) {
+	shortCheckpointInterval(t, 0)
+
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	serverDone := serveMPVIPCEvents(ipc.path, []string{
+		durationEvent(5400),
+		timePosEvent(100),
+		timePosEvent(200),
+		timePosEvent(300),
+	})
+
+	rec := &checkpointRecorder{}
+	slow := func(pos, dur float64) {
+		time.Sleep(150 * time.Millisecond) // a slow history write
+		rec.record(pos, dur)
+	}
+	m := &MPV{}
+	m.SetCheckpoint(slow)
+	if pos, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 300 {
+		t.Fatalf("trackPlayback position = %g, want 300", pos)
+	}
+
+	before := len(rec.snapshot())
+	if before == 0 {
+		t.Fatal("checkpoint callback never completed before trackPlayback returned")
+	}
+	time.Sleep(300 * time.Millisecond)
+	if after := len(rec.snapshot()); after != before {
+		t.Fatalf("checkpoint callback ran after trackPlayback returned (%d calls grew to %d); it would interleave with the exit-time save", before, after)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -28,6 +28,16 @@ type Player interface {
 	Available() bool
 }
 
+// Checkpointer is implemented by players that can report the playback
+// position periodically while playback is still running (currently only mpv,
+// the one player tracked over IPC). Callers type-assert for it and install a
+// callback so a hard shutdown mid-watch loses at most one checkpoint interval
+// of resume position instead of the whole watch. The callback is never
+// invoked after Play returns.
+type Checkpointer interface {
+	SetCheckpoint(fn func(position, duration float64))
+}
+
 // NotFoundError returns a helpful error message when a player binary is missing.
 func NotFoundError(name string) error {
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## What

Playback position is now checkpointed to history periodically (every ~30s)
while the player is running, instead of only being written when the player
exits. A hard shutdown — power cut, kernel panic, anything that kills mpv,
the supervisor, and the tracker at once — now costs at most ~30 seconds of
resume position instead of the entire session.

Motivating incident: a machine hard-shutdown mid-movie after well over an
hour of playback left no history row at all, because the position only ever
lived in process memory until exit.

## How

- `internal/player`: mpv's IPC tracking loop (`trackPlayback`) now invokes an
  optional checkpoint callback, throttled to a package-level interval
  (shortened in tests). The player never learns any media metadata — it
  reports only (position, duration).
- The hook is an optional `Checkpointer` interface implemented only by the
  mpv player. VLC/Generic players never track position at all, so a hook
  there could never fire; making it part of the core interface would force
  dead implementations.
- `cmd`: `playStream` and the session path supply the callback via a shared
  `historyCheckpoint` helper that reuses the same save routine as the
  exit-time save, so a checkpoint row and a final row are structurally
  identical (update-in-place per ID). Zero positions are skipped, mirroring
  the existing behaviour.
- The exit-time save still runs unchanged and wins over the last checkpoint —
  it is more precise. The callback cannot fire after `Play` returns, so the
  final save never interleaves with a checkpoint.

## Verified

- 10 new tests, each watched fail on an assertion before the code existed;
  the agent-path test was additionally mutation-verified (deleting
  `playStream`'s `SetCheckpoint` wiring fails it on the mid-playback
  assertion).
- An end-to-end test drives the real `playRun` (`play --ref` agent path, the
  primary production path) with only the provider, player, and availability
  probe stubbed, and asserts a checkpoint is on disk mid-playback with the
  exit save winning afterwards.
- Call-site sweep for direct `Play` calls: `playLiveSurf` (live TV) is the
  only uncheckpointed path, deliberately — live TV has no resume position and
  never writes history even at exit.
- Gate: `go build ./... && go vet ./... && go test ./...` (CGO_ENABLED=0),
  `GOOS=windows` build + vet, `GOOS=darwin` build, and
  `CGO_ENABLED=1 go test -race -count=2` over both `./internal/player/` and
  `./cmd/` — all green.

## Not verified

- No live end-to-end run against a real provider/mpv for this branch yet; the
  installed binary will be rebuilt and exercised after merge.
- Checkpoint write failures are logged at debug level only, matching the
  existing exit-time save policy — a failing disk surfaces nothing louder.
- The first checkpoint lands ~30s after playback starts; a crash inside the
  first window still loses that session's position (bounded by design).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Playback history now saves watch progress periodically during supported playback sessions.
  - If playback stops unexpectedly, your resume position is preserved within a short interval of the interruption.
  - Final playback position continues to replace earlier checkpoints, avoiding duplicate history entries.
  - Checkpointing is only enabled when history tracking is turned on.
  - Invalid or zero-position checkpoints are ignored to prevent inaccurate history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->