### PR TITLE
fix(player): never persist a position the tracker never observed

### DIFF
--- a/cmd/playstream_history_test.go
+++ b/cmd/playstream_history_test.go
@@ -113,6 +113,46 @@ func TestPlayStreamSkipsHistoryOnAbnormalExitWithoutPosition(t *testing.T) {
 	}
 }
 
+// The incident this guards against: a watch whose mpv IPC socket never came
+// up plays fine but is tracked as position 0, and quitting the player is a
+// clean exit — so the exit-time save wrote 0 over a good resume point from an
+// earlier watch, and the next launch restarted the film from the beginning.
+// A session that observed nothing must leave history alone.
+func TestPlayStreamKeepsExistingPositionWhenTrackerNeverObserved(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{PositionUnknown: true},
+	})
+
+	prior := media.HistoryEntry{
+		ID: "movie/z", Title: "Z", Type: media.Movie,
+		Position: 2109, Duration: 5400,
+	}
+	if err := history.Save(prior); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/z", Title: "Z", Type: media.Movie}
+
+	if err := playStream(stream, "Z", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	entries, loadErr := history.Load()
+	if loadErr != nil {
+		t.Fatalf("history.Load: %v", loadErr)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/z" {
+			if e.Position != 2109 {
+				t.Fatalf("history position = %g, want 2109 kept: a session that never observed a position must not overwrite the previous one", e.Position)
+			}
+			return
+		}
+	}
+	t.Fatalf("the pre-existing history entry for movie/z is gone; entries: %+v", entries)
+}
+
 // The clean-exit path must keep saving exactly as before, including a
 // position of 0 (a finished watch mpv reports as 0 still records the entry).
 func TestPlayStreamStillSavesOnCleanExit(t *testing.T) {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -593,8 +593,10 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 	// tracked position alongside the error, and an abnormal exit (killed,
 	// crash) is exactly the watch whose resume point must not be lost. With no
 	// tracked position there is nothing to keep, and writing 0 would clobber a
-	// real position from an earlier watch of the same title.
-	if cfg.History && (playErr == nil || result.Position > 0) {
+	// real position from an earlier watch of the same title — which is also
+	// why a session whose tracker never observed a position is skipped even
+	// though it exited cleanly: its result is a default, not a measurement.
+	if cfg.History && !result.PositionUnknown && (playErr == nil || result.Position > 0) {
 		entry := media.HistoryEntry{
 			ID:       selected.ID,
 			Title:    selected.Title,

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -279,6 +279,7 @@ func playCurrentEpisode(sess *playlist.Session) error {
 		if playErr == nil {
 			sess.LastPosition = result.Position
 			sess.LastDuration = result.Duration
+			sess.LastPositionUnknown = result.PositionUnknown
 			return nil
 		}
 
@@ -365,6 +366,13 @@ func downloadEpisode(stream *media.Stream, sess *playlist.Session, title string)
 // saveHistory persists the current episode to watch history.
 func saveHistory(sess *playlist.Session) {
 	if !cfg.History {
+		return
+	}
+	// The position tracker never observed anything for this episode, so
+	// LastPosition is 0 by default rather than by measurement. Writing it
+	// would overwrite the resume point an earlier, tracked watch recorded.
+	if sess.LastPositionUnknown {
+		debugf("skipping history save: no position was observed for this episode")
 		return
 	}
 

--- a/cmd/session_checkpoint_test.go
+++ b/cmd/session_checkpoint_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"testing"
 
+	"lobster/internal/history"
 	"lobster/internal/media"
 	"lobster/internal/player"
 	"lobster/internal/playlist"
@@ -81,6 +82,45 @@ func TestPlayCurrentEpisodeCheckpointsPositionMidPlayback(t *testing.T) {
 	if sess.LastPosition != 1234 || sess.LastDuration != 5400 {
 		t.Fatalf("session final state = pos %g dur %g, want 1234/5400", sess.LastPosition, sess.LastDuration)
 	}
+}
+
+// The session path has the same exposure as playStream: a blind tracker plus a
+// clean player exit used to hand saveHistory a position of 0, overwriting the
+// episode's real resume point. An episode whose position was never observed
+// must not be written at all.
+func TestSessionKeepsExistingPositionWhenTrackerNeverObserved(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{PositionUnknown: true},
+	})
+
+	prior := media.HistoryEntry{
+		ID: "tv/s", Title: "S", Type: media.TV,
+		Season: 1, Episode: 3, Position: 1500, Duration: 2400,
+	}
+	if err := history.Save(prior); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	sess := sessionForTest(prov)
+	if err := playCurrentEpisode(sess); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+	saveHistory(sess)
+
+	entries, loadErr := history.Load()
+	if loadErr != nil {
+		t.Fatalf("history.Load: %v", loadErr)
+	}
+	for _, e := range entries {
+		if e.ID == "tv/s" && e.Season == 1 && e.Episode == 3 {
+			if e.Position != 1500 {
+				t.Fatalf("history position = %g, want 1500 kept: an episode whose position was never observed must not overwrite the previous one", e.Position)
+			}
+			return
+		}
+	}
+	t.Fatalf("the pre-existing history entry for tv/s S01E03 is gone; entries: %+v", entries)
 }
 
 // With history disabled the session path must not install a checkpoint

--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -98,14 +98,16 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 	// Track position and duration from IPC in a goroutine, using atomics to avoid data race.
 	// The ipcDone channel is used to synchronize the goroutine before reading final values.
 	var posBits, durBits atomic.Uint64
+	var observed atomic.Bool
 	ipcDone := make(chan struct{})
 	procDone := make(chan struct{})
 	startTime := time.Now()
 	go func() {
 		defer close(ipcDone)
-		pos, dur := m.trackPlayback(ipc, procDone)
+		pos, dur, ok := m.trackPlayback(ipc, procDone)
 		posBits.Store(math.Float64bits(pos))
 		durBits.Store(math.Float64bits(dur))
+		observed.Store(ok)
 	}()
 
 	waitErr := cmd.Wait()
@@ -119,6 +121,10 @@ func (m *MPV) Play(stream *media.Stream, title string, startPos float64, subFile
 	result := PlayResult{
 		Position: math.Float64frombits(posBits.Load()),
 		Duration: math.Float64frombits(durBits.Load()),
+		// The tracker either observed a position for this session or it saw
+		// nothing at all; in the second case Position is a default, not a
+		// measurement, and callers must not persist it.
+		PositionUnknown: !observed.Load(),
 	}
 
 	if waitErr != nil {
@@ -175,14 +181,19 @@ func dialWithRetry(ipc *ipcSocket, stop <-chan struct{}) (io.ReadWriteCloser, er
 }
 
 // trackPlayback polls mpv's IPC for the current playback position and duration.
+// The third return says whether mpv ever reported a position at all: false
+// means the socket never came up, or came up and said nothing, so the returned
+// 0 carries no information about where the watch stopped. Callers need that
+// distinction to avoid writing 0 over a real resume point.
 // If a checkpoint callback is installed, it receives (position, duration)
 // periodically — throttled to checkpointInterval — so a hard shutdown that
 // kills mpv and this process at once loses at most one interval of position.
 // The callback runs on its own goroutine (a slow history write must not back
 // up the IPC event loop), but trackPlayback drains it before returning, so no
 // invocation can interleave with the caller's exit-time save.
-func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, float64) {
+func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, float64, bool) {
 	var lastPos, lastDur float64
+	var observed bool
 
 	var ckCh chan [2]float64
 	ckDone := make(chan struct{})
@@ -209,7 +220,7 @@ func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, floa
 		// Playback proceeds without tracking; say so instead of silently
 		// recording the watch as position 0.
 		fmt.Fprintf(os.Stderr, "mpv ipc: position tracking unavailable: %v\n", err)
-		return 0, 0
+		return 0, 0, false
 	}
 	defer conn.Close()
 
@@ -227,23 +238,34 @@ func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, floa
 			// IPC write failed — mpv may have exited early or the socket
 			// is broken. Return zero state so the caller can detect this.
 			fmt.Fprintf(os.Stderr, "mpv ipc: failed to observe %s: %v\n", prop, err)
-			return 0, 0
+			return 0, 0, false
 		}
 	}
 
 	lastCheckpoint := time.Now()
 	for scanner.Scan() {
 		line := scanner.Text()
+		// Data is a pointer because mpv sends "data":null for a property it
+		// has no value for yet — before playback starts, and again as it shuts
+		// down. A null must not count as an observation, and a plain float64
+		// would decode it as an indistinguishable 0.
 		var event struct {
-			Event string  `json:"event"`
-			Name  string  `json:"name"`
-			Data  float64 `json:"data"`
+			Event string   `json:"event"`
+			Name  string   `json:"name"`
+			Data  *float64 `json:"data"`
 		}
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
 			continue
 		}
-		if event.Name == "time-pos" && event.Data > 0 {
-			lastPos = event.Data
+		if event.Name == "time-pos" && event.Data != nil {
+			// mpv told us where playback is, so the position this call returns
+			// is a measurement — including when that measurement is 0, which
+			// is why this is set before the > 0 filter below rather than from
+			// lastPos.
+			observed = true
+		}
+		if event.Name == "time-pos" && event.Data != nil && *event.Data > 0 {
+			lastPos = *event.Data
 			// Hand the position to the checkpoint writer, at most once per
 			// interval. The send never blocks: if the writer is still busy
 			// with the previous write, this position is simply skipped and a
@@ -256,12 +278,12 @@ func (m *MPV) trackPlayback(ipc *ipcSocket, stop <-chan struct{}) (float64, floa
 				}
 			}
 		}
-		if event.Name == "duration" && event.Data > 0 {
-			lastDur = event.Data
+		if event.Name == "duration" && event.Data != nil && *event.Data > 0 {
+			lastDur = *event.Data
 		}
 	}
 
-	return lastPos, lastDur
+	return lastPos, lastDur, observed
 }
 
 // formatDuration formats seconds as HH:MM:SS.

--- a/internal/player/mpv_checkpoint_test.go
+++ b/internal/player/mpv_checkpoint_test.go
@@ -105,7 +105,7 @@ func TestTrackPlaybackInvokesCheckpointDuringPlayback(t *testing.T) {
 	rec := &checkpointRecorder{}
 	m := &MPV{}
 	m.SetCheckpoint(rec.record)
-	pos, dur := m.trackPlayback(ipc, make(chan struct{}))
+	pos, dur, _ := m.trackPlayback(ipc, make(chan struct{}))
 	if pos != 200 || dur != 5400 {
 		t.Fatalf("trackPlayback = %g, %g; want 200, 5400 (final state must be unaffected by checkpointing)", pos, dur)
 	}
@@ -145,7 +145,7 @@ func TestTrackPlaybackCheckpointHonoursInterval(t *testing.T) {
 	rec := &checkpointRecorder{}
 	m := &MPV{}
 	m.SetCheckpoint(rec.record)
-	if pos, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 300 {
+	if pos, _, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 300 {
 		t.Fatalf("trackPlayback position = %g, want 300", pos)
 	}
 	if calls := rec.snapshot(); len(calls) != 0 {
@@ -178,7 +178,7 @@ func TestTrackPlaybackNeverCheckpointsZeroPosition(t *testing.T) {
 	rec := &checkpointRecorder{}
 	m := &MPV{}
 	m.SetCheckpoint(rec.record)
-	if pos, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 150 {
+	if pos, _, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 150 {
 		t.Fatalf("trackPlayback position = %g, want 150", pos)
 	}
 
@@ -223,7 +223,7 @@ func TestTrackPlaybackCheckpointNeverOutlivesTracking(t *testing.T) {
 	}
 	m := &MPV{}
 	m.SetCheckpoint(slow)
-	if pos, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 300 {
+	if pos, _, _ := m.trackPlayback(ipc, make(chan struct{})); pos != 300 {
 		t.Fatalf("trackPlayback position = %g, want 300", pos)
 	}
 

--- a/internal/player/mpv_track_test.go
+++ b/internal/player/mpv_track_test.go
@@ -88,7 +88,7 @@ func TestTrackPlaybackConnectsWhenSocketAppearsLate(t *testing.T) {
 	serverDone := serveMPVIPC(ipc.path, 1200*time.Millisecond, 987.5, 5400)
 
 	m := &MPV{}
-	pos, dur := m.trackPlayback(ipc, make(chan struct{}))
+	pos, dur, _ := m.trackPlayback(ipc, make(chan struct{}))
 	// Assert on the outcome first: if the tracker never connected, the server
 	// is still blocked in Accept and draining serverDone would deadlock.
 	if pos != 987.5 {
@@ -96,6 +96,30 @@ func TestTrackPlaybackConnectsWhenSocketAppearsLate(t *testing.T) {
 	}
 	if dur != 5400 {
 		t.Fatalf("trackPlayback duration = %g, want 5400", dur)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A session whose tracker connected and saw mpv report a position must say so,
+// so callers can tell "the position really is this" from "we never found out".
+func TestTrackPlaybackReportsObservedWhenMPVReportsPosition(t *testing.T) {
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	serverDone := serveMPVIPC(ipc.path, 0, 620, 5400)
+
+	m := &MPV{}
+	pos, _, observed := m.trackPlayback(ipc, make(chan struct{}))
+	if pos != 620 {
+		t.Fatalf("trackPlayback position = %g, want 620", pos)
+	}
+	if !observed {
+		t.Fatalf("trackPlayback observed = false after mpv reported time-pos %g; a tracked position must be reported as observed", pos)
 	}
 	if err := <-serverDone; err != nil {
 		t.Fatal(err)
@@ -115,12 +139,64 @@ func TestTrackPlaybackGivesUpAtDialBound(t *testing.T) {
 
 	start := time.Now()
 	m := &MPV{}
-	pos, dur := m.trackPlayback(ipc, make(chan struct{}))
+	pos, dur, observed := m.trackPlayback(ipc, make(chan struct{}))
 	if pos != 0 || dur != 0 {
 		t.Fatalf("trackPlayback = %g, %g; want 0, 0 when nothing ever listens", pos, dur)
 	}
+	if observed {
+		t.Fatalf("trackPlayback observed = true after never connecting; position 0 here means nothing was seen, not that playback sat at 0")
+	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("trackPlayback took %s to give up; the bound is %s", elapsed, 300*time.Millisecond)
+	}
+}
+
+// A tracker that connects but is told nothing — mpv reports time-pos as null
+// until playback actually starts, so a quit during buffering yields exactly
+// this — has still observed no position, and must not claim otherwise.
+func TestTrackPlaybackUnobservedWhenMPVReportsNoPosition(t *testing.T) {
+	ipc, err := newIPCSocket()
+	if err != nil {
+		t.Fatalf("newIPCSocket: %v", err)
+	}
+	t.Cleanup(ipc.cleanup)
+
+	serverDone := make(chan error, 1)
+	go func() {
+		ln, err := net.Listen("unix", ipc.path)
+		if err != nil {
+			serverDone <- fmt.Errorf("fake mpv: listen: %w", err)
+			return
+		}
+		defer ln.Close()
+		conn, err := ln.Accept()
+		if err != nil {
+			serverDone <- fmt.Errorf("fake mpv: accept: %w", err)
+			return
+		}
+		defer conn.Close()
+		r := bufio.NewReader(conn)
+		for i := 0; i < 2; i++ {
+			if _, err := r.ReadString('\n'); err != nil {
+				serverDone <- fmt.Errorf("fake mpv: reading observe_property %d: %w", i, err)
+				return
+			}
+		}
+		// mpv's answer for a property it has no value for yet.
+		if _, err := conn.Write([]byte(`{"event":"property-change","id":1,"name":"time-pos","data":null}` + "\n")); err != nil {
+			serverDone <- fmt.Errorf("fake mpv: writing event: %w", err)
+			return
+		}
+		serverDone <- nil
+	}()
+
+	m := &MPV{}
+	pos, _, observed := m.trackPlayback(ipc, make(chan struct{}))
+	if observed {
+		t.Fatalf("trackPlayback observed = true when mpv only ever reported a null time-pos (position %g)", pos)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -145,7 +221,7 @@ func TestTrackPlaybackStopsRetryingOnceProcessExits(t *testing.T) {
 
 	start := time.Now()
 	m := &MPV{}
-	pos, dur := m.trackPlayback(ipc, stop)
+	pos, dur, _ := m.trackPlayback(ipc, stop)
 	if pos != 0 || dur != 0 {
 		t.Fatalf("trackPlayback = %g, %g; want 0, 0", pos, dur)
 	}

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -14,6 +14,18 @@ import (
 type PlayResult struct {
 	Position float64 // last playback position in seconds
 	Duration float64 // total media duration in seconds (0 if unknown)
+
+	// PositionUnknown reports that this session tracked the playback position
+	// and never observed one — mpv's IPC socket never came up within the dial
+	// bound, or mpv never reported a time-pos over it. Position is then a
+	// default rather than a measurement, and persisting it would overwrite a
+	// real resume point recorded by an earlier watch of the same title.
+	//
+	// It is deliberately false for a session that genuinely sat at position 0,
+	// so the two stay distinguishable, and false for players that do not
+	// report positions at all (vlc, generic): those make no claim either way
+	// and history goes on recording their watches exactly as before.
+	PositionUnknown bool
 }
 
 // Player is the interface for media player implementations.

--- a/internal/playlist/session.go
+++ b/internal/playlist/session.go
@@ -19,6 +19,11 @@ type Session struct {
 	EpisodeIdx   int
 	LastPosition float64 // playback position from most recent play
 	LastDuration float64 // total media duration from most recent play
+	// LastPositionUnknown carries player.PlayResult.PositionUnknown from the
+	// most recent play: the position tracker never observed a position, so
+	// LastPosition is a default rather than a measurement and must not be
+	// persisted over the episode's existing resume point.
+	LastPositionUnknown bool
 }
 
 // New creates a Session positioned at the given season and episode.


### PR DESCRIPTION
## What

A playback session whose position tracker never connected no longer writes a
history row. Previously such a session persisted position 0 and overwrote a
perfectly good saved position.

## The incident this fixes

Observed live, not hypothetical:

1. A `play --detach` run took longer than the 30s IPC dial window to expose its
   mpv socket, and logged `mpv ipc: position tracking unavailable`. Playback was
   fine; lobster just had no idea where the viewer was.
2. That session's in-memory position stayed 0 for its whole life.
3. On quit the process exited *cleanly*, and the exit-time save persisted 0 —
   overwriting the existing row for that film (2109s, written by an earlier
   healthy session).
4. The next launch found 0, passed no `--start`, and restarted from the
   beginning. The first checkpoint then cemented the loss.

35 minutes of a film, gone, with every individual step behaving "correctly".

## Root cause

"The tracker reported 0" and "the tracker never connected, so we know nothing"
were indistinguishable at save time. `cmd/search.go` gated on
`playErr == nil || result.Position > 0`, so a clean exit short-circuits the
position test and 0 is written as a legitimate value.

The TV path was worse: `saveHistory` had **no zero check at all**, so it could
clobber a saved position even more readily. Fixed there too.

## How

`PlayResult` carries an explicit `PositionUnknown` signal, set when the IPC
tracker never observed a `time-pos`. Both save paths skip persisting when it is
set.

The flag is deliberately negative-sense rather than a positive `Tracked`: the
VLC and generic players return a bare `PlayResult{}` and never report positions
at all, so a positive flag would have silently stopped recording history for
users of those players — `lobster history` would have quietly gone empty for
them. The zero value must mean "today's behaviour".

A genuine tracked position of 0 stays distinguishable from an unobserved one by
mechanism, not by a `> 0` test: `trackPlayback` decodes `data` as `*float64`
(mpv sends `"data":null` before playback starts) and marks the position observed
on any non-null `time-pos`, *before* the `> 0` filter. So a real 0 is
`{0, observed}` and a blind session is `{0, unknown}`. The existing `> 0` filters
on the tracked values are untouched.

The checkpoint path needed no change: structurally a blind session can never
checkpoint, since the send only happens after a `time-pos` event.

## Verified

- Headline test reproduces the incident exactly — pre-existing row at 2109, a
  tracker that never connects, a clean exit — and asserts the row survives. It
  was watched failing first, on `history position = 0, want 2109 kept`.
- The equivalent session/TV test was watched failing on `history position = 0,
  want 1500 kept`.
- Mutation-verified: deleting either guard turns the corresponding test red on
  its assertion; *inverting* both guards breaks five tests including the
  clean-exit save, the abnormal-exit save and the checkpoint test — so normal
  behaviour is pinned, not merely unbroken.
- Gate green: build/vet/test with `CGO_ENABLED=0`, `GOOS=windows` build + vet,
  `GOOS=darwin` build, and `CGO_ENABLED=1 go test ./internal/player/ ./cmd/
  -race -count=2`.

## Not verified / out of scope

- An earlier theory that the 30s dial window was inherited from a failed first
  mpv attempt is **wrong** and no fix was written for it: every `Play` call
  creates a fresh socket and computes its own deadline, so the window is
  per-call. The observed log line means one mpv genuinely took over 30s to
  expose its socket. That case is now harmless rather than destructive.
- The 30s `ipcDialTimeout` may simply be too short for slow starts. Raising it
  is nearly free, since the dial loop exits early when mpv dies — but it is a
  timing decision of its own and is not made here.
- VLC and the generic player still overwrite a good position with 0 on every
  watch. Pre-existing, untouched: fixing it means deciding whether a
  non-tracking player should record a watch at all.
- No live end-to-end run on this branch; the installed binary is rebuilt and
  exercised after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing resume positions when playback ends before a valid position is detected.
  - Prevented unmeasured playback positions from being saved as 0 and overwriting a previously stored position.
  - Continued saving genuine positions at 0 and playback positions from supported players as expected.

- **Tests**
  - Added regression coverage for preserving watch history when no playback position is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->