### PR TITLE
chore: stop CodeRabbit from auto-reviewing every push

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# CodeRabbit configuration.
+#
+# Automatic review on every push is disabled: reviews are requested explicitly
+# with `@coderabbitai review` on a pull request when they are wanted.
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Disables CodeRabbit's automatic review on every push.

Reviews are still available on demand — `@coderabbitai review` on a pull
request — but they no longer fire unprompted on each push to each branch.

Kept on its own branch rather than folded into an in-flight feature PR, since
it changes repo-wide behaviour and should be reviewable on its own.
