### PR TITLE
fix(history): stop untracked watches and concurrent writes destroying history

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"lobster/internal/config"
+	"lobster/internal/history"
 )
 
 // Version is set at build time via ldflags.
@@ -138,6 +139,11 @@ func applyConfig() error {
 		log.SetOutput(os.Stderr)
 		log.SetFlags(0)
 	}
+
+	// The history package falls back to an unlocked write when its lock cannot
+	// be established. Route that notice through debugf so the downgrade is
+	// diagnosable instead of silent.
+	history.SetLogger(debugf)
 
 	return nil
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -593,10 +593,17 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 	// tracked position alongside the error, and an abnormal exit (killed,
 	// crash) is exactly the watch whose resume point must not be lost. With no
 	// tracked position there is nothing to keep, and writing 0 would clobber a
-	// real position from an earlier watch of the same title — which is also
-	// why a session whose tracker never observed a position is skipped even
-	// though it exited cleanly: its result is a default, not a measurement.
-	if cfg.History && !result.PositionUnknown && (playErr == nil || result.Position > 0) {
+	// real position from an earlier watch of the same title.
+	//
+	// A result marked PositionUnknown carries a default rather than a
+	// measurement, and the two reasons for that are not the same thing. A
+	// player with no position tracking (vlc, iina, celluloid) also marks the
+	// result PositionUntracked: the watch definitely happened, so it is
+	// recorded, keeping whatever position history already holds. A tracked
+	// player that was never heard from says nothing about whether playback
+	// happened at all, so it writes nothing — even on a clean exit.
+	if cfg.History && (playErr == nil || result.Position > 0) &&
+		(!result.PositionUnknown || result.PositionUntracked) {
 		entry := media.HistoryEntry{
 			ID:       selected.ID,
 			Title:    selected.Title,
@@ -606,7 +613,11 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 			Position: result.Position,
 			Duration: result.Duration,
 		}
-		if err := history.Save(entry); err != nil {
+		save := history.Save
+		if result.PositionUntracked {
+			save = history.SaveKeepingPosition
+		}
+		if err := save(entry); err != nil {
 			debugf("saving history failed: %v", err)
 		}
 	}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -280,6 +280,7 @@ func playCurrentEpisode(sess *playlist.Session) error {
 			sess.LastPosition = result.Position
 			sess.LastDuration = result.Duration
 			sess.LastPositionUnknown = result.PositionUnknown
+			sess.LastPositionUntracked = result.PositionUntracked
 			return nil
 		}
 
@@ -368,10 +369,12 @@ func saveHistory(sess *playlist.Session) {
 	if !cfg.History {
 		return
 	}
-	// The position tracker never observed anything for this episode, so
-	// LastPosition is 0 by default rather than by measurement. Writing it
-	// would overwrite the resume point an earlier, tracked watch recorded.
-	if sess.LastPositionUnknown {
+	// When LastPositionUnknown is set, LastPosition is 0 by default rather
+	// than by measurement, so it must never reach the episode's stored resume
+	// point. The two ways that happens are handled differently.
+	if sess.LastPositionUnknown && !sess.LastPositionUntracked {
+		// A tracked player that was never heard from: nothing here says the
+		// episode actually played, so record nothing at all.
 		debugf("skipping history save: no position was observed for this episode")
 		return
 	}
@@ -385,7 +388,13 @@ func saveHistory(sess *playlist.Session) {
 		Position: sess.LastPosition,
 		Duration: sess.LastDuration,
 	}
-	if err := history.Save(entry); err != nil {
+	save := history.Save
+	if sess.LastPositionUntracked {
+		// The player cannot report a position at all, but the watch is real:
+		// record it while keeping any position history already holds.
+		save = history.SaveKeepingPosition
+	}
+	if err := save(entry); err != nil {
 		debugf("saving history failed: %v", err)
 	}
 }

--- a/cmd/untracked_history_test.go
+++ b/cmd/untracked_history_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/history"
+	"lobster/internal/media"
+	"lobster/internal/player"
+)
+
+// untrackedResult is what vlc, iina and celluloid return: the watch happened,
+// but no position was ever measured, so the zero Position is a default.
+func untrackedResult() player.PlayResult {
+	return player.PlayResult{PositionUnknown: true, PositionUntracked: true}
+}
+
+// The owner's live bug: watching a title in VLC wrote position 0 over the
+// resume point an earlier mpv watch had recorded, so the next launch restarted
+// from the beginning. VLC cannot measure a position, so it must leave the
+// stored one alone.
+func TestPlayStreamKeepsStoredPositionForAnUntrackedPlayer(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{result: untrackedResult()})
+
+	prior := media.HistoryEntry{
+		ID: "movie/v", Title: "V", Type: media.Movie,
+		Position: 2109, Duration: 5400,
+	}
+	if err := history.Save(prior); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/v", Title: "V", Type: media.Movie}
+	if err := playStream(stream, "V", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/v" {
+			if e.Position != 2109 || e.Duration != 5400 {
+				t.Fatalf("history entry = %+v, want position 2109 / duration 5400 kept: an untracked player must not overwrite a real resume point", e)
+			}
+			return
+		}
+	}
+	t.Fatalf("the pre-existing history entry for movie/v is gone; entries: %+v", entries)
+}
+
+// The other half: an untracked player must still record the watch. Skipping
+// the save outright (which is what a tracked-but-blind session does) would
+// mean a title only ever watched in VLC never appears in `lobster history`.
+func TestPlayStreamRecordsAnUntrackedWatchOfANewTitle(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{result: untrackedResult()})
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/w", Title: "W", Type: media.Movie}
+	if err := playStream(stream, "W", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/w" {
+			if e.Position != 0 {
+				t.Fatalf("history position = %g, want 0: there was no resume point to keep", e.Position)
+			}
+			return
+		}
+	}
+	t.Fatalf("no history entry for movie/w: an untracked watch must still be recorded; entries: %+v", entries)
+}
+
+// mpv's behaviour must not move. A tracked session that never observed a
+// position makes no claim that the watch reached the player at all — the IPC
+// socket never came up — so it writes nothing, not even a new row. That is the
+// #52 contract, and the untracked-player change must not widen it.
+func TestPlayStreamWritesNothingWhenTrackedPlayerNeverObserved(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{PositionUnknown: true},
+	})
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/u", Title: "U", Type: media.Movie}
+	if err := playStream(stream, "U", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.ID == "movie/u" {
+			t.Fatalf("history row created for a tracked session that observed nothing: %+v", e)
+		}
+	}
+}
+
+// The session (playlist) path saves through saveHistory rather than
+// playStream, so it needs the same guarantee proved separately.
+func TestSessionKeepsStoredPositionForAnUntrackedPlayer(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{result: untrackedResult()})
+
+	prior := media.HistoryEntry{
+		ID: "tv/s", Title: "S", Type: media.TV,
+		Season: 1, Episode: 3, Position: 1500, Duration: 2400,
+	}
+	if err := history.Save(prior); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	sess := sessionForTest(prov)
+	if err := playCurrentEpisode(sess); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+	saveHistory(sess)
+
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.ID == "tv/s" && e.Season == 1 && e.Episode == 3 {
+			if e.Position != 1500 || e.Duration != 2400 {
+				t.Fatalf("history entry = %+v, want position 1500 / duration 2400 kept for an untracked player", e)
+			}
+			return
+		}
+	}
+	t.Fatalf("the pre-existing history entry for tv/s S01E03 is gone; entries: %+v", entries)
+}
+
+// And the session path must record an untracked episode nobody has watched
+// before, for the same reason playStream must.
+func TestSessionRecordsAnUntrackedWatchOfANewEpisode(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{result: untrackedResult()})
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	sess := sessionForTest(prov)
+	if err := playCurrentEpisode(sess); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+	saveHistory(sess)
+
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.ID == "tv/s" && e.Season == 1 && e.Episode == 3 {
+			if e.Position != 0 {
+				t.Fatalf("history position = %g, want 0: there was no resume point to keep", e.Position)
+			}
+			return
+		}
+	}
+	t.Fatalf("no history entry for tv/s S01E03: an untracked watch must still be recorded; entries: %+v", entries)
+}
+
+// mpv's session-path behaviour must not move either: a tracked-but-blind
+// episode writes no row at all.
+func TestSessionWritesNothingWhenTrackedPlayerNeverObserved(t *testing.T) {
+	playStreamHarness(t, &stubPlayerImpl{
+		result: player.PlayResult{PositionUnknown: true},
+	})
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	sess := sessionForTest(prov)
+	if err := playCurrentEpisode(sess); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+	saveHistory(sess)
+
+	entries, err := history.Load()
+	if err != nil {
+		t.Fatalf("history.Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.ID == "tv/s" {
+			t.Fatalf("history row created for a tracked session that observed nothing: %+v", e)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/image v0.45.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.41.0
 	modernc.org/sqlite v1.50.0
@@ -115,7 +116,6 @@ require (
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	lukechampine.com/blake3 v1.1.6 // indirect
 	modernc.org/libc v1.72.0 // indirect

--- a/internal/history/concurrent_test.go
+++ b/internal/history/concurrent_test.go
@@ -1,0 +1,115 @@
+package history
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"lobster/internal/media"
+)
+
+// dataHomeEnv names the environment variable config.dataDir consults on this
+// platform, so a child process can be pointed at the same history file as the
+// parent test.
+func dataHomeEnv() string {
+	if runtime.GOOS == "windows" {
+		return "LOCALAPPDATA"
+	}
+	return "XDG_DATA_HOME"
+}
+
+// concurrentWriters is how many writers race for the history file. Enough that
+// at least two overlap in practice; small enough to stay fast under -race.
+const concurrentWriters = 8
+
+// TestSaveFromSeparateProcessesKeepsEveryRow models the race that is actually
+// reachable for this program: two `lobster play` runs alive at the same time,
+// each calling Save on the one history file. Save loads the whole file,
+// mutates one row and writes the result back through a temp file and a rename.
+// The rename is atomic; the load-mutate-write around it is not. A writer that
+// loaded before another's rename writes back a file that never contained the
+// other's row, and that row is gone for good.
+//
+// This is deliberately a MULTI-PROCESS test, not goroutines: goroutines would
+// be satisfied by a package mutex, which cannot serialise two lobster
+// processes and so would not close this race at all. Each child does exactly
+// one Save of its own distinct row and waits at a file barrier first, so the
+// writes overlap rather than queueing up behind process startup.
+func TestSaveFromSeparateProcessesKeepsEveryRow(t *testing.T) {
+	if os.Getenv("LOBSTER_TEST_SAVE_ROW") != "" {
+		t.Skip("running as the child writer")
+	}
+
+	dir := t.TempDir()
+	barrier := filepath.Join(dir, "start")
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentWriters; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cmd := exec.Command(os.Args[0], "-test.run=^TestChildWriterSavesOneRow$", "-test.v")
+			cmd.Env = append(os.Environ(),
+				dataHomeEnv()+"="+dir,
+				"LOBSTER_TEST_SAVE_ROW="+strconv.Itoa(i),
+				"LOBSTER_TEST_SAVE_BARRIER="+barrier,
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Errorf("child %d: %v\n%s", i, err, out)
+			}
+		}(i)
+	}
+
+	// Let every child reach the barrier before releasing them together.
+	time.Sleep(300 * time.Millisecond)
+	if err := os.WriteFile(barrier, nil, 0600); err != nil {
+		t.Fatalf("releasing barrier: %v", err)
+	}
+	wg.Wait()
+
+	setDataHome(t, dir)
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != concurrentWriters {
+		t.Fatalf("history holds %d rows, want %d: Save's load-mutate-rename is not atomic across processes, so a writer that loaded before another's rename drops that writer's row: %+v",
+			len(entries), concurrentWriters, entries)
+	}
+}
+
+// TestChildWriterSavesOneRow is the child half of
+// TestSaveFromSeparateProcessesKeepsEveryRow. It is a no-op unless the parent
+// invoked it with LOBSTER_TEST_SAVE_ROW set.
+func TestChildWriterSavesOneRow(t *testing.T) {
+	row := os.Getenv("LOBSTER_TEST_SAVE_ROW")
+	if row == "" {
+		t.Skip("helper for TestSaveFromSeparateProcessesKeepsEveryRow")
+	}
+
+	if barrier := os.Getenv("LOBSTER_TEST_SAVE_BARRIER"); barrier != "" {
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			if _, err := os.Stat(barrier); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("barrier %s never appeared", barrier)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	if err := Save(media.HistoryEntry{
+		ID:    "movie/" + row,
+		Title: "Row " + row,
+		Type:  media.Movie,
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -125,6 +125,34 @@ func Save(entry media.HistoryEntry) error {
 	return nil
 }
 
+// SaveKeepingPosition records a watch whose player could not report a playback
+// position. Any Position and Duration already stored for the same
+// (ID, Season, Episode) are carried into the entry before it is written, so
+// the watch is recorded without its default 0 replacing a real resume point;
+// a title with no stored entry is appended at position 0, there being no
+// resume point to lose.
+//
+// It lives here rather than in the callers because (ID, Season, Episode) is
+// history's own identity for a row — the key Save updates in place — and two
+// copies of that rule would be free to drift apart.
+func SaveKeepingPosition(entry media.HistoryEntry) error {
+	// A read failure here is not recoverable by writing anyway: Save would
+	// then rebuild the file from this single entry and drop the rest of the
+	// history, which is a far worse outcome than not recording one watch.
+	entries, err := Load()
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.ID == entry.ID && e.Season == entry.Season && e.Episode == entry.Episode {
+			entry.Position = e.Position
+			entry.Duration = e.Duration
+			break
+		}
+	}
+	return Save(entry)
+}
+
 // Remove deletes an entry from the history.
 func Remove(id string, season, episode int) error {
 	entries, err := Load()

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -58,8 +58,17 @@ func Load() ([]media.HistoryEntry, error) {
 }
 
 // Save writes or updates an entry in the history file.
-// Uses atomic write (write to temp file, then rename) to prevent corruption.
+// Uses atomic write (write to temp file, then rename) to prevent corruption,
+// under the history write lock so that a concurrent lobster process cannot
+// interleave its own load and rename with this one and drop rows.
 func Save(entry media.HistoryEntry) error {
+	return withHistoryLock(func() error { return saveLocked(entry) })
+}
+
+// saveLocked is Save's body. It must be called with the history write lock
+// held: on its own, load, mutate and rename is not atomic, so two writers can
+// each write back a file that never contained the other's row.
+func saveLocked(entry media.HistoryEntry) error {
 	path, err := config.HistoryPath()
 	if err != nil {
 		return err
@@ -136,25 +145,38 @@ func Save(entry media.HistoryEntry) error {
 // history's own identity for a row — the key Save updates in place — and two
 // copies of that rule would be free to drift apart.
 func SaveKeepingPosition(entry media.HistoryEntry) error {
-	// A read failure here is not recoverable by writing anyway: Save would
-	// then rebuild the file from this single entry and drop the rest of the
-	// history, which is a far worse outcome than not recording one watch.
-	entries, err := Load()
-	if err != nil {
-		return err
-	}
-	for _, e := range entries {
-		if e.ID == entry.ID && e.Season == entry.Season && e.Episode == entry.Episode {
-			entry.Position = e.Position
-			entry.Duration = e.Duration
-			break
+	// The read and the write it feeds are one critical section: a checkpoint
+	// written by another lobster process in between would be overwritten by
+	// the position copied here, which is older than it.
+	return withHistoryLock(func() error {
+		// A read failure here is not recoverable by writing anyway: the save
+		// would then rebuild the file from this single entry and drop the rest
+		// of the history, which is a far worse outcome than not recording one
+		// watch.
+		entries, err := Load()
+		if err != nil {
+			return err
 		}
-	}
-	return Save(entry)
+		for _, e := range entries {
+			if e.ID == entry.ID && e.Season == entry.Season && e.Episode == entry.Episode {
+				entry.Position = e.Position
+				entry.Duration = e.Duration
+				break
+			}
+		}
+		return saveLocked(entry)
+	})
 }
 
-// Remove deletes an entry from the history.
+// Remove deletes an entry from the history, under the same write lock as
+// Save: it is the same load, mutate and rename, and so loses rows to a
+// concurrent writer in the same way if it runs unlocked.
 func Remove(id string, season, episode int) error {
+	return withHistoryLock(func() error { return removeLocked(id, season, episode) })
+}
+
+// removeLocked is Remove's body; it must be called with the write lock held.
+func removeLocked(id string, season, episode int) error {
 	entries, err := Load()
 	if err != nil {
 		return err

--- a/internal/history/keep_position_test.go
+++ b/internal/history/keep_position_test.go
@@ -1,0 +1,105 @@
+package history
+
+import (
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// A player that cannot report a position hands the save path an entry whose
+// Position and Duration are zero by default rather than by measurement.
+// Writing that entry as-is replaces the resume point an earlier, tracked watch
+// recorded, which is exactly the bug: watch ten minutes of a film in VLC and
+// the mpv resume point for it is gone.
+func TestSaveKeepingPositionKeepsTheStoredPosition(t *testing.T) {
+	setDataHome(t, t.TempDir())
+
+	prior := media.HistoryEntry{
+		ID: "movie/keep", Title: "Keep", Type: media.Movie,
+		Position: 2109, Duration: 5400,
+	}
+	if err := Save(prior); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	untracked := prior
+	untracked.Position, untracked.Duration = 0, 0
+	if err := SaveKeepingPosition(untracked); err != nil {
+		t.Fatalf("SaveKeepingPosition: %v", err)
+	}
+
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("history holds %d entries, want 1 updated in place: %+v", len(entries), entries)
+	}
+	if entries[0].Position != 2109 {
+		t.Fatalf("position = %g, want 2109 kept: an untracked watch must not write its default 0 over a real resume point", entries[0].Position)
+	}
+	if entries[0].Duration != 5400 {
+		t.Fatalf("duration = %g, want 5400 kept alongside the position", entries[0].Duration)
+	}
+}
+
+// The other half of the same guarantee: with nothing stored there is no resume
+// point to protect, so the watch itself must still be recorded — otherwise a
+// title only ever watched in VLC would never appear in `lobster history`.
+func TestSaveKeepingPositionRecordsAnUnseenTitle(t *testing.T) {
+	setDataHome(t, t.TempDir())
+
+	entry := media.HistoryEntry{
+		ID: "tv/new", Title: "New", Type: media.TV,
+		Season: 2, Episode: 5,
+	}
+	if err := SaveKeepingPosition(entry); err != nil {
+		t.Fatalf("SaveKeepingPosition: %v", err)
+	}
+
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("history holds %d entries, want the new watch recorded: %+v", len(entries), entries)
+	}
+	if entries[0].ID != "tv/new" || entries[0].Season != 2 || entries[0].Episode != 5 {
+		t.Fatalf("recorded entry = %+v, want tv/new S02E05", entries[0])
+	}
+	if entries[0].Position != 0 {
+		t.Fatalf("position = %g, want 0 for a title with no stored resume point", entries[0].Position)
+	}
+}
+
+// Only the entry for the same (ID, Season, Episode) may donate a position:
+// episode 3's resume point must never leak onto episode 4.
+func TestSaveKeepingPositionMatchesOnEpisode(t *testing.T) {
+	setDataHome(t, t.TempDir())
+
+	other := media.HistoryEntry{
+		ID: "tv/s", Title: "S", Type: media.TV,
+		Season: 1, Episode: 3, Position: 1500, Duration: 2400,
+	}
+	if err := Save(other); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	next := media.HistoryEntry{ID: "tv/s", Title: "S", Type: media.TV, Season: 1, Episode: 4}
+	if err := SaveKeepingPosition(next); err != nil {
+		t.Fatalf("SaveKeepingPosition: %v", err)
+	}
+
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, e := range entries {
+		if e.Season == 1 && e.Episode == 4 && e.Position != 0 {
+			t.Fatalf("S01E04 position = %g, want 0: a different episode's position must not be carried over", e.Position)
+		}
+	}
+	if len(entries) != 2 {
+		t.Fatalf("history holds %d entries, want 2 (E03 kept, E04 added): %+v", len(entries), entries)
+	}
+}

--- a/internal/history/lock.go
+++ b/internal/history/lock.go
@@ -4,9 +4,38 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"lobster/internal/config"
 )
+
+var (
+	logMu sync.RWMutex
+	logf  func(string, ...any)
+)
+
+// SetLogger wires a sink for the one diagnostic this package emits: the notice
+// that a history write ran without the lock. Nil (the default) keeps the
+// package silent, so packages that never wire one are unaffected.
+func SetLogger(fn func(string, ...any)) {
+	logMu.Lock()
+	defer logMu.Unlock()
+	logf = fn
+}
+
+// warnUnlocked reports that locking degraded and the write is going ahead
+// anyway. It exists so the fallback is diagnosable: the failure mode it
+// precedes — a row silently lost to a concurrent lobster — is otherwise
+// invisible from the outside.
+func warnUnlocked(stage string, err error) {
+	logMu.RLock()
+	fn := logf
+	logMu.RUnlock()
+	if fn == nil {
+		return
+	}
+	fn("history lock unavailable (%s: %v); writing unlocked, so a lobster writing at the same moment can drop a row", stage, err)
+}
 
 // withHistoryLock runs fn while holding an exclusive OS-level lock covering
 // every history write.
@@ -24,10 +53,15 @@ import (
 // Readers are deliberately not locked. A write lands by rename, so a reader
 // always sees one complete file, either the old one or the new one.
 //
-// Locking is best effort. If the lock file cannot be created or locked — a
-// filesystem with no lock support, a data dir that is read-only — fn runs
-// unlocked rather than failing: racing writers are better than never recording
-// a watch, and unlocked is exactly what every write did before this existed.
+// Locking is best effort, and the trade-off is real in both directions. When
+// the lock file cannot be created or locked — a filesystem with no working
+// flock, such as some NFS and FUSE mounts — fn runs unlocked, which means the
+// load-modify-rename race this lock exists to close is back and a concurrent
+// writer's row can be lost. Failing the write instead would trade that
+// unlikely lost row for recording no history at all on those filesystems,
+// which is the worse outcome for the user; unlocked is also exactly what every
+// write did before this lock existed, so nothing regresses. The fallback is
+// announced through warnUnlocked rather than taken silently.
 func withHistoryLock(fn func() error) error {
 	path, err := config.HistoryPath()
 	if err != nil {
@@ -39,11 +73,13 @@ func withHistoryLock(fn func() error) error {
 
 	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
+		warnUnlocked("opening lock file", err)
 		return fn()
 	}
 	defer f.Close()
 
 	if err := lockFile(f); err != nil {
+		warnUnlocked("taking lock", err)
 		return fn()
 	}
 	defer unlockFile(f)

--- a/internal/history/lock.go
+++ b/internal/history/lock.go
@@ -1,0 +1,52 @@
+package history
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"lobster/internal/config"
+)
+
+// withHistoryLock runs fn while holding an exclusive OS-level lock covering
+// every history write.
+//
+// The lock lives in a side-car file rather than on the history file itself
+// because each write replaces the history file by rename: a lock held on the
+// old inode says nothing to a process that opens the new one.
+//
+// It is an OS lock rather than a mutex because the writers that actually
+// collide are separate lobster processes — two `lobster play` runs open at
+// once, each doing load, mutate, atomic rename — and a mutex serialises only
+// one process's goroutines. It covers those as well: the lock is held per open
+// file description, so two goroutines in one process block each other too.
+//
+// Readers are deliberately not locked. A write lands by rename, so a reader
+// always sees one complete file, either the old one or the new one.
+//
+// Locking is best effort. If the lock file cannot be created or locked — a
+// filesystem with no lock support, a data dir that is read-only — fn runs
+// unlocked rather than failing: racing writers are better than never recording
+// a watch, and unlocked is exactly what every write did before this existed.
+func withHistoryLock(fn func() error) error {
+	path, err := config.HistoryPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating history dir: %w", err)
+	}
+
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return fn()
+	}
+	defer f.Close()
+
+	if err := lockFile(f); err != nil {
+		return fn()
+	}
+	defer unlockFile(f)
+
+	return fn()
+}

--- a/internal/history/lock_test.go
+++ b/internal/history/lock_test.go
@@ -1,0 +1,110 @@
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/media"
+)
+
+// captureLockWarnings wires SetLogger to a slice for the duration of the test
+// and restores the previous sink afterwards, so one test's logger never leaks
+// into another's.
+func captureLockWarnings(t *testing.T) func() []string {
+	t.Helper()
+
+	var mu sync.Mutex
+	var got []string
+	SetLogger(func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, format)
+	})
+	t.Cleanup(func() { SetLogger(nil) })
+
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), got...)
+	}
+}
+
+// blockLockFile makes the side-car lock path unopenable by occupying it with a
+// directory, which is the closest reproducible stand-in for the filesystems
+// (some NFS, some FUSE) where lock setup genuinely fails.
+func blockLockFile(t *testing.T) {
+	t.Helper()
+
+	path, err := config.HistoryPath()
+	if err != nil {
+		t.Fatalf("HistoryPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("creating data dir: %v", err)
+	}
+	if err := os.Mkdir(path+".lock", 0700); err != nil {
+		t.Fatalf("blocking lock path: %v", err)
+	}
+}
+
+// TestSaveStillRecordsWhenLockSetupFails pins the fail-open half of the
+// trade-off: on a filesystem where the lock cannot be established, a watch is
+// still recorded rather than lost. Failing the write instead would leave such
+// users with no history at all.
+func TestSaveStillRecordsWhenLockSetupFails(t *testing.T) {
+	setDataHome(t, t.TempDir())
+	blockLockFile(t)
+	captureLockWarnings(t)
+
+	if err := Save(media.HistoryEntry{ID: "movie/1", Title: "One", Type: media.Movie}); err != nil {
+		t.Fatalf("Save with lock setup failing: %v, want the write to proceed unlocked", err)
+	}
+
+	entries, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ID != "movie/1" {
+		t.Fatalf("history holds %+v, want the one row written while locking was unavailable", entries)
+	}
+}
+
+// TestSaveAnnouncesAnUnlockedWrite pins the other half: the downgrade is not
+// silent. Without a diagnostic, a user on such a filesystem has no way to tell
+// that their history writes lost the guarantee this lock provides.
+func TestSaveAnnouncesAnUnlockedWrite(t *testing.T) {
+	setDataHome(t, t.TempDir())
+	blockLockFile(t)
+	warnings := captureLockWarnings(t)
+
+	if err := Save(media.HistoryEntry{ID: "movie/1", Title: "One", Type: media.Movie}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got := warnings()
+	if len(got) != 1 {
+		t.Fatalf("got %d lock warnings (%q), want exactly 1: an unlocked history write must be announced, not taken silently", len(got), got)
+	}
+	if !strings.Contains(got[0], "unlocked") {
+		t.Errorf("warning %q does not say the write went ahead unlocked", got[0])
+	}
+}
+
+// TestSaveIsSilentWhenLockingWorks keeps the diagnostic honest: it must fire
+// on the degraded path only, or it stops meaning anything.
+func TestSaveIsSilentWhenLockingWorks(t *testing.T) {
+	setDataHome(t, t.TempDir())
+	warnings := captureLockWarnings(t)
+
+	if err := Save(media.HistoryEntry{ID: "movie/1", Title: "One", Type: media.Movie}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if got := warnings(); len(got) != 0 {
+		t.Fatalf("got lock warnings %q on a working filesystem, want none", got)
+	}
+}

--- a/internal/history/lock_unix.go
+++ b/internal/history/lock_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package history
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// lockFile takes an exclusive flock on f, blocking until it is granted. flock
+// is released by the kernel when the file description closes, including when
+// the process dies, so a lobster killed mid-write leaves no stale lock behind.
+func lockFile(f *os.File) error {
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+		// A signal can interrupt the blocking wait; that is not a failure to
+		// lock, so try again rather than falling back to an unlocked write.
+		if !errors.Is(err, syscall.EINTR) {
+			return err
+		}
+	}
+}
+
+func unlockFile(f *os.File) { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }

--- a/internal/history/lock_windows.go
+++ b/internal/history/lock_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package history
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockFile takes an exclusive byte-range lock on f, blocking until it is
+// granted. Windows drops the lock when the handle closes, including on process
+// exit, so a lobster killed mid-write leaves no stale lock behind.
+func lockFile(f *os.File) error {
+	return windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, new(windows.Overlapped))
+}
+
+func unlockFile(f *os.File) {
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, new(windows.Overlapped))
+}

--- a/internal/player/generic.go
+++ b/internal/player/generic.go
@@ -22,11 +22,13 @@ func (g *Generic) Available() bool {
 	return err == nil
 }
 
-// Play launches the generic player. Position tracking is not supported.
+// Play launches the generic player. Position tracking is not supported, so
+// every result carries a default position rather than a measurement and is
+// marked PositionUnknown and PositionUntracked.
 func (g *Generic) Play(stream *media.Stream, title string, startPos float64, subFiles []string) (PlayResult, error) {
 	stream, cleanup, err := wrapDeobfuscated(stream)
 	if err != nil {
-		return PlayResult{}, err
+		return untrackedPosition(), err
 	}
 	defer cleanup()
 
@@ -50,12 +52,12 @@ func (g *Generic) Play(stream *media.Stream, title string, startPos float64, sub
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 
-	if err := cmd.Run(); err != nil {
+	if err := runPlayerCmd(cmd); err != nil {
 		if _, ok := err.(*exec.ExitError); ok {
-			return PlayResult{}, nil
+			return untrackedPosition(), nil
 		}
-		return PlayResult{}, fmt.Errorf("running %s: %w", g.name, err)
+		return untrackedPosition(), fmt.Errorf("running %s: %w", g.name, err)
 	}
 
-	return PlayResult{}, nil
+	return untrackedPosition(), nil
 }

--- a/internal/player/player.go
+++ b/internal/player/player.go
@@ -5,6 +5,7 @@ package player
 
 import (
 	"fmt"
+	"os/exec"
 	"runtime"
 
 	"lobster/internal/media"
@@ -15,17 +16,26 @@ type PlayResult struct {
 	Position float64 // last playback position in seconds
 	Duration float64 // total media duration in seconds (0 if unknown)
 
-	// PositionUnknown reports that this session tracked the playback position
-	// and never observed one — mpv's IPC socket never came up within the dial
-	// bound, or mpv never reported a time-pos over it. Position is then a
-	// default rather than a measurement, and persisting it would overwrite a
-	// real resume point recorded by an earlier watch of the same title.
+	// PositionUnknown reports that Position is a default rather than a
+	// measurement, so persisting it would overwrite a real resume point
+	// recorded by an earlier watch of the same title.
+	//
+	// It is set when a tracked player was never heard from — mpv's IPC socket
+	// never came up within the dial bound, or mpv never reported a time-pos
+	// over it — and always for players that cannot report a position at all,
+	// which additionally set PositionUntracked.
 	//
 	// It is deliberately false for a session that genuinely sat at position 0,
-	// so the two stay distinguishable, and false for players that do not
-	// report positions at all (vlc, generic): those make no claim either way
-	// and history goes on recording their watches exactly as before.
+	// so "really 0" and "never found out" stay distinguishable.
 	PositionUnknown bool
+
+	// PositionUntracked narrows PositionUnknown: the player has no position
+	// tracking at all (vlc, iina, celluloid), so nothing was lost by not
+	// measuring — as opposed to a tracked player whose tracking failed.
+	// The watch is real and worth recording; only its Position and Duration
+	// are meaningless. Callers keep whatever position history already holds
+	// instead of skipping the entry outright.
+	PositionUntracked bool
 }
 
 // Player is the interface for media player implementations.
@@ -80,3 +90,16 @@ func New(name, audioLang string) Player {
 		return &MPV{audioLang: audioLang} // Default to mpv
 	}
 }
+
+// untrackedPosition is the result of a player that cannot observe a playback
+// position at all. Position and Duration are zero by default, not by
+// measurement, so the save paths record the watch while keeping whatever
+// position history already holds, rather than writing this 0 over it.
+func untrackedPosition() PlayResult {
+	return PlayResult{PositionUnknown: true, PositionUntracked: true}
+}
+
+// runPlayerCmd runs a player process to completion. It is a package var so
+// tests can exercise the players that launch-and-wait (vlc, iina, celluloid)
+// without spawning a real media player.
+var runPlayerCmd = func(cmd *exec.Cmd) error { return cmd.Run() }

--- a/internal/player/position_unknown_test.go
+++ b/internal/player/position_unknown_test.go
@@ -1,0 +1,92 @@
+package player
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"lobster/internal/media"
+)
+
+// stubRunPlayerCmd replaces the process runner so a Play call exercises the
+// full argument-building and return path without ever launching a real media
+// player. It restores the production runner afterwards.
+func stubRunPlayerCmd(t *testing.T, err error) {
+	t.Helper()
+	prev := runPlayerCmd
+	runPlayerCmd = func(*exec.Cmd) error { return err }
+	t.Cleanup(func() { runPlayerCmd = prev })
+}
+
+// exitErr is the *exec.ExitError the players special-case: VLC and the mpv
+// frontends exit non-zero when the user closes the window, which is a normal
+// end of playback rather than a failure. It is built by hand rather than by
+// running a command, so no test here spawns a process; ProcessState is
+// non-nil because the error formats itself through it.
+func exitErr() error {
+	return &exec.ExitError{ProcessState: &os.ProcessState{}}
+}
+
+// checkUntracked asserts the pair of flags a player with no position tracking
+// owes its caller. PositionUnknown says the zero Position is a default rather
+// than a measurement, so it must not reach history; PositionUntracked says
+// why — the player never had tracking — which is what tells the save paths to
+// record the watch while keeping the stored position, instead of skipping it
+// the way a tracked-but-blind session is skipped.
+func checkUntracked(t *testing.T, name string, result PlayResult, when string) {
+	t.Helper()
+	if !result.PositionUnknown {
+		t.Fatalf("%s Play %s returned PositionUnknown = false with Position %g; %s cannot observe a position, so 0 here is a default and must not be persisted",
+			name, when, result.Position, name)
+	}
+	if !result.PositionUntracked {
+		t.Fatalf("%s Play %s returned PositionUntracked = false; without it the save paths skip the entry entirely and a title watched only in %s never reaches history",
+			name, when, name)
+	}
+}
+
+// Neither VLC nor the mpv frontends observe a playback position, so every
+// result they return carries a default 0 rather than a measurement. They must
+// say so: a result with PositionUnknown false claims position 0 was really
+// seen, and the history save paths then write that 0 over the resume point an
+// earlier tracked watch recorded.
+func TestNonTrackingPlayersReportPositionUnknown(t *testing.T) {
+	stream := &media.Stream{URL: "https://example.invalid/stream.m3u8"}
+
+	for _, tc := range []struct {
+		name   string
+		player Player
+	}{
+		{"vlc", &VLC{}},
+		{"iina", &Generic{name: "iina"}},
+		{"celluloid", &Generic{name: "celluloid"}},
+	} {
+		t.Run(tc.name+"/clean exit", func(t *testing.T) {
+			stubRunPlayerCmd(t, nil)
+			result, err := tc.player.Play(stream, "Title", 0, nil)
+			if err != nil {
+				t.Fatalf("Play returned error %v, want nil", err)
+			}
+			checkUntracked(t, tc.name, result, "on a clean exit")
+		})
+
+		t.Run(tc.name+"/user closed the window", func(t *testing.T) {
+			stubRunPlayerCmd(t, exitErr())
+			result, err := tc.player.Play(stream, "Title", 0, nil)
+			if err != nil {
+				t.Fatalf("Play returned error %v, want nil for a non-zero exit", err)
+			}
+			checkUntracked(t, tc.name, result, "after a non-zero exit")
+		})
+
+		t.Run(tc.name+"/launch failed", func(t *testing.T) {
+			stubRunPlayerCmd(t, errors.New("boom"))
+			result, err := tc.player.Play(stream, "Title", 0, nil)
+			if err == nil {
+				t.Fatalf("Play returned nil error for a failed launch")
+			}
+			checkUntracked(t, tc.name, result, "alongside a launch error")
+		})
+	}
+}

--- a/internal/player/vlc.go
+++ b/internal/player/vlc.go
@@ -23,12 +23,13 @@ func (v *VLC) Available() bool {
 	return err == nil
 }
 
-// Play launches VLC. VLC doesn't have IPC position tracking like mpv,
-// so we return zero position/duration.
+// Play launches VLC. VLC has no position tracking here, so every result it
+// returns carries a default position rather than a measurement and is marked
+// PositionUnknown and PositionUntracked.
 func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFiles []string) (PlayResult, error) {
 	stream, cleanup, err := wrapDeobfuscated(stream)
 	if err != nil {
-		return PlayResult{}, err
+		return untrackedPosition(), err
 	}
 	defer cleanup()
 
@@ -54,13 +55,13 @@ func (v *VLC) Play(stream *media.Stream, title string, startPos float64, subFile
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 
-	if err := cmd.Run(); err != nil {
+	if err := runPlayerCmd(cmd); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			_ = exitErr // VLC exits non-zero on user close
-			return PlayResult{}, nil
+			return untrackedPosition(), nil
 		}
-		return PlayResult{}, fmt.Errorf("running vlc: %w", err)
+		return untrackedPosition(), fmt.Errorf("running vlc: %w", err)
 	}
 
-	return PlayResult{}, nil
+	return untrackedPosition(), nil
 }

--- a/internal/playlist/session.go
+++ b/internal/playlist/session.go
@@ -24,6 +24,11 @@ type Session struct {
 	// LastPosition is a default rather than a measurement and must not be
 	// persisted over the episode's existing resume point.
 	LastPositionUnknown bool
+	// LastPositionUntracked carries player.PlayResult.PositionUntracked from
+	// the most recent play: the player has no position tracking at all, so the
+	// watch is real but LastPosition is meaningless. The episode is recorded,
+	// keeping whatever position history already holds for it.
+	LastPositionUntracked bool
 }
 
 // New creates a Session positioned at the given season and episode.


### PR DESCRIPTION
## What

Two related history-integrity fixes.

**1. An untracked player no longer destroys a resume point.**

VLC, IINA, celluloid and the generic player cannot report a playback position.
They returned a bare `PlayResult`, so `Position: 0` looked like a measurement,
and every watch wrote 0 over whatever an earlier tracked watch had saved. A
film watched in VLC lost its resume point.

`PlayResult` gains `PositionUntracked`, which narrows the `PositionUnknown`
added in #52. The two states are now distinct and handled differently:

- *Untracked player* → record the watch, but keep any stored position: the new
  `history.SaveKeepingPosition` carries the existing `Position`/`Duration` for
  the same `(ID, Season, Episode)` into the entry, and appends at 0 only when
  the title is new. So `lobster history` still lists what you watched, and a
  real resume point is never overwritten by a default.
- *Tracked player that never observed a position* (mpv, IPC never came up) →
  still writes nothing, exactly as #52 established.
- *Genuinely at position 0* → still distinct from both. Nothing tests
  `Position > 0`; that conflation is the bug #52 fixed.

`SaveKeepingPosition` lives in `internal/history` because `(ID, Season,
Episode)` is history's own row identity — the key `Save` already updates in
place — so a second copy in `cmd` would be free to drift.

**2. Concurrent history writes lose whole rows.**

A local review flagged a read-modify-write window in `SaveKeepingPosition`. The
specific interleaving it described — a checkpoint landing between the load and
the save *within one process* — is **not reachable**: `SaveKeepingPosition` is
selected only for untracked players, `MPV` is the only `Checkpointer` and never
sets that flag, and a checkpoint cannot overlap the exit-time save anyway
(`MPV.Play` blocks on `<-ipcDone`, and `trackPlayback` closes and drains its
checkpoint channel before returning).

The reachable race is *between processes*, and it is worse than the reported
symptom. `Save` does load → mutate → atomic rename; the rename is atomic but
the read-modify-write is not, so two `lobster play` runs writing the same file
lose entire rows. A test racing eight processes over one history file lost 4–6
of 8 rows on every run. This pre-existed `SaveKeepingPosition` — plain `Save`
and `Remove` have the same shape. Two overlapping supervised runs were observed
on a real machine, so this is not theoretical.

Fixed with an exclusive OS lock (`flock` on unix, `LockFileEx` on Windows) held
across the whole read-modify-write, shared by `Save`, `SaveKeepingPosition` and
`Remove`. The lock is a side-car `history.tsv.lock`: each write replaces
`history.tsv` by rename, so a lock on that inode would be meaningless to the
next writer.

A package mutex — the shape the review suggested — was **rejected**: it
serialises one process's goroutines and cannot touch a cross-process race, so it
would have made the file look protected while every row loss continued. The
structural half of the suggestion was adopted: the three writers now share one
critical section.

## Verified

- Reds witnessed on assertions before each fix, including
  `position = 0, want 2109 kept: an untracked watch must not write its default 0
  over a real resume point`, `no history entry for movie/w: an untracked watch
  must still be recorded`, and `history holds 3 rows, want 8: Save's
  load-mutate-rename is not atomic across processes`.
- Mutation-verified throughout: dropping the preservation, preserving without
  matching the key, never writing, and using plain `Save` for untracked watches
  each turn the corresponding test red. Removing the tracked-but-blind skip reds
  the two #52 tests — so mpv's behaviour is pinned by mutation, not by reading.
- The concurrency test spawns eight real child processes rather than goroutines,
  deliberately: a goroutine version would have been satisfied by the mutex that
  does not fix this, and its name would have overclaimed.
- Gate: build/vet/test with `CGO_ENABLED=0`, `GOOS=windows` build + vet,
  `GOOS=darwin` build, `CGO_ENABLED=1 go test ./internal/history/
  ./internal/player/ ./cmd/ -race -count=2`. The `cmd` and `internal/history`
  test binaries also pass with an empty `PATH`, so no test depends on a locally
  installed mpv or vlc — which CI does not have.

## Not verified / notes

- The Windows `LockFileEx` path compiles and vets but is not executed here; it
  runs on CI's windows job.
- `golang.org/x/sys` moves from indirect to direct in `go.mod` (same version,
  no `go.sum` change) for that path.
- Locking is best effort: if the lock cannot be taken, the write proceeds
  unlocked rather than dropping the watch. Strictly no worse than before, but
  not an absolute guarantee on exotic filesystems.
- `history.tsv.lock` is a new file in the user's data directory.
- VLC position tracking is deliberately **not** included. It is achievable only
  over an unauthenticated localhost TCP port (the snap's `--extraintf rc`
  resolves to the Lua CLI module and ignores `--rc-unix`), which any local
  process could use to observe or control playback. That trade-off is the
  owner's call, and the answer was no.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playback history now correctly handles players that cannot report positions, preserving existing resume points while recording new watches.
  * Sessions that never report a position no longer create inaccurate history entries.
  * History updates are more reliable when multiple playback processes save simultaneously.
  * History remains recordable when file locking is unavailable, with a diagnostic warning.
* **Tests**
  * Added coverage for position preservation, untracked playback, concurrent history updates, and locking failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->