### PR TITLE
fix(subtitle): stage subtitles where sandboxed players can read them

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -503,7 +503,7 @@ func playStream(stream *media.Stream, title string, selected media.SearchResult,
 			if err == nil {
 				defer tmpDir.Cleanup()
 				for _, sub := range subs {
-					f, err := resolveAndDownloadSub(tmpDir, sub, season, episode)
+					f, err := subtitleDownload(tmpDir, sub, season, episode)
 					if err != nil {
 						debugf("subtitle download failed (%s): %v", sub.Label, err)
 						continue

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -273,9 +273,10 @@ func playCurrentEpisode(sess *playlist.Session) error {
 			return err
 		}
 
-		subFiles := resolveSubtitles(stream, sess.Content.Title, sess.CurrentSeason().Number, sess.Current().Number)
+		subFiles, cleanupSubs := resolveSubtitles(stream, sess.Content.Title, sess.CurrentSeason().Number, sess.Current().Number)
 
 		result, playErr := p.Play(stream, title, startPos, subFiles)
+		cleanupSubs()
 		if playErr == nil {
 			sess.LastPosition = result.Position
 			sess.LastDuration = result.Duration
@@ -302,11 +303,18 @@ func playCurrentEpisode(sess *playlist.Session) error {
 	}
 }
 
+// subtitleDownload is a seam so tests can exercise the staging-directory
+// lifecycle without reaching the network.
+var subtitleDownload = resolveAndDownloadSub
+
 // resolveSubtitles downloads multiple subtitle files.
 // User can cycle tracks with 'j' in mpv.
-func resolveSubtitles(stream *media.Stream, title string, season, episode int) []string {
+// The returned cleanup is never nil and must be called once the player has
+// exited: subtitles are staged under $HOME, which nothing else reclaims.
+func resolveSubtitles(stream *media.Stream, title string, season, episode int) ([]string, func()) {
+	noCleanup := func() {}
 	if flagNoSubs {
-		return nil
+		return nil, noCleanup
 	}
 
 	subs := subtitle.FilterByEpisode(
@@ -317,7 +325,7 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 		season, episode,
 	)
 	if len(subs) == 0 {
-		return nil
+		return nil, noCleanup
 	}
 	// Limit to 3 subtitle downloads to avoid stream URL expiry.
 	if len(subs) > 3 {
@@ -326,13 +334,12 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 
 	tmpDir, err := subtitle.NewTempDir()
 	if err != nil {
-		return nil
+		return nil, noCleanup
 	}
-	// Note: tmpDir cleanup happens when process exits; acceptable for a session
 
 	var subFiles []string
 	for _, sub := range subs {
-		f, err := resolveAndDownloadSub(tmpDir, sub, season, episode)
+		f, err := subtitleDownload(tmpDir, sub, season, episode)
 		if err != nil {
 			debugf("subtitle download failed (%s): %v", sub.Label, err)
 			continue
@@ -340,12 +347,13 @@ func resolveSubtitles(stream *media.Stream, title string, season, episode int) [
 		debugf("subtitle file: %s (%s)", f, sub.Label)
 		subFiles = append(subFiles, f)
 	}
-	return subFiles
+	return subFiles, tmpDir.Cleanup
 }
 
 // downloadEpisode handles the download path.
 func downloadEpisode(stream *media.Stream, sess *playlist.Session, title string) error {
-	subFiles := resolveSubtitles(stream, sess.Content.Title, sess.CurrentSeason().Number, sess.Current().Number)
+	subFiles, cleanupSubs := resolveSubtitles(stream, sess.Content.Title, sess.CurrentSeason().Number, sess.Current().Number)
+	defer cleanupSubs()
 	dlSub := ""
 	if len(subFiles) > 0 {
 		dlSub = subFiles[0]

--- a/cmd/subtitle_staging_test.go
+++ b/cmd/subtitle_staging_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"lobster/internal/config"
+	"lobster/internal/media"
+	"lobster/internal/subtitle"
+)
+
+// Subtitles are no longer staged in /tmp, which the system reclaims on its own;
+// they live under $HOME now, so whoever asks for them must be handed a cleanup
+// and must call it — otherwise every episode of a session leaves a directory
+// behind in the user's home.
+func TestResolveSubtitlesCleanupRemovesStagingDir(t *testing.T) {
+	prevCfg, prevNoSubs := cfg, flagNoSubs
+	t.Cleanup(func() { cfg, flagNoSubs = prevCfg, prevNoSubs })
+	cfg = &config.Config{SubsLanguage: "english"}
+	flagNoSubs = false
+
+	// Keep staging out of the real home directory.
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, "Videos"), 0o755); err != nil {
+		t.Fatalf("creating fake Videos dir: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// No network: the stub writes the file the real downloader would have
+	// fetched, into the staging directory the caller created.
+	prevDownload := subtitleDownload
+	t.Cleanup(func() { subtitleDownload = prevDownload })
+	var stagingDir string
+	subtitleDownload = func(td *subtitle.TempDir, sub media.Subtitle, season, episode int) (string, error) {
+		stagingDir = td.Path()
+		path := filepath.Join(stagingDir, "stub.srt")
+		if err := os.WriteFile(path, []byte("1\n"), 0o644); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+
+	stream := &media.Stream{
+		URL:       "https://example.invalid/stream.m3u8",
+		Subtitles: []media.Subtitle{{URL: "https://example.invalid/a.srt", Label: "English", Language: "english"}},
+	}
+
+	subFiles, cleanup := resolveSubtitles(stream, "Some Film", 0, 0)
+	if cleanup == nil {
+		t.Fatal("resolveSubtitles returned a nil cleanup; the staging dir would leak")
+	}
+	if len(subFiles) != 1 {
+		t.Fatalf("subFiles = %v, want one staged subtitle", subFiles)
+	}
+	if _, err := os.Stat(subFiles[0]); err != nil {
+		t.Fatalf("staged subtitle %q missing: %v", subFiles[0], err)
+	}
+
+	cleanup()
+
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Errorf("staging dir %q survived cleanup (stat err %v)", stagingDir, err)
+	}
+}
+
+// With subtitles switched off there is nothing to clean, but the caller still
+// calls what it is handed.
+func TestResolveSubtitlesCleanupNeverNilWhenDisabled(t *testing.T) {
+	prevNoSubs := flagNoSubs
+	t.Cleanup(func() { flagNoSubs = prevNoSubs })
+	flagNoSubs = true
+
+	subFiles, cleanup := resolveSubtitles(&media.Stream{}, "Some Film", 0, 0)
+	if subFiles != nil {
+		t.Errorf("subFiles = %v, want nil with --no-subs", subFiles)
+	}
+	if cleanup == nil {
+		t.Fatal("resolveSubtitles returned a nil cleanup with --no-subs; callers would panic")
+	}
+	cleanup()
+}

--- a/internal/subtitle/staging.go
+++ b/internal/subtitle/staging.go
@@ -33,20 +33,74 @@ const staleAfter = 24 * time.Hour
 // So the base has to be a non-hidden directory under $HOME. A media directory
 // is the least surprising home for subtitle files; the last resort is a plain
 // "lobster" directory, created only when no media directory exists.
+//
+// Being under $HOME lexically is not enough — see withinHome.
 func stagingBases() []string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
+		return nil
+	}
+	resolvedHome, ok := resolveHome()
+	if !ok {
 		return nil
 	}
 
 	var existing []string
 	for _, name := range []string{"Videos", "Movies", "Downloads"} {
 		dir := filepath.Join(home, name)
-		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
-			existing = append(existing, dir)
+		fi, err := os.Stat(dir)
+		if err != nil || !fi.IsDir() {
+			continue
 		}
+		if !withinHome(resolvedHome, dir) {
+			continue
+		}
+		existing = append(existing, dir)
 	}
+	// The last resort needs no check here: newStagingDir creates it directly
+	// under $HOME and verifies the directory it actually reached.
 	return append(existing, filepath.Join(home, "lobster"))
+}
+
+// resolveHome returns $HOME with symlinks resolved, and false when there is no
+// usable home directory.
+func resolveHome() (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		return "", false
+	}
+	return resolved, true
+}
+
+// withinHome reports whether path, once every symlink in it is resolved, is
+// still inside resolvedHome.
+//
+// A media directory symlinked to another drive is a common arrangement, and
+// os.Stat and os.MkdirAll both follow symlinks without complaint — so
+// "$HOME/Videos/.lobster/subs-x" can name a file on /mnt. snapd's home
+// interface is enforced by AppArmor, which decides on the resolved path, so
+// such a directory is denied to a confined player exactly as /tmp is: staging
+// there would look like a fix and silently be none. A path that cannot be
+// resolved is treated as outside, since the point is to hand out only paths
+// known to be reachable.
+//
+// This rejects escapes, not symlinks. One that resolves back inside $HOME is
+// perfectly readable, and refusing it would push those users onto the
+// broken-for-snaps temp-dir fallback for no reason.
+func withinHome(resolvedHome, path string) bool {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedHome, resolved)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 // newStagingDir creates a fresh staging directory a confined player can read,
@@ -54,9 +108,16 @@ func stagingBases() []string {
 // with no writable home, say) — an unreadable subtitle is better than no
 // playback at all.
 func newStagingDir() (string, error) {
+	resolvedHome, homeOK := resolveHome()
 	for _, base := range stagingBases() {
 		parent := filepath.Join(base, stagingParent)
 		if err := os.MkdirAll(parent, 0o700); err != nil {
+			continue
+		}
+		// The base passed stagingBases, but stagingParent itself can be a
+		// symlink out of $HOME, and the last-resort base was never checked.
+		// Verify the path actually reached, not the one asked for.
+		if !homeOK || !withinHome(resolvedHome, parent) {
 			continue
 		}
 		pruneStale(parent)

--- a/internal/subtitle/staging.go
+++ b/internal/subtitle/staging.go
@@ -1,0 +1,105 @@
+package subtitle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// stagingParent is the directory created inside the chosen base directory. It
+// is dot-prefixed so it stays out of the user's way in a file manager; that is
+// safe because snapd's home interface only hides paths whose *first* component
+// below $HOME is dot-prefixed, not nested ones.
+const stagingParent = ".lobster"
+
+// staleAfter is how long an abandoned staging directory is kept before a later
+// run sweeps it. A hard kill skips Cleanup, and unlike /tmp a directory under
+// $HOME is never reclaimed by the system.
+const staleAfter = 24 * time.Hour
+
+// stagingBases returns candidate base directories for subtitle staging, most
+// preferred first.
+//
+// Players packaged as snaps (the VLC snap on this machine, VLC 3.0.20) run with
+// a private /tmp, so a file the host wrote to os.TempDir() does not exist as far
+// as the player is concerned. Their view of the user's files comes from snapd's
+// home interface, which exposes $HOME but denies any path whose first component
+// below $HOME is dot-prefixed. Both halves were verified empirically against
+// this VLC snap: a subtitle in /tmp fails to open with "No such file or
+// directory", one under ~/.cache with "Permission denied", and one under
+// ~/Videos/.lobster/ loads.
+//
+// So the base has to be a non-hidden directory under $HOME. A media directory
+// is the least surprising home for subtitle files; the last resort is a plain
+// "lobster" directory, created only when no media directory exists.
+func stagingBases() []string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return nil
+	}
+
+	var existing []string
+	for _, name := range []string{"Videos", "Movies", "Downloads"} {
+		dir := filepath.Join(home, name)
+		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
+			existing = append(existing, dir)
+		}
+	}
+	return append(existing, filepath.Join(home, "lobster"))
+}
+
+// newStagingDir creates a fresh staging directory a confined player can read,
+// falling back to os.MkdirTemp when nothing under $HOME is usable (a container
+// with no writable home, say) — an unreadable subtitle is better than no
+// playback at all.
+func newStagingDir() (string, error) {
+	for _, base := range stagingBases() {
+		parent := filepath.Join(base, stagingParent)
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			continue
+		}
+		pruneStale(parent)
+		dir, err := os.MkdirTemp(parent, "subs-*")
+		if err != nil {
+			continue
+		}
+		return dir, nil
+	}
+	return os.MkdirTemp("", "lobster-subs-*")
+}
+
+// pruneStale removes staging directories left behind by runs that were killed
+// before they could clean up. Best effort: anything still in use by a
+// concurrent run is younger than staleAfter and is left alone.
+func pruneStale(parent string) {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-staleAfter)
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "subs-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(parent, e.Name()))
+	}
+}
+
+// removeStagingDir deletes a staging directory and, if that leaves the shared
+// parent empty, the parent too. os.Remove refuses a non-empty directory, so a
+// concurrent run's staging directory is never disturbed.
+func removeStagingDir(dir string) {
+	if dir == "" {
+		return
+	}
+	_ = os.RemoveAll(dir)
+	parent := filepath.Dir(dir)
+	if filepath.Base(parent) == stagingParent {
+		_ = os.Remove(parent)
+	}
+}

--- a/internal/subtitle/staging.go
+++ b/internal/subtitle/staging.go
@@ -70,8 +70,20 @@ func newStagingDir() (string, error) {
 }
 
 // pruneStale removes staging directories left behind by runs that were killed
-// before they could clean up. Best effort: anything still in use by a
-// concurrent run is younger than staleAfter and is left alone.
+// before they could clean up.
+//
+// A staging directory's mtime is set when its subtitle files are written, at
+// the start of playback, and reading those files afterwards never advances it.
+// So a session that runs longer than staleAfter can have its own live staging
+// directory swept by a second lobster process starting in the meantime. That
+// window is left open deliberately rather than guarded with a lock: staged
+// files are handed to the player only as launch arguments, and nothing reopens
+// one mid-playback. mpv is given every track at launch and then holds no
+// descriptor on the files at all — selecting a track whose file has since been
+// deleted still renders it, because the file was read in full at load time —
+// and VLC is given a single file at launch. Losing the directory under a
+// running player is therefore not observable; the process's own Cleanup on a
+// pruned directory is a no-op.
 func pruneStale(parent string) {
 	entries, err := os.ReadDir(parent)
 	if err != nil {

--- a/internal/subtitle/staging_test.go
+++ b/internal/subtitle/staging_test.go
@@ -143,3 +143,100 @@ func TestNewTempDirPrunesStaleSiblings(t *testing.T) {
 		t.Errorf("fresh staging dir %q was pruned: %v", second.Path(), err)
 	}
 }
+
+// resolvedRel relativises path against home with every symlink resolved, which
+// is what AppArmor does before applying snapd's home rule. A lexical check
+// passes happily on a path that resolves onto another filesystem.
+func resolvedRel(t *testing.T, home, path string) string {
+	t.Helper()
+	resolvedHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatalf("resolving home %q: %v", home, err)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolving %q: %v", path, err)
+	}
+	rel, err := filepath.Rel(resolvedHome, resolved)
+	if err != nil {
+		t.Fatalf("relativising %q against %q: %v", resolved, resolvedHome, err)
+	}
+	return rel
+}
+
+// A media directory symlinked to another drive is a common arrangement, and
+// os.Stat and os.MkdirAll both follow symlinks without complaint. Such a base
+// must be rejected: snapd's home rule is enforced on the resolved path, so a
+// staging directory that lands on /mnt is denied to the VLC snap exactly as
+// /tmp is, and staging there would look like a fix while silently being none.
+func TestNewTempDirRejectsABaseSymlinkedOutsideHome(t *testing.T) {
+	home := fakeHome(t)
+	outside := t.TempDir()
+	videos := filepath.Join(home, "Videos")
+	if err := os.Remove(videos); err != nil {
+		t.Fatalf("clearing Videos: %v", err)
+	}
+	if err := os.Symlink(outside, videos); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	t.Cleanup(td.Cleanup)
+
+	if rel := resolvedRel(t, home, td.Path()); strings.HasPrefix(rel, "..") {
+		t.Errorf("staging dir %q resolves outside the home directory (rel %q); a symlinked media directory is followed by os.MkdirAll but denied by snapd", td.Path(), rel)
+	}
+	if _, err := os.Stat(filepath.Join(outside, stagingParent)); err == nil {
+		t.Errorf("%s was created on the far side of the symlink before the base was rejected", stagingParent)
+	}
+}
+
+// The shared parent can be the symlink even when the base is sound.
+func TestNewTempDirRejectsAParentSymlinkedOutsideHome(t *testing.T) {
+	home := fakeHome(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(home, "Videos", stagingParent)); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	t.Cleanup(td.Cleanup)
+
+	if rel := resolvedRel(t, home, td.Path()); strings.HasPrefix(rel, "..") {
+		t.Errorf("staging dir %q resolves outside the home directory (rel %q)", td.Path(), rel)
+	}
+}
+
+// Rejecting escapes must not reject a symlink that stays inside $HOME — those
+// are readable, and over-rejecting would push users onto the broken-for-snaps
+// temp-dir fallback for no reason.
+func TestNewTempDirAcceptsASymlinkThatStaysInsideHome(t *testing.T) {
+	home := fakeHome(t)
+	real := filepath.Join(home, "media")
+	if err := os.Mkdir(real, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", real, err)
+	}
+	videos := filepath.Join(home, "Videos")
+	if err := os.Remove(videos); err != nil {
+		t.Fatalf("clearing Videos: %v", err)
+	}
+	if err := os.Symlink(real, videos); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	t.Cleanup(td.Cleanup)
+
+	if rel := resolvedRel(t, home, td.Path()); !strings.HasPrefix(rel, "media"+string(filepath.Separator)) {
+		t.Errorf("staging dir %q resolved to rel %q; the symlinked base inside $HOME should have been used, not skipped", td.Path(), rel)
+	}
+}

--- a/internal/subtitle/staging_test.go
+++ b/internal/subtitle/staging_test.go
@@ -1,0 +1,145 @@
+package subtitle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeHome points os.UserHomeDir at a throwaway directory containing the
+// standard Videos folder, so the staging-location tests never touch the real
+// home directory.
+func fakeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.Mkdir(filepath.Join(home, "Videos"), 0o755); err != nil {
+		t.Fatalf("creating fake Videos dir: %v", err)
+	}
+	t.Setenv("HOME", home)        // unix
+	t.Setenv("USERPROFILE", home) // windows
+	return home
+}
+
+// Snap-confined players (the VLC snap, for one) get a private /tmp and cannot
+// see anything the host wrote there, so a staging directory under os.TempDir()
+// makes every downloaded subtitle silently unloadable.
+func TestNewTempDirIsNotUnderTempDir(t *testing.T) {
+	home := fakeHome(t)
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	t.Cleanup(td.Cleanup)
+
+	// The fake home is itself under t.TempDir(), so "under os.TempDir()" cannot
+	// be the assertion here; what must not happen is the staging dir being
+	// created *directly in* the system temp dir, which is what os.MkdirTemp("")
+	// does and what a confined player cannot see.
+	if got := filepath.Dir(td.Path()); got == os.TempDir() {
+		t.Errorf("staging dir %q was created directly in the system temp dir; a snap-confined player has its own private /tmp and cannot read it", td.Path())
+	}
+	if rel, err := filepath.Rel(home, td.Path()); err != nil || strings.HasPrefix(rel, "..") {
+		t.Errorf("staging dir %q is not under the home directory %q", td.Path(), home)
+	}
+}
+
+// snapd's home interface exposes files under $HOME to a confined snap, but it
+// excludes any path whose first component below $HOME is dot-prefixed. Verified
+// empirically against the VLC snap: ~/.cache/... reads back "Permission
+// denied", ~/Videos/.lobster/... loads fine.
+func TestNewTempDirTopLevelHomeComponentIsNotHidden(t *testing.T) {
+	home := fakeHome(t)
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	t.Cleanup(td.Cleanup)
+
+	rel, err := filepath.Rel(home, td.Path())
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Fatalf("staging dir %q is not under home %q", td.Path(), home)
+	}
+	first := strings.Split(filepath.ToSlash(rel), "/")[0]
+	if strings.HasPrefix(first, ".") {
+		t.Errorf("staging dir %q sits under hidden top-level home directory %q; snapd's home interface hides those from confined players", td.Path(), first)
+	}
+}
+
+func TestCleanupRemovesStagingDirAndEmptyParent(t *testing.T) {
+	fakeHome(t)
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	path := td.Path()
+	if err := os.WriteFile(filepath.Join(path, "a.srt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("writing subtitle: %v", err)
+	}
+
+	td.Cleanup()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("staging dir %q still exists after Cleanup (stat err %v)", path, err)
+	}
+	parent := filepath.Dir(path)
+	if _, err := os.Stat(parent); !os.IsNotExist(err) {
+		t.Errorf("empty parent %q still exists after Cleanup (stat err %v)", parent, err)
+	}
+}
+
+// Home is not always usable (some containers have no writable $HOME). Playback
+// must not fail over that — fall back to the old temp-dir behaviour.
+func TestNewTempDirFallsBackWhenHomeUnusable(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("writing blocker: %v", err)
+	}
+	t.Setenv("HOME", blocker)
+	t.Setenv("USERPROFILE", blocker)
+
+	td, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir must not fail when home is unusable: %v", err)
+	}
+	t.Cleanup(td.Cleanup)
+	if fi, err := os.Stat(td.Path()); err != nil || !fi.IsDir() {
+		t.Errorf("fallback staging dir %q unusable: err %v", td.Path(), err)
+	}
+}
+
+// A hard kill skips Cleanup. /tmp self-cleans on reboot; a directory under
+// $HOME does not, so stale staging dirs must be swept on the next run.
+func TestNewTempDirPrunesStaleSiblings(t *testing.T) {
+	fakeHome(t)
+
+	first, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	stale := first.Path()
+	if err := os.WriteFile(filepath.Join(stale, "old.srt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("writing subtitle: %v", err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("backdating staging dir: %v", err)
+	}
+
+	second, err := NewTempDir()
+	if err != nil {
+		t.Fatalf("NewTempDir: %v", err)
+	}
+	t.Cleanup(second.Cleanup)
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale staging dir %q survived a later NewTempDir (stat err %v)", stale, err)
+	}
+	if _, err := os.Stat(second.Path()); err != nil {
+		t.Errorf("fresh staging dir %q was pruned: %v", second.Path(), err)
+	}
+}

--- a/internal/subtitle/subtitle.go
+++ b/internal/subtitle/subtitle.go
@@ -1,5 +1,6 @@
-// Package subtitle handles subtitle filtering and secure temp file management.
-// Uses os.MkdirTemp with random suffixes instead of predictable /tmp/lobster/ paths.
+// Package subtitle handles subtitle filtering and staging-directory management.
+// Staging directories carry a random suffix rather than a predictable name, and
+// live where a sandboxed player can read them (see staging.go).
 package subtitle
 
 import (
@@ -105,25 +106,29 @@ func BestMatch(subtitles []media.Subtitle, language string) *media.Subtitle {
 	return &filtered[0]
 }
 
-// TempDir manages a secure temporary directory for subtitle files.
+// TempDir manages the throwaway directory downloaded subtitles are staged in.
 type TempDir struct {
 	path string
 }
 
-// NewTempDir creates a randomized temporary directory for subtitle files.
+// NewTempDir creates a randomized staging directory for subtitle files in a
+// location sandboxed players can actually read.
 func NewTempDir() (*TempDir, error) {
-	dir, err := os.MkdirTemp("", "lobster-subs-*")
+	dir, err := newStagingDir()
 	if err != nil {
-		return nil, fmt.Errorf("creating subtitle temp dir: %w", err)
+		return nil, fmt.Errorf("creating subtitle staging dir: %w", err)
 	}
 	return &TempDir{path: dir}, nil
 }
 
-// Cleanup removes the temporary directory and all contents.
+// Path returns the directory subtitle files are written into.
+func (t *TempDir) Path() string { return t.path }
+
+// Cleanup removes the staging directory and all contents. It must be called:
+// unlike /tmp, the staging directory lives under $HOME and nothing else
+// reclaims it.
 func (t *TempDir) Cleanup() {
-	if t.path != "" {
-		os.RemoveAll(t.path)
-	}
+	removeStagingDir(t.path)
 }
 
 // Download fetches a subtitle file to the temp directory and returns the local path.


### PR DESCRIPTION
## What

Downloaded subtitles are staged where a sandboxed player can actually read
them, instead of in `/tmp`.

## The bug

`internal/subtitle` staged subtitles in `os.MkdirTemp("")` — `/tmp` — and
handed that path to the player as `--sub-file`. A snap-packaged player gets a
**private /tmp** and cannot see anything the host wrote there, so every
downloaded subtitle silently failed to load. Nothing errored; the subtitles
just never appeared.

## What was measured, not assumed

Confinement matrix via `snap run --shell vlc` (VLC snap 3.0.20, rev 3777):

- inside the sandbox `/tmp` is an empty private mount, and `$HOME` is remapped
  to `~/snap/vlc/3777`;
- by absolute host path, `~/.cache/...` and `~/.local/share/...` are both
  **Permission denied** — so the obvious "put it in the cache dir" fix would
  have been just as broken;
- only the FIRST path component under `$HOME` matters: a visible top-level
  directory is readable, and dot-directories nested inside one are fine.

Confirmed end to end with headless VLC (`-I dummy --aout dummy --no-video
--play-and-exit`) against a locally generated black/silent clip:

| staged at | result |
|---|---|
| `/tmp/.../old-location.srt` | `cannot open file … (No such file or directory)` |
| `~/.cache/.../probe.txt` | `cannot open file … (Permission denied)` |
| `~/Videos/.lobster/subs-*/final.srt` | `detected SubRIP format` / `loading all subtitles` |

## How

Staging base is the first existing of `~/Videos`, `~/Movies`, `~/Downloads`,
else `~/lobster`; the directory is `<base>/.lobster/subs-XXXXXX`. If no home
is usable it falls back to `os.MkdirTemp("")`, i.e. today's behaviour.

`Cleanup` removes the staging directory and its `.lobster` parent once that
empties (`os.Remove` refuses a non-empty directory, so concurrent runs are
safe), and each run sweeps sibling `subs-*` directories older than 24h left
behind by a hard kill.

`cmd/session.go`'s `resolveSubtitles` now returns a never-nil cleanup and both
callers run it. It previously discarded cleanup deliberately, leaking a staging
directory per episode *and* per source retry — harmless while the files were in
`/tmp`, not harmless once they live under `$HOME`.

mpv is unaffected: it simply receives a different `--sub-file` path.

## A review finding, verified and rejected

A local review argued the 24h sweep could delete a staging directory still in
use, since a directory's mtime does not advance while a player reads from it,
and that a later subtitle-track switch would then fail.

The mechanism is real and is now stated correctly in the code — the previous
comment claimed "anything still in use by a concurrent run is younger than
staleAfter", which is provably false and is corrected in `ba722c4`.

The asserted consequence is **not** real, established by demonstration rather
than argument. mpv reads external subtitle files in full at load and holds no
descriptor on them: inspection of a live mpv showed 0 of 71 open fds
referencing its staged `.srt` files while all three tracks were registered. A
headless mpv with two `--sub-file` tracks then had both files deleted, and
switching `sid=1 → 2 → 1` still produced the correct subtitle text. VLC is
handed only `subFiles[0]` at launch and lobster never adds a track
mid-playback.

So the window requires a single playback session over 24h plus a second lobster
run starting during it, and is harmless on both supported players when it
occurs. A lock file (plus a Windows `LockFileEx` path, a new file in every
staging dir, and stale-lock recovery) was rejected as disproportionate to a
window with no observable effect, as was encoding the owning PID in the
directory name. The proportionate fix for "the code is fine but the comment
lies" is to fix the comment.

## Verified

- Reds witnessed on assertions before the fix, including `staging dir
  "/tmp/lobster-subs-…" is under the system temp dir "/tmp"; a snap-confined
  player has its own private /tmp and cannot read it` and `stale staging dir …
  survived a later NewTempDir`.
- Mutation-verified: emptying the base list, making `.lobster` a hidden
  top-level directory, dropping the stale sweep, not removing the empty parent,
  and making removal a no-op each turn the corresponding tests red — the
  hidden-top-level mutation fails with snapd's actual permission message.
- Gate: build/vet/test with `CGO_ENABLED=0`, `GOOS=windows` build + vet,
  `GOOS=darwin` build, `CGO_ENABLED=1 -race -count=2` on `./internal/player/
  ./cmd/`. The `cmd` test binary also passes with an empty `PATH`, so no test
  depends on a locally installed mpv or vlc — which CI does not have.

## Not verified / notes

- Windows and macOS take the same code path (`%USERPROFILE%\Videos`,
  `~/Movies`). Harmless there, but it is a behaviour change on platforms that
  never had the snap problem.
- `internal/player/generic.go` hands `--sub-file` to a user-configured player.
  If someone configures a player that opens subtitle files lazily rather than
  preloading, the prune window above could bite it. The new comment scopes its
  claims to mpv and VLC and asserts nothing about generic players.
- Two other `/tmp` handoffs to external programs are **not** fixed here and are
  latent versions of this same bug: `internal/player/ipc_unix.go` puts mpv's IPC
  socket in `/tmp` (fine for a distro mpv, would silently kill position tracking
  under a snap or flatpak mpv), and `internal/poster/poster.go` writes posters
  to `/tmp/lobster-posters` for the terminal image renderer.
  `internal/torrentstream` uses `/tmp` but hands the player a loopback URL, so
  it is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary subtitle files are now removed automatically after playback or downloads.
  * Subtitle cleanup remains reliable even when subtitles are disabled.
  * Improved subtitle access for confined environments, including Snap-based players.
  * Stale temporary subtitle data is cleaned up automatically, reducing leftover files.
  * Subtitle handling now falls back safely when a suitable home-directory location is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->