### PR TITLE
fix(cmd): resume from history on every playback path, not just play

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -299,7 +299,7 @@ tbcpl_include_untrusted = false
 ## All Flags
 
 ```
--c, --continue              Resume from watch history
+-c, --continue[=false]      Resume from watch history (on by default)
 -a, --audio-language <lang> Preferred audio track language (default: english)
 -d, --download <path>       Download to path instead of streaming
 -j, --json                  Output stream metadata as JSON

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Lobster is a security-hardened Go rewrite of [lobster.sh](https://github.com/jus
 - 🧭 Episode navigation — next, previous, replay, episode list, cross-season
 - ⬇ Download with ffmpeg for offline viewing
 - 🌍 Subtitles with automatic language matching
-- ▶ Watch history with resume support (`--continue`)
+- ▶ Watch history with resume on by default (`--continue=false` to start fresh)
 - 🎞 Quality selection — 360p, 480p, 720p, 1080p (HLS variant matching)
 - 📺 Live TV — free IPTV channels including a 456-channel Sports category ([jump to guide](#live-tv-and-sports))
 - 📦 JSON output mode for scripting and piping
@@ -104,7 +104,7 @@ Config is stored in `%APPDATA%\lobster\config.toml` and history in `%LOCALAPPDAT
 ## Flags
 
 ```
--c, --continue
+-c, --continue[=false]      (resume from history; on by default)
 -a, --audio-language <lang>
 -d, --download <path>
 -j, --json

--- a/cmd/continue_default_test.go
+++ b/cmd/continue_default_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"lobster/internal/history"
+	"lobster/internal/media"
+	"lobster/internal/player"
+)
+
+// posRecordingPlayer records the resume position playback was started at.
+// That argument is the whole observable effect of the --continue gate, so it
+// is what these tests assert on.
+type posRecordingPlayer struct {
+	startPos float64
+	result   player.PlayResult
+}
+
+func (p *posRecordingPlayer) Play(_ *media.Stream, _ string, startPos float64, _ []string) (player.PlayResult, error) {
+	p.startPos = startPos
+	return p.result, nil
+}
+func (p *posRecordingPlayer) Name() string    { return "stub" }
+func (p *posRecordingPlayer) Available() bool { return true }
+
+// continueFromCLI returns the value flagContinue holds after a real `lobster`
+// invocation with these arguments has been parsed. It binds the persistent
+// flags onto a throwaway command so the flag's registered default is applied
+// afresh — reading rootCmd's flag instead would only report whatever the
+// package globals already happen to hold, which is precisely what a test of
+// the default must not trust.
+//
+// The globals are restored before returning, so callers may pin flags
+// (playStreamHarness) either side of this call without interference.
+func continueFromCLI(t *testing.T, args ...string) bool {
+	t.Helper()
+
+	dl, lang, alang := flagDownload, flagLanguage, flagAudioLang
+	prov, qual, plr, base := flagProvider, flagQuality, flagPlayer, flagBase
+	nosubs, cont, js, dbg := flagNoSubs, flagContinue, flagJSON, flagDebug
+	restore := func() {
+		flagDownload, flagLanguage, flagAudioLang = dl, lang, alang
+		flagProvider, flagQuality, flagPlayer, flagBase = prov, qual, plr, base
+		flagNoSubs, flagContinue, flagJSON, flagDebug = nosubs, cont, js, dbg
+	}
+	t.Cleanup(restore)
+
+	tmp := &cobra.Command{Use: "tmp"}
+	registerPersistentFlags(tmp)
+	err := tmp.PersistentFlags().Parse(args)
+	got := flagContinue
+	restore()
+	if err != nil {
+		t.Fatalf("parsing %v: %v", args, err)
+	}
+	return got
+}
+
+// resumeHarness installs a position-recording player and a hermetic history
+// dir, then sets flagContinue to whatever the given argv would produce.
+// Ordering matters: playStreamHarness pins --no-subs on and --json off so no
+// subtitle lookup or metadata short-circuit runs, and it also zeroes
+// flagContinue, so the CLI-derived value is applied last.
+func resumeHarness(t *testing.T, args ...string) *posRecordingPlayer {
+	t.Helper()
+	cont := continueFromCLI(t, args...)
+	rec := &posRecordingPlayer{}
+	playStreamHarness(t, rec)
+	flagContinue = cont
+	return rec
+}
+
+// The reported bug: `lobster --base yts "captain america: winter soldier"`
+// restarted a film history held a good position for, because --continue was
+// registered false and only the agent `play` command opted back in. Resuming
+// is the default on every playback entry point, so the interactive search
+// path must start the player at the stored position.
+func TestSearchPathResumesFromHistoryByDefault(t *testing.T) {
+	rec := resumeHarness(t, "--base", "yts", "captain america: winter soldier")
+
+	if err := history.Save(media.HistoryEntry{
+		ID: "movie/ca2", Title: "CA2", Type: media.Movie,
+		Position: 3123, Duration: 8000,
+	}); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/ca2", Title: "CA2", Type: media.Movie}
+	if err := playStream(stream, "CA2", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	if rec.startPos != 3123 {
+		t.Fatalf("player started at %g, want 3123: an interactive search must resume from history by default", rec.startPos)
+	}
+}
+
+// --continue=false is a deliberate fresh start and must still win on the
+// search path. The history entry here is deliberately a resumable one: a test
+// that fed an empty history could not tell the gate from its absence.
+func TestSearchPathExplicitContinueFalseStartsFromZero(t *testing.T) {
+	rec := resumeHarness(t, "--continue=false", "captain america: winter soldier")
+
+	if err := history.Save(media.HistoryEntry{
+		ID: "movie/ca2", Title: "CA2", Type: media.Movie,
+		Position: 3123, Duration: 8000,
+	}); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	stream := &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}
+	sel := media.SearchResult{ID: "movie/ca2", Title: "CA2", Type: media.Movie}
+	if err := playStream(stream, "CA2", sel, 0, 0); err != nil {
+		t.Fatalf("playStream: %v", err)
+	}
+
+	if rec.startPos != 0 {
+		t.Fatalf("player started at %g, want 0: --continue=false must not resume", rec.startPos)
+	}
+}
+
+// The TV/session path has its own copy of the resume gate
+// (playCurrentEpisode), reached by picking a show interactively. It must
+// default to resuming too, or a part-watched episode restarts.
+func TestSessionPathResumesFromHistoryByDefault(t *testing.T) {
+	rec := resumeHarness(t)
+
+	if err := history.Save(media.HistoryEntry{
+		ID: "tv/s", Title: "S", Type: media.TV,
+		Season: 1, Episode: 3, Position: 900, Duration: 2400,
+	}); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	if err := playCurrentEpisode(sessionForTest(prov)); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+
+	if rec.startPos != 900 {
+		t.Fatalf("episode started at %g, want 900: the session path must resume from history by default", rec.startPos)
+	}
+}
+
+// ...and must still honour an explicit --continue=false, with a resumable
+// entry present for it to ignore.
+func TestSessionPathExplicitContinueFalseStartsFromZero(t *testing.T) {
+	rec := resumeHarness(t, "--continue=false")
+
+	if err := history.Save(media.HistoryEntry{
+		ID: "tv/s", Title: "S", Type: media.TV,
+		Season: 1, Episode: 3, Position: 900, Duration: 2400,
+	}); err != nil {
+		t.Fatalf("seeding history: %v", err)
+	}
+
+	prov := &stubStreamProvider{stream: &media.Stream{URL: "http://127.0.0.1:1/never-dialed.m3u8"}}
+	if err := playCurrentEpisode(sessionForTest(prov)); err != nil {
+		t.Fatalf("playCurrentEpisode: %v", err)
+	}
+
+	if rec.startPos != 0 {
+		t.Fatalf("episode started at %g, want 0: --continue=false must not resume on the session path", rec.startPos)
+	}
+}
+
+// The detach interaction, half one: forwardedArgs omits a flag the caller did
+// not pass, so the supervised child is launched with no --continue at all and
+// falls back to its own registered default. That is only a resume if the
+// registered default is itself "resume" — the argv check alone would pass just
+// as happily with the old false default, so both halves are asserted here.
+func TestDetachedChildResumesWithoutExplicitContinue(t *testing.T) {
+	withInheritedFlags(t, playCmd, "continue")
+	playCmd.Flags().Lookup("continue").Changed = false // the caller passed nothing
+
+	argv := detachChildArgv(playCmd, "/usr/bin/lobster")
+	for _, a := range argv {
+		if strings.HasPrefix(a, "--continue") {
+			t.Fatalf("detachChildArgv(...) = %v, forwarded %q though --continue was not passed", argv, a)
+		}
+	}
+
+	if !continueFromCLI(t) {
+		t.Fatal("a supervised child launched without --continue does not resume; a detached play would start from the beginning")
+	}
+}
+
+// The detach interaction, half two: an explicit --continue=false must reach
+// the child as --continue=false (not a bare --continue, which cobra reads as
+// true) and must still mean "do not resume" once the child parses it.
+func TestDetachedChildHonoursExplicitContinueFalse(t *testing.T) {
+	withInheritedFlags(t, playCmd, "continue")
+	if err := playCmd.Flags().Set("continue", "false"); err != nil {
+		t.Fatalf("Set --continue=false: %v", err)
+	}
+
+	argv := detachChildArgv(playCmd, "/usr/bin/lobster")
+	if !containsArg(argv, "--continue=false") {
+		t.Fatalf("detachChildArgv(...) = %v, missing --continue=false", argv)
+	}
+
+	if continueFromCLI(t, "--continue=false") {
+		t.Fatal("a child parsing --continue=false still has continue on; it would silently resume")
+	}
+}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -78,8 +78,11 @@ func historyRun(cmd *cobra.Command, args []string) error {
 	// Find matching result by ID
 	for _, r := range results {
 		if r.ID == selected.ID {
-			// Override continue flag to resume
-			flagContinue = true
+			// No flagContinue override here: resuming is the registered
+			// default (root.go), and forcing it would override the one
+			// caller who said --continue=false, i.e. "replay this from the
+			// start" — a coherent request even when picking off the history
+			// list.
 			return resolveAndPlay(p, r, selected.Season, selected.Episode)
 		}
 	}

--- a/cmd/play.go
+++ b/cmd/play.go
@@ -182,18 +182,6 @@ func playRun(cmd *cobra.Command, args []string) error {
 		return emitErr("unsupported", 1, "--download is not supported by 'play'; use the interactive CLI")
 	}
 
-	// Resume from history by default: nothing in the JSON envelope tells a
-	// caller to pass -c, and the "resume_tracking":true it reports reads as a
-	// promise that replay will resume. An explicit --continue=false is a
-	// deliberate fresh start and must win. The detach path needs no special
-	// handling: an unchanged flag is not forwarded (forwardedArgs), so the
-	// supervised child re-applies this same default in its own playRun, and an
-	// explicit --continue=false is forwarded verbatim by detach.go's Changed()
-	// handling.
-	if !cmd.Flags().Changed("continue") {
-		flagContinue = true
-	}
-
 	// Checked before the --detach dispatch so a detached invocation reports
 	// exit 4 to the caller immediately, rather than forking a supervisor that
 	// fails into a log file the agent has no reason to read.

--- a/cmd/play_test.go
+++ b/cmd/play_test.go
@@ -609,13 +609,14 @@ func playMovieRefForContinue(t *testing.T) *bool {
 
 // The agent play command must resume from history by default: nothing in the
 // JSON envelope tells a caller to pass -c, and "resume_tracking":true reads
-// as a promise that it will. When --continue was not passed on this
-// invocation, playRun must behave as if it were.
+// as a promise that it will. The defaulting lives on the flag itself
+// (root.go), so this feeds playRun the value a real invocation without
+// --continue produces and checks it survives to playback.
 func TestPlayDefaultsContinueOn(t *testing.T) {
 	seen := playMovieRefForContinue(t)
 	withInheritedFlags(t, playCmd, "continue") // restores the Changed bit
 
-	flagContinue = false // cobra's default when the flag is not passed
+	flagContinue = continueFromCLI(t) // what `lobster play --ref R` actually parses to
 
 	if err := playRun(playCmd, nil); err != nil {
 		t.Fatalf("playRun: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,18 +57,38 @@ func Execute() {
 	}
 }
 
+// registerPersistentFlags binds every global flag as a persistent flag of c.
+// It is split out of init so a test can bind the same set onto a throwaway
+// command and parse a real argv through it, which is the only way to observe
+// the values the CLI actually produces for an invocation: pflag applies a
+// flag's default at registration time, so re-parsing rootCmd's own FlagSet
+// would only report whatever the globals already hold.
+func registerPersistentFlags(c *cobra.Command) {
+	fs := c.PersistentFlags()
+	fs.StringVarP(&flagDownload, "download", "d", "", "Download to path instead of playing (default: config download_dir)")
+	fs.StringVarP(&flagLanguage, "language", "l", "", "Subtitle language (default: english)")
+	fs.StringVarP(&flagAudioLang, "audio-language", "a", "", "Preferred audio track language (default: english)")
+	fs.BoolVarP(&flagNoSubs, "no-subs", "n", false, "Disable subtitles")
+	fs.StringVarP(&flagProvider, "provider", "p", "", "Server provider: Vidcloud | UpCloud")
+	fs.StringVarP(&flagQuality, "quality", "q", "", "Video quality: 360 | 480 | 720 | 1080 | best")
+	fs.StringVar(&flagPlayer, "player", "", "Media player: mpv | vlc | iina | celluloid")
+	// Resuming a part-watched title is the default on every playback entry
+	// point, so it lives here rather than being re-opted-into per command:
+	// the interactive search path and the TV/session path both read
+	// flagContinue directly and had no opt-in of their own, which is how
+	// `lobster "<title>"` came to restart films the agent `play` command
+	// resumed. --continue=false remains a deliberate fresh start, and is
+	// forwarded verbatim to a detached child by detach.go's Changed()
+	// handling, while an unpassed flag is not forwarded at all and the
+	// child re-applies this default itself.
+	fs.BoolVarP(&flagContinue, "continue", "c", true, "Auto-resume from history (--continue=false to start fresh)")
+	fs.BoolVarP(&flagJSON, "json", "j", false, "Output stream metadata as JSON")
+	fs.StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | moviebox | vaplayer | vidnest | tbcpl | 1shows.org | allanime | yts")
+	fs.BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
+}
+
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&flagDownload, "download", "d", "", "Download to path instead of playing (default: config download_dir)")
-	rootCmd.PersistentFlags().StringVarP(&flagLanguage, "language", "l", "", "Subtitle language (default: english)")
-	rootCmd.PersistentFlags().StringVarP(&flagAudioLang, "audio-language", "a", "", "Preferred audio track language (default: english)")
-	rootCmd.PersistentFlags().BoolVarP(&flagNoSubs, "no-subs", "n", false, "Disable subtitles")
-	rootCmd.PersistentFlags().StringVarP(&flagProvider, "provider", "p", "", "Server provider: Vidcloud | UpCloud")
-	rootCmd.PersistentFlags().StringVarP(&flagQuality, "quality", "q", "", "Video quality: 360 | 480 | 720 | 1080 | best")
-	rootCmd.PersistentFlags().StringVar(&flagPlayer, "player", "", "Media player: mpv | vlc | iina | celluloid")
-	rootCmd.PersistentFlags().BoolVarP(&flagContinue, "continue", "c", false, "Auto-resume from history")
-	rootCmd.PersistentFlags().BoolVarP(&flagJSON, "json", "j", false, "Output stream metadata as JSON")
-	rootCmd.PersistentFlags().StringVar(&flagBase, "base", "", "Content source: flixhq.to | flixhq.ws | kimcartoon.com.co | soap2day | moviebox | vaplayer | vidnest | tbcpl | 1shows.org | allanime | yts")
-	rootCmd.PersistentFlags().BoolVarP(&flagDebug, "debug", "x", false, "Debug logging to stderr")
+	registerPersistentFlags(rootCmd)
 
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(findCmd)


### PR DESCRIPTION
## What

Resuming from history is now the default on every playback path, not only
`lobster play`.

## The bug

`lobster --base yts "captain america: winter soldier"` started from the
beginning even though history held a good position for that title, while the
same film via `lobster play --ref <...>` resumed correctly.

`--continue` was registered on the root command with default `false`
(`cmd/root.go`), and only two commands opted in: `playRun`, via
`if !cmd.Flags().Changed("continue") { flagContinue = true }`, and `historyRun`.
The interactive search path never set it, so the resume lookup in `playStream`
was dead for it and playback always started at 0. The position was being saved
correctly the whole time — this was purely the read side.

## How

The flag is registered with default `true`. The gate is read straight from the
`flagContinue` global in two places — `playStream` (`cmd/search.go`) and
`playCurrentEpisode` (`cmd/session.go`) — and neither has a `cobra.Command` to
ask `Changed()` on, so reusing the `playRun` idiom would have meant threading a
command through those call paths rather than copying three lines. Flipping the
registered default covers every entry point at once.

That made two overrides redundant, and removing them fixed a second bug:
`historyRun` set `flagContinue = true` unconditionally, so
`lobster history --continue=false` — "replay this one from the start" — was
silently ignored.

`registerPersistentFlags` is extracted from `init` so a test can bind the flag
set onto a throwaway command and parse a real argv. pflag applies defaults at
registration time, so re-parsing `rootCmd`'s own FlagSet can only echo whatever
the globals already hold, which would make such a test vacuous. It takes a
`*cobra.Command` rather than a `*pflag.FlagSet` to avoid promoting `pflag` out
of `// indirect` in `go.mod`.

## Verified

Reds witnessed on assertions before the fix:

- `player started at 0, want 3123: an interactive search must resume from history by default`
- `episode started at 0, want 900: the session path must resume from history by default`
- `a supervised child launched without --continue does not resume; a detached play would start from the beginning`

Mutation-verified, each reverted after: restoring the `false` default reds all
three plus an existing `play` test; dropping `flagContinue &&` from either gate
reds the corresponding "does not resume when disabled" test; emitting a bare
`--continue` instead of `--continue=false` in `forwardedArgs` reds the detach
test and three existing ones.

The detach interaction is asserted from both sides in one test, deliberately:
that an unchanged flag emits no `--continue` token **and** that an empty argv
parses to `true`. The argv half alone passed just as happily under the old
`false` default, so on its own it proved nothing. With `--continue=false` set,
the argv carries exactly `--continue=false` — not a bare `--continue`, which
cobra reads as true — and parsing it back yields `false`.

Gate: `go build`/`vet`/`test ./...` with `CGO_ENABLED=0`, `GOOS=windows` build +
vet, `GOOS=darwin` build, and `CGO_ENABLED=1 go test ./cmd/ -race -count=2`. The
`cmd` test binary also passes with an empty `PATH`, so nothing depends on a
locally installed mpv — which CI does not have.

## Not verified / notes

- **`lobster history --continue=false` is a user-visible behaviour change that
  is not covered by a test.** `historyRun` goes through `ui.Select` (which execs
  fzf) and a live `newProvider().Search`, so testing it needs seams that do not
  exist yet. The change is right — the flag was being ignored — but the gap is
  real and is called out here rather than papered over.
- History resume matches on the provider ID, so the same film from a different
  `--base` is a different row and will not resume. Unchanged by this PR, but
  worth knowing alongside it.
- `cmd/history.go` is CRLF in this repo (one of six files `gofmt -l` already
  flags on `main`). An editor that normalises it produces a ~180-line phantom
  diff; the committed change is 5+/2-.
- `README.md` and `GUIDE.md` updated to say resume is on by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback now resumes from watch history by default.
  * Use `--continue=false` to start playback from the beginning.
  * The setting is respected when selecting content from watch history and across playback modes.

* **Documentation**
  * Updated the user guide and README to describe the new default behavior and optional boolean flag syntax.

* **Bug Fixes**
  * Explicit requests to start from the beginning are no longer overridden when resuming content from history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->