### PR TITLE
fix(torrentstream): take the storage backend that cannot SIGBUS

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -274,6 +274,40 @@ download_dir = "~/Videos/lobster"
 torrent_fallback = false
 ```
 
+#### Torrent storage backend
+
+The torrent library stores pieces through one of two file backends. The default
+memory-maps them, which is faster but has a race: a file can be truncated while
+another mapping of it is still live, and reading the truncated tail raises
+`SIGBUS` — a signal, not a Go error, so lobster dies mid-playback with no
+recoverable failure.
+
+Lobster avoids this for you. When a run could open a magnet — `--base yts`, or
+`torrent_fallback = true` — it restarts itself once at startup with the safer
+backend selected:
+
+```sh
+TORRENT_STORAGE_DEFAULT_FILE_IO=classic
+```
+
+The library reads that variable in its own package initialisation, before any
+lobster code runs, so it can only be chosen before the process starts; that is
+why lobster restarts rather than setting it in place. The restart replaces the
+process (same pid, terminal and exit status) and happens before any search or
+output, so it is not observable in normal use.
+
+Two things worth knowing:
+
+- **Setting it yourself is respected**, including `mmap`. If you would rather
+  have the throughput and accept the race, set it and lobster leaves it alone.
+- **On Windows there is no way to restart in place**, so lobster prints a
+  warning instead. Set the variable in your environment before launching to get
+  the safe backend there.
+
+Set it to anything other than `classic` or `mmap` and the library panics during
+startup, before lobster can report it — the message will be a bare Go panic
+naming the value you typed.
+
 ### TBCPL catalog feed
 
 Lobster can pull site metadata from [tbcpl.lol](https://tbcpl.lol), a directory of streaming sites, to keep mirror domains fresh, add a best-effort fallback embed provider, and feed additional live-TV/sports channels. The catalog is cached for 12 hours with an embedded offline snapshot as a fallback.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -274,7 +274,7 @@ download_dir = "~/Videos/lobster"
 torrent_fallback = false
 ```
 
-#### Torrent storage backend
+### Torrent storage backend
 
 The torrent library stores pieces through one of two file backends. The default
 memory-maps them, which is faster but has a race: a file can be truncated while

--- a/cmd/fallback_providers_test.go
+++ b/cmd/fallback_providers_test.go
@@ -71,6 +71,13 @@ func TestMain(m *testing.M) {
 	os.Setenv("LOCALAPPDATA", dataDir)  // windows
 	defer os.RemoveAll(dataDir)
 
+	// applyConfig re-execs this process onto the torrent library's classic
+	// storage backend when a run could open a magnet and the backend has not
+	// been chosen. A test binary must never do that — it would replace itself
+	// with a fresh `go test` run, repeatedly. Choosing the backend here makes
+	// the check a no-op, and classic is what the re-exec would have selected.
+	os.Setenv("TORRENT_STORAGE_DEFAULT_FILE_IO", "classic")
+
 	// Stub flixhqDomain to prevent live network probes in tests.
 	// Tests that need a healthy or dead result override this with t.Cleanup restore.
 	prev := flixhqDomain

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"lobster/internal/config"
 	"lobster/internal/history"
+	"lobster/internal/torrentstream"
 )
 
 // Version is set at build time via ldflags.
@@ -153,6 +155,14 @@ func applyConfig() error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
+	// The torrent library picks its storage backend in its own init(), so the
+	// only way onto the one that cannot SIGBUS is to start the process again
+	// with the variable already set. Do it here, once the effective base and
+	// fallback setting are known but before any search, network call or
+	// terminal setup — the re-exec replays argv, so anything the user would
+	// not want repeated must not have happened yet.
+	torrentstream.EnsureSafeStorage(mayStreamTorrent(cfg), warnf)
+
 	if cfg.Debug {
 		log.SetOutput(os.Stderr)
 		log.SetPrefix("[lobster] ")
@@ -170,6 +180,27 @@ func applyConfig() error {
 }
 
 // debugf logs a message if debug mode is enabled.
+// mayStreamTorrent reports whether this run could open a magnet, which decides
+// whether the storage backend matters at all.
+//
+// YTS is the only provider that resolves to one, and it is reachable exactly
+// two ways: named as the base, or enabled as a fallback. Anything else resolves
+// to HTTP or HLS and never reaches the torrent client.
+func mayStreamTorrent(c *config.Config) bool {
+	if c == nil {
+		return false
+	}
+	return strings.EqualFold(c.Base, "yts") || c.TorrentFallback
+}
+
+// warnf reports something the user should know but that does not stop the run.
+// Unlike debugf it is not gated on the debug flag: a silent downgrade to a
+// backend that can kill the process is exactly the kind of thing that should
+// not need a flag to be seen.
+func warnf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "lobster: "+format+"\n", args...)
+}
+
 func debugf(format string, args ...interface{}) {
 	if cfg != nil && cfg.Debug {
 		log.Printf(format, args...)

--- a/cmd/torrentstorage_test.go
+++ b/cmd/torrentstorage_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"testing"
+
+	"lobster/internal/config"
+)
+
+// mayStreamTorrent decides whether the storage backend matters for a run, and
+// so whether applyConfig re-execs. Getting it wrong in one direction leaves the
+// SIGBUS-prone backend in place for a run that streams; in the other it
+// re-execs runs that never touch a torrent.
+func TestMayStreamTorrent(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{"no config at all", nil, false},
+		{"yts as the base resolves to magnets", &config.Config{Base: "yts"}, true},
+		// Base reaches this from a flag as well as the file, and neither is
+		// case-normalised on the way in.
+		{"yts spelled loudly", &config.Config{Base: "YTS"}, true},
+		{"the fallback can reach yts from any base", &config.Config{Base: "flixhq.to", TorrentFallback: true}, true},
+		{"an http provider with no fallback never streams", &config.Config{Base: "flixhq.to"}, false},
+		{"an empty base with no fallback never streams", &config.Config{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := mayStreamTorrent(c.cfg); got != c.want {
+				t.Errorf("mayStreamTorrent(%+v) = %v, want %v", c.cfg, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/torrentstream/exec_unix.go
+++ b/internal/torrentstream/exec_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package torrentstream
+
+import (
+	"os"
+	"syscall"
+)
+
+// canExec reports that this platform can replace its own process image.
+const canExec = true
+
+// execSelf replaces this process with a fresh copy of the same binary, adding
+// env to the environment. It does not return on success.
+//
+// execve rather than a child process: the pid, open file descriptors and
+// controlling terminal all survive, so signal handling, the TUI's terminal and
+// the exit status need no forwarding. Those are the costs of supervising a
+// child, and this avoids them by not having one.
+func execSelf(env string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	// The new image finds the variable set, so its own check is a no-op and
+	// there is no exec loop.
+	return syscall.Exec(exe, os.Args, append(os.Environ(), env))
+}

--- a/internal/torrentstream/exec_windows.go
+++ b/internal/torrentstream/exec_windows.go
@@ -1,0 +1,14 @@
+package torrentstream
+
+import "errors"
+
+// canExec is false on Windows: there is no execve, and the alternative — a
+// child process the parent supervises — would have to forward signals, console
+// handles and the exit status, which is a great deal of machinery for a race
+// the user can avoid by setting one variable.
+const canExec = false
+
+// execSelf never runs on Windows; canExec keeps callers away from it.
+func execSelf(string) error {
+	return errors.New("no exec on windows")
+}

--- a/internal/torrentstream/fileio.go
+++ b/internal/torrentstream/fileio.go
@@ -1,0 +1,100 @@
+package torrentstream
+
+import (
+	"fmt"
+	"os"
+)
+
+// fileIoEnv selects the storage layer's file backend. The torrent library reads
+// it in its own package init(), so by the time any of our code runs the choice
+// is already made and os.Setenv is too late — the only way to change it is to
+// start the process again with the variable already set.
+const fileIoEnv = "TORRENT_STORAGE_DEFAULT_FILE_IO"
+
+// classicIo is the backend that does not memory-map.
+const classicIo = "classic"
+
+// Why this exists at all: with the variable unset the library defaults to its
+// mmap backend, where openForWrite can truncate a file while another handle
+// still holds a live mapping of it. Touching the truncated tail of a mapping is
+// a SIGBUS, which is a signal rather than a Go error — no recover, no
+// stack trace worth reading, the whole process dies mid-playback. The window is
+// narrow (it needs a shrinking truncate racing a read), but the cost when it
+// opens is total, and the classic backend simply does not have it.
+//
+// Neither obvious fix applies. The library exposes no programmatic choice:
+// defaultFileIo is an unexported package variable and fileIo an unexported
+// interface, and every exported constructor — NewFile, NewFileOpts and the
+// deprecated NewFileWith* family — funnels through it. And there is no fixed
+// release to move to; v1.61.0 is the newest published version.
+
+// ioPlan is what ensureClassicFileIo should do about the backend. Keeping the
+// decision separate from the act is what makes it testable: reproducing an
+// actual truncate/mmap race is inherently flaky, but "given this environment,
+// do we re-exec, and with what?" is exact.
+type ioPlan struct {
+	// exec re-executes this process with value set for fileIoEnv.
+	exec bool
+	// value is the backend to select when exec is set.
+	value string
+	// warn, when non-empty, is a message to show instead of re-executing.
+	warn string
+}
+
+// planFileIo decides how to reach the classic backend.
+//
+// willStream says the run may open a magnet. set and current describe
+// fileIoEnv as the process was started with. canExec says the platform can
+// replace its own process image.
+//
+// An explicit setting is always left alone, including "mmap": choosing the
+// faster backend and accepting the race is the user's call to make, and
+// silently overriding it would make their setting a lie.
+func planFileIo(willStream, set bool, current string, canExec bool) ioPlan {
+	if !willStream || set {
+		return ioPlan{}
+	}
+	if !canExec {
+		return ioPlan{warn: fmt.Sprintf(
+			"torrent streaming is using the memory-mapped storage backend, where a truncate racing a read can kill lobster with SIGBUS.\n"+
+				"To use the slower backend that cannot, start lobster with %s=%s set in the environment.", fileIoEnv, classicIo)}
+	}
+	return ioPlan{exec: true, value: classicIo}
+}
+
+// ensureClassicFileIo puts the process on the classic storage backend when a
+// run may stream a torrent, by starting it again with fileIoEnv set.
+//
+// On success this call does not return: the process image is replaced, keeping
+// the same pid, file descriptors, controlling terminal and exit status, so
+// nothing supervises anything and there is no second process to reason about.
+// It must therefore run before anything the user would not want repeated —
+// which is why the caller is config loading rather than the playback path that
+// discovers the magnet.
+//
+// A failure to re-exec is reported and not fatal. Refusing to run at all would
+// trade a narrow race for a certain outage.
+func ensureClassicFileIo(willStream bool, warnf func(string, ...any)) {
+	current, set := os.LookupEnv(fileIoEnv)
+	plan := planFileIo(willStream, set, current, canExec)
+	switch {
+	case plan.warn != "":
+		warnf("%s", plan.warn)
+	case plan.exec:
+		if err := execSelf(fileIoEnv + "=" + plan.value); err != nil {
+			warnf("could not switch to the %s storage backend (%v); continuing on the memory-mapped one, "+
+				"where a truncate racing a read can kill lobster with SIGBUS", plan.value, err)
+		}
+	}
+}
+
+// EnsureSafeStorage selects a torrent storage backend that cannot SIGBUS, for a
+// run that may open a magnet. It is a no-op for a run that cannot, and for one
+// whose backend the user has already chosen.
+//
+// willStream should be true whenever the YTS provider is reachable — as the
+// primary source or as an enabled fallback — since it is the only provider that
+// resolves to a magnet.
+func EnsureSafeStorage(willStream bool, warnf func(string, ...any)) {
+	ensureClassicFileIo(willStream, warnf)
+}

--- a/internal/torrentstream/fileio_test.go
+++ b/internal/torrentstream/fileio_test.go
@@ -1,0 +1,106 @@
+package torrentstream
+
+import (
+	"strings"
+	"testing"
+)
+
+// Reproducing a truncate/mmap race is inherently flaky, so what is pinned here
+// is the decision rather than the race: given an environment, do we re-exec,
+// and with what?
+func TestPlanFileIo(t *testing.T) {
+	cases := []struct {
+		name       string
+		willStream bool
+		set        bool
+		current    string
+		canExec    bool
+		want       ioPlan
+	}{{
+		name:       "a run that cannot open a magnet is left alone",
+		willStream: false, set: false, canExec: true,
+		want: ioPlan{},
+	}, {
+		name:       "an unset backend on a streaming run is switched to classic",
+		willStream: true, set: false, canExec: true,
+		want: ioPlan{exec: true, value: classicIo},
+	}, {
+		// Overriding this would make the user's own setting a lie, and picking
+		// throughput over the race is theirs to choose.
+		name:       "an explicit mmap choice is respected, race and all",
+		willStream: true, set: true, current: "mmap", canExec: true,
+		want: ioPlan{},
+	}, {
+		name:       "an explicit classic choice needs no second process",
+		willStream: true, set: true, current: classicIo, canExec: true,
+		want: ioPlan{},
+	}, {
+		// The library panics in its own init() on an unrecognised value, before
+		// any of our code runs, so this process would already be dead. What
+		// matters is that we never re-exec on top of it and never pass it on.
+		name:       "a set-but-unrecognised value is still the user's setting",
+		willStream: true, set: true, current: "mmapp", canExec: true,
+		want: ioPlan{},
+	}, {
+		name:       "without exec the user is told how to opt in",
+		willStream: true, set: false, canExec: false,
+		want: ioPlan{warn: "..."},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := planFileIo(c.willStream, c.set, c.current, c.canExec)
+			if c.want.warn != "" {
+				if got.warn == "" {
+					t.Fatalf("planFileIo returned no warning: %+v", got)
+				}
+				if got.exec {
+					t.Errorf("planFileIo wants to re-exec on a platform that cannot")
+				}
+				// A warning nobody can act on is noise.
+				if !strings.Contains(got.warn, fileIoEnv) || !strings.Contains(got.warn, classicIo) {
+					t.Errorf("the warning does not say what to set: %q", got.warn)
+				}
+				return
+			}
+			if got != c.want {
+				t.Errorf("planFileIo(%v, %v, %q, %v) = %+v, want %+v",
+					c.willStream, c.set, c.current, c.canExec, got, c.want)
+			}
+		})
+	}
+}
+
+// The re-exec must never target anything but the backend it promises. Passing
+// an unrecognised value would panic the new process in the library's init,
+// replacing a narrow race with a certain crash.
+func TestPlanFileIoOnlyEverSelectsClassic(t *testing.T) {
+	plan := planFileIo(true, false, "", true)
+	if !plan.exec {
+		t.Fatalf("expected a re-exec, got %+v", plan)
+	}
+	if plan.value != classicIo {
+		t.Errorf("re-exec would set %s=%q; the library panics in init() on anything but %q or \"mmap\"",
+			fileIoEnv, plan.value, classicIo)
+	}
+}
+
+// ensureClassicFileIo must stay silent when there is nothing to do, or a user
+// who has already chosen gets nagged on every run.
+func TestEnsureClassicFileIoIsSilentWhenTheBackendIsChosen(t *testing.T) {
+	t.Setenv(fileIoEnv, classicIo)
+	var said []string
+	ensureClassicFileIo(true, func(f string, a ...any) { said = append(said, f) })
+	if len(said) != 0 {
+		t.Errorf("ensureClassicFileIo said %v with the backend already chosen", said)
+	}
+}
+
+func TestEnsureClassicFileIoIsSilentForANonStreamingRun(t *testing.T) {
+	t.Setenv(fileIoEnv, "")
+	var said []string
+	ensureClassicFileIo(false, func(f string, a ...any) { said = append(said, f) })
+	if len(said) != 0 {
+		t.Errorf("ensureClassicFileIo said %v for a run that cannot open a magnet", said)
+	}
+}

--- a/internal/torrentstream/server.go
+++ b/internal/torrentstream/server.go
@@ -54,11 +54,6 @@ type serveEntry struct {
 // multi-gigabyte film.
 const is32Bit = ^uint(0)>>32 == 0
 
-// fileIoEnv selects the storage layer's file backend. It is read in that
-// package's init(), so it can only be set before the process starts — not from
-// here.
-const fileIoEnv = "TORRENT_STORAGE_DEFAULT_FILE_IO"
-
 // New starts a torrent client and a loopback HTTP server. dataDir is where
 // pieces land; empty uses a temp directory removed on Close.
 func New(dataDir string) (*Server, error) {
@@ -66,10 +61,10 @@ func New(dataDir string) (*Server, error) {
 	// the library as "mapping file: invalid argument" after the download has
 	// apparently started — worth catching up front with the two things that
 	// actually work, both verified.
-	if is32Bit && os.Getenv(fileIoEnv) != "classic" {
+	if is32Bit && os.Getenv(fileIoEnv) != classicIo {
 		return nil, fmt.Errorf(
 			"torrent streaming needs a 64-bit build: this one is 32-bit and cannot memory-map a multi-gigabyte file.\n"+
-				"Either rebuild with GOARCH=amd64, or re-run with %s=classic", fileIoEnv)
+				"Either rebuild with GOARCH=amd64, or re-run with %s=%s", fileIoEnv, classicIo)
 	}
 	tmp := ""
 	if dataDir == "" {


### PR DESCRIPTION
Closes #42.

## The race, read out of the source

`storage/file-io-mmap.go`, `openForWrite`:

```go
v, ok := me.paths[name]
if ok {
    if int64(len(v.m)) == size && v.writable {
        return newMmapFile(v), nil
    } else {
        v.dec()                       // only unmaps if refs hit zero
        g.MustDelete(me.paths, name)
    }
}
f, err := openFileExtra(name, os.O_RDWR)
err = f.Truncate(size)                // shrinks the file
```

If another handle still holds a ref, the old mapping stays live across that
truncate. Touching the truncated tail is `SIGBUS` — a signal, not a Go error, so
there is no recover and no useful stack; lobster dies mid-playback. It needs a
*shrinking* truncate racing a read, so the window is narrow, but when it opens
the cost is the whole process.

## Why the two obvious fixes still don't apply

Both re-checked against `v1.61.0`, as #42 did:

- **No programmatic choice.** `defaultFileIo` is an unexported package variable
  and `fileIo` an unexported interface. Every exported constructor — `NewFile`,
  `NewFileOpts`, and the deprecated `NewFileWithCompletion` /
  `NewFileByInfoHash` / `NewFileWithCustomPathMaker*` family — funnels through
  `NewFileOpts` → `fileClientImpl` → `defaultFileIo()`. `NewFileClientOpts` has
  no field for it.
- **No release to move to.** `v1.61.0` is still the newest published version.

The only selector is `TORRENT_STORAGE_DEFAULT_FILE_IO`, read in that package's
`init()` — already too late by the time any lobster code runs.

## One thing #42 got wrong

The issue weighed re-exec as costly: *"complicates signal handling, terminal/TTY
inheritance, and exit-code propagation."* Those are the costs of a **parent
supervising a child**. `syscall.Exec` has no child — `execve` replaces the
process image, so the pid, file descriptors, controlling terminal and exit
status all simply continue.

Verified under strace, trigger case:

```
1710  execve(".../lobster", [".../lobster", "version"], 0x7ffe... /* 137 vars */) = 0
1710  execve(".../lobster", [".../lobster", "version"], 0xc0002... /* 138 vars */) = 0
```

Same pid. One extra variable. argv unchanged. Exit 0. That reframing is what
makes re-exec the cheap option rather than the expensive one.

## How

`applyConfig` calls `torrentstream.EnsureSafeStorage` once the effective config
is known. Placement follows from where the decision *can* be made: a magnet
comes only from YTS, reachable exactly two ways — named as the base, or enabled
as a fallback — and both are known at config load, before any search, network
call or terminal setup. The playback path that discovers the magnet
(`search.go:523`) would be far too late, since re-exec replays argv and by then
the user has already searched.

Three deliberate limits:

- **An explicit setting is left alone, `mmap` included.** Choosing throughput
  and accepting the race is the user's call; overriding it silently would make
  their setting a lie.
- **Windows warns instead.** No `execve`, and a supervised child there would
  reintroduce every cost avoided above — for a race the user can sidestep with
  one variable.
- **A failed re-exec warns and continues.** Refusing to run would trade a narrow
  race for a certain outage.

The decision is a pure function (`planFileIo`) separate from the act, which is
what makes it testable — exactly as #42 proposed, since the race itself is not.

## Verified

Mutation-checked; each turns the matching test red:

| mutation | test |
|---|---|
| override an explicit user choice | `TestPlanFileIo` |
| re-exec into `mmap` rather than `classic` | `TestPlanFileIoOnlyEverSelectsClassic` |
| a warning naming neither the variable nor the value | `TestPlanFileIo` |
| ignore `torrent_fallback` | `TestMayStreamTorrent` |
| match the base case-sensitively | `TestMayStreamTorrent` |

End-to-end under strace, with both negative controls:

| scenario | execve count |
|---|---|
| `torrent_fallback = true`, variable unset | **2** (re-exec) |
| `--base yts` / `--base YTS`, variable unset | **2** (re-exec) |
| variable already `classic` | 1 |
| `torrent_fallback = false`, no yts base | 1 |

Exactly 2 rather than N is also the loop guard: the new image finds the variable
set, so its own check is a no-op.

`cmd`'s `TestMain` now pins the variable. Without it a test binary reaching
`applyConfig` would `execve` **itself** into a fresh `go test` run, repeatedly.

Gate: build + vet for `linux`, `windows` and `darwin`; `go test -race ./...`;
`-count=2` on `torrentstream` and `cmd`.

## Not verified

- **The SIGBUS itself.** A test that reliably reproduces a truncate/mmap race is
  inherently flaky, so what is pinned is the decision, not the crash. The race
  was read out of the `v1.61.0` source rather than observed.
- **The Windows path.** `canExec` is a compile-time `false` there and the
  warning is covered by a test, but no Windows machine ran this.
- The re-exec costs one `execve` per triggering run — measured only as "not
  observable in normal use", not benchmarked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved torrent streaming reliability by automatically selecting the safer storage backend when a run may open magnet links.
  - On supported platforms, the app restarts once at startup to apply the safer setting before torrent activity begins.
  - On Windows, a warning is shown when the safer backend cannot be applied automatically.
  - Existing storage settings are respected; unsupported values continue to fail at startup.

- **Documentation**
  - Added guidance on torrent storage backends, safety behavior, platform differences, and supported settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
